### PR TITLE
Refer to correct image tag in release note

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Calculate Image Tag (Strip 'v' prefix)
+        run: |
+          tag_name="${{ github.ref_name }}"
+          echo "IMAGE_TAG=${tag_name#v}" >> $GITHUB_ENV
+
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v1
         with:
@@ -27,20 +32,20 @@ jobs:
             ## 🐳 Docker Images
 
             **Available Docker Images:**
-            - `${{ env.IMAGE_PREFIX }}-api:${{ github.ref_name }}`
-            - `${{ env.IMAGE_PREFIX }}-cli:${{ github.ref_name }}`
-            - `${{ env.IMAGE_PREFIX }}-web:${{ github.ref_name }}`
+            - `${{ env.IMAGE_PREFIX }}-api:${{ env.IMAGE_TAG }}`
+            - `${{ env.IMAGE_PREFIX }}-cli:${{ env.IMAGE_TAG }}`
+            - `${{ env.IMAGE_PREFIX }}-web:${{ env.IMAGE_TAG }}`
 
             ## 🚀 Quick Start
             ```bash
             # Run API server
-            docker run -p 8000:8000 ${{ env.IMAGE_PREFIX }}-api:${{ github.ref_name }}
+            docker run -p 8000:8000 ${{ env.IMAGE_PREFIX }}-api:${{ env.IMAGE_TAG }}
 
             # Run CLI tool
-            docker run --rm ${{ env.IMAGE_PREFIX }}-cli:${{ github.ref_name }} --help
+            docker run --rm ${{ env.IMAGE_PREFIX }}-cli:${{ env.IMAGE_TAG }} --help
 
             # Run Web UI
-            docker run -p 8080:8080 ${{ env.IMAGE_PREFIX }}-web:${{ github.ref_name }}
+            docker run -p 8080:8080 ${{ env.IMAGE_PREFIX }}-web:${{ env.IMAGE_TAG }}
             ```
 
             ## 📋 What's Changed


### PR DESCRIPTION
Release note contained image names like `ghcr.io/jfmlima/shelly-manager-api:v1.0.5` (note the v in the image tag) but images are tagged without the v. Ref: https://github.com/jfmlima/shelly-manager/pkgs/container/shelly-manager-api/495252505?tag=1.0.5