### PR TITLE
Refer to correct image tag in release note

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,7 @@ on:
 env:
   REGISTRY: ghcr.io
   IMAGE_PREFIX: ghcr.io/jfmlima/shelly-manager
+  IMAGE_TAG: ${{ substring(github.ref_name, 1) }}
 
 jobs:
   create-release:
@@ -27,20 +28,20 @@ jobs:
             ## 🐳 Docker Images
 
             **Available Docker Images:**
-            - `${{ env.IMAGE_PREFIX }}-api:${{ github.ref_name }}`
-            - `${{ env.IMAGE_PREFIX }}-cli:${{ github.ref_name }}`
-            - `${{ env.IMAGE_PREFIX }}-web:${{ github.ref_name }}`
+            - `${{ env.IMAGE_PREFIX }}-api:${{ env.IMAGE_TAG }}`
+            - `${{ env.IMAGE_PREFIX }}-cli:${{ env.IMAGE_TAG }}`
+            - `${{ env.IMAGE_PREFIX }}-web:${{ env.IMAGE_TAG }}`
 
             ## 🚀 Quick Start
             ```bash
             # Run API server
-            docker run -p 8000:8000 ${{ env.IMAGE_PREFIX }}-api:${{ github.ref_name }}
+            docker run -p 8000:8000 ${{ env.IMAGE_PREFIX }}-api:${{ env.IMAGE_TAG }}
 
             # Run CLI tool
-            docker run --rm ${{ env.IMAGE_PREFIX }}-cli:${{ github.ref_name }} --help
+            docker run --rm ${{ env.IMAGE_PREFIX }}-cli:${{ env.IMAGE_TAG }} --help
 
             # Run Web UI
-            docker run -p 8080:8080 ${{ env.IMAGE_PREFIX }}-web:${{ github.ref_name }}
+            docker run -p 8080:8080 ${{ env.IMAGE_PREFIX }}-web:${{ env.IMAGE_TAG }}
             ```
 
             ## 📋 What's Changed


### PR DESCRIPTION
Release note contained image names like `ghcr.io/jfmlima/shelly-manager-api:v1.0.5` (note the `v` in the image tag) but images are tagged without the `v`.