### PR TITLE
Fix Wall Display auth with SHA-256 Digest

### DIFF
--- a/packages/api/src/api/presentation/handlers.py
+++ b/packages/api/src/api/presentation/handlers.py
@@ -6,6 +6,7 @@ from collections.abc import Callable, MutableMapping
 from datetime import datetime
 from typing import Any
 
+from core.domain.entities.exceptions import DeviceAuthenticationError
 from litestar.connection import Request
 from litestar.exceptions import HTTPException
 from litestar.response import Response
@@ -35,6 +36,20 @@ def handle_value_error(request: Request, exc: ValueError) -> Response:
             "timestamp": datetime.now().isoformat(),
         },
         status_code=400,
+        media_type="application/json",
+    )
+
+
+def handle_device_authentication_error(
+    request: Request, exc: DeviceAuthenticationError
+) -> Response:
+    return Response(
+        content={
+            "error": "Authentication Required",
+            "message": str(exc),
+            "timestamp": datetime.now().isoformat(),
+        },
+        status_code=401,
         media_type="application/json",
     )
 
@@ -84,6 +99,7 @@ EXCEPTION_HANDLERS: (
     ]
     | None
 ) = {
+    DeviceAuthenticationError: handle_device_authentication_error,
     DeviceNotFoundHTTPException: handle_device_not_found_exception,
     ValueError: handle_value_error,
     HTTPException: handle_http_exception,

--- a/packages/cli/src/cli/credential_commands.py
+++ b/packages/cli/src/cli/credential_commands.py
@@ -1,7 +1,7 @@
 import click
 from rich.table import Table
 
-from cli.commands.common import async_command, common_options
+from cli.commands.common import async_command
 from cli.presentation.styles import Messages
 
 
@@ -15,7 +15,6 @@ def credential_commands() -> None:
 @click.argument("mac")
 @click.argument("password")
 @click.option("--username", default="admin", help="Username (default: admin)")
-@common_options
 @click.pass_context
 @async_command
 async def set_credential(
@@ -40,7 +39,6 @@ async def set_credential(
 @credential_commands.command("set-global")
 @click.argument("password")
 @click.option("--username", default="admin", help="Username (default: admin)")
-@common_options
 @click.pass_context
 @async_command
 async def set_global_credential(
@@ -62,7 +60,6 @@ async def set_global_credential(
 
 
 @credential_commands.command("list")
-@common_options
 @click.pass_context
 @async_command
 async def list_credentials(ctx: click.Context) -> None:
@@ -95,7 +92,6 @@ async def list_credentials(ctx: click.Context) -> None:
 
 @credential_commands.command("delete")
 @click.argument("mac")
-@common_options
 @click.pass_context
 @async_command
 async def delete_credential(ctx: click.Context, mac: str) -> None:

--- a/packages/core/src/core/gateways/device/shelly_device_gateway.py
+++ b/packages/core/src/core/gateways/device/shelly_device_gateway.py
@@ -15,6 +15,7 @@ from ...domain.entities.exceptions import (
 )
 from ...domain.enums.enums import Status
 from ...domain.value_objects.action_result import ActionResult
+from ...utils.validation import normalize_mac
 from ..network.network import RpcNetworkGateway
 from .component_type_mapping import get_api_component_type
 from .device import DeviceGateway
@@ -54,16 +55,21 @@ class ShellyDeviceGateway(DeviceGateway):
             )
             device_data = device_info.get("result", device_info)
 
-            # Check if auth is required from cache or if it was just marked during request
-            auth_required = False
+            auth_required = device_data.get("auth_en", False)
+
             if (
                 hasattr(self._rpc_client, "auth_state_cache")
                 and self._rpc_client.auth_state_cache
             ):
-                device_id = device_data.get("id") or ip
-                auth_required = self._rpc_client.auth_state_cache.requires_auth(
-                    device_id
-                )
+                if auth_required:
+                    self._rpc_client.auth_state_cache.mark_auth_required(
+                        normalize_mac(ip)
+                    )
+                else:
+                    device_id = device_data.get("id") or ip
+                    auth_required = self._rpc_client.auth_state_cache.requires_auth(
+                        device_id
+                    )
 
             device = DiscoveredDevice(
                 ip=ip,
@@ -136,6 +142,16 @@ class ShellyDeviceGateway(DeviceGateway):
                     "result", device_info_response
                 )
                 rpc_success = True
+
+                if (
+                    device_info_data
+                    and device_info_data.get("auth_en", False)
+                    and hasattr(self._rpc_client, "auth_state_cache")
+                    and self._rpc_client.auth_state_cache
+                ):
+                    self._rpc_client.auth_state_cache.mark_auth_required(
+                        normalize_mac(ip)
+                    )
             except Exception as e:
                 logger.error(f"Error getting device info: {e}", exc_info=True)
 
@@ -149,6 +165,8 @@ class ShellyDeviceGateway(DeviceGateway):
                 )
                 components_data = components_response.get("result", components_response)
                 rpc_success = True
+            except DeviceAuthenticationError:
+                raise
             except Exception as e:
                 logger.error(f"Error getting components: {e}", exc_info=True)
 
@@ -159,6 +177,8 @@ class ShellyDeviceGateway(DeviceGateway):
                 )
                 status_response = status_response.get("result", status_response)
                 rpc_success = True
+            except DeviceAuthenticationError:
+                raise
             except Exception as e:
                 logger.error(f"Error getting device status: {e}", exc_info=True)
 
@@ -175,6 +195,8 @@ class ShellyDeviceGateway(DeviceGateway):
                 status_data=status_response,
             )
 
+        except DeviceAuthenticationError:
+            raise
         except Exception as e:
             logger.error(
                 f"Error getting device status via RPC, attempting legacy fallback: {e}",

--- a/packages/core/src/core/gateways/network/async_shelly_rpc_client.py
+++ b/packages/core/src/core/gateways/network/async_shelly_rpc_client.py
@@ -16,6 +16,7 @@ from core.services.authentication_service import AuthenticationService
 from core.utils.validation import normalize_mac
 
 from .network import RpcNetworkGateway
+from .shelly_digest_auth import ShellyDigestAuth
 
 logger = logging.getLogger(__name__)
 
@@ -38,7 +39,7 @@ class AsyncShellyRPCClient(RpcNetworkGateway):
         self.auth_state_cache = auth_state_cache
         self._closed = False
         self._ip_to_mac: dict[str, str] = {}
-        self._digest_auth_cache: dict[str, httpx.DigestAuth] = {}
+        self._digest_auth_cache: dict[str, ShellyDigestAuth] = {}
 
     async def make_rpc_request(
         self,
@@ -138,7 +139,7 @@ class AsyncShellyRPCClient(RpcNetworkGateway):
 
     async def _get_or_create_digest_auth(
         self, ip: str, mac: str
-    ) -> httpx.DigestAuth | None:
+    ) -> ShellyDigestAuth | None:
         """Get cached or create new DigestAuth instance for a device.
 
         Args:
@@ -163,7 +164,7 @@ class AsyncShellyRPCClient(RpcNetworkGateway):
             return None
 
         logger.debug("Creating new DigestAuth for %s (MAC: %s)", ip, mac)
-        digest_auth = httpx.DigestAuth(
+        digest_auth = ShellyDigestAuth(
             username=credential.username, password=credential.password
         )
         self._digest_auth_cache[mac] = digest_auth

--- a/packages/core/src/core/gateways/network/shelly_digest_auth.py
+++ b/packages/core/src/core/gateways/network/shelly_digest_auth.py
@@ -1,0 +1,81 @@
+"""
+Shelly-specific DigestAuth that correctly handles empty opaque values.
+
+httpx 0.28.1's DigestAuth uses ``if challenge.opaque:`` which treats b""
+as falsy, omitting opaque from the Authorization header. RFC 7616 requires
+clients to return opaque unchanged — even when empty. Shelly Wall Display
+devices send ``opaque=""`` and reject responses that omit it.
+"""
+
+from __future__ import annotations
+
+import httpx
+from httpx._auth import _DigestAuthChallenge
+from httpx._models import Request
+from httpx._utils import to_str
+
+
+class ShellyDigestAuth(httpx.DigestAuth):
+    # Pinned to httpx 0.28.1 — verify on upgrades.
+    def _build_auth_header(
+        self, request: Request, challenge: _DigestAuthChallenge
+    ) -> str:
+        hash_func = self._ALGORITHM_TO_HASH_FUNCTION[challenge.algorithm.upper()]
+
+        def digest(data: bytes) -> bytes:
+            return hash_func(data).hexdigest().encode()
+
+        A1 = b":".join((self._username, challenge.realm, self._password))
+
+        path = request.url.raw_path
+        A2 = b":".join((request.method.encode(), path))
+        HA2 = digest(A2)
+
+        nc_value = b"%08x" % self._nonce_count
+        cnonce = self._get_client_nonce(self._nonce_count, challenge.nonce)
+        self._nonce_count += 1
+
+        HA1 = digest(A1)
+        if challenge.algorithm.lower().endswith("-sess"):
+            HA1 = digest(b":".join((HA1, challenge.nonce, cnonce)))
+
+        qop = self._resolve_qop(challenge.qop, request=request)
+        if qop is None:
+            digest_data = [HA1, challenge.nonce, HA2]
+        else:
+            digest_data = [HA1, challenge.nonce, nc_value, cnonce, qop, HA2]
+
+        format_args: dict[str, bytes] = {
+            "username": self._username,
+            "realm": challenge.realm,
+            "nonce": challenge.nonce,
+            "uri": path,
+            "response": digest(b":".join(digest_data)),
+            "algorithm": challenge.algorithm.encode(),
+        }
+        if challenge.opaque is not None:
+            format_args["opaque"] = challenge.opaque
+        if qop:
+            format_args["qop"] = b"auth"
+            format_args["nc"] = nc_value
+            format_args["cnonce"] = cnonce
+
+        return "Digest " + self._get_header_value(format_args)
+
+    def _get_header_value(self, header_fields: dict[str, bytes]) -> str:
+        NON_QUOTED_FIELDS = ("algorithm", "qop", "nc")
+        QUOTED_TEMPLATE = '{}="{}"'
+        NON_QUOTED_TEMPLATE = "{}={}"
+
+        header_value = ""
+        for i, (field, value) in enumerate(header_fields.items()):
+            if i > 0:
+                header_value += ", "
+            template = (
+                QUOTED_TEMPLATE
+                if field not in NON_QUOTED_FIELDS
+                else NON_QUOTED_TEMPLATE
+            )
+            header_value += template.format(field, to_str(value))
+
+        return header_value

--- a/packages/core/src/core/use_cases/scan_devices.py
+++ b/packages/core/src/core/use_cases/scan_devices.py
@@ -56,6 +56,7 @@ class ScanDevicesUseCase:
                 Status.DETECTED,
                 Status.UPDATE_AVAILABLE,
                 Status.NO_UPDATE_NEEDED,
+                Status.AUTH_REQUIRED,
             ]:
                 discovered_devices.append(result)
 
@@ -124,11 +125,7 @@ class ScanDevicesUseCase:
             )
 
     def _apply_device_status_rules(self, device: DiscoveredDevice) -> None:
-        if device.auth_required and device.status in [
-            Status.DETECTED,
-            Status.UPDATE_AVAILABLE,
-            Status.NO_UPDATE_NEEDED,
-        ]:
+        if device.auth_required and device.status == Status.DETECTED:
             device.status = Status.AUTH_REQUIRED
 
     async def _discover_devices_via_mdns(self, request: ScanRequest) -> list[str]:

--- a/packages/core/tests/unit/gateways/device/test_shelly_device_gateway.py
+++ b/packages/core/tests/unit/gateways/device/test_shelly_device_gateway.py
@@ -4,6 +4,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 from core.domain.entities.device_status import DeviceStatus
 from core.domain.entities.discovered_device import DiscoveredDevice
+from core.domain.entities.exceptions import DeviceAuthenticationError
 from core.domain.enums.enums import Status
 from core.gateways.device.legacy_device_gateway import LegacyDeviceGateway
 from core.gateways.device.shelly_device_gateway import ShellyDeviceGateway
@@ -401,6 +402,100 @@ class TestShellyDeviceGateway:
         assert result is not None
 
         assert result.status == Status.DETECTED
+
+    async def test_it_detects_auth_required_from_auth_en(
+        self, mock_rpc_client, mock_legacy_gateway
+    ):
+        mock_rpc_client.auth_state_cache = MagicMock()
+        mock_rpc_client.auth_state_cache.requires_auth.return_value = False
+        gateway = ShellyDeviceGateway(
+            rpc_client=mock_rpc_client, legacy_gateway=mock_legacy_gateway
+        )
+
+        device_info = {
+            "id": "ShellyWallDisplay-000822891495",
+            "model": "SAWD-0A1XX10EU1",
+            "fw_id": "20260313-152112/2.5.8-4ec844c8",
+            "auth_en": True,
+        }
+        mock_rpc_client.make_rpc_request = AsyncMock(
+            side_effect=[
+                (device_info, 0.1),
+                Exception("Auth required for update check"),
+            ]
+        )
+
+        result = await gateway.discover_device("192.168.1.100")
+
+        assert result is not None
+        assert result.auth_required is True
+        mock_rpc_client.auth_state_cache.mark_auth_required.assert_called_once()
+
+    async def test_it_keeps_update_status_when_auth_succeeds(
+        self, mock_rpc_client, mock_legacy_gateway
+    ):
+        mock_rpc_client.auth_state_cache = MagicMock()
+        mock_rpc_client.auth_state_cache.requires_auth.return_value = False
+        gateway = ShellyDeviceGateway(
+            rpc_client=mock_rpc_client, legacy_gateway=mock_legacy_gateway
+        )
+
+        device_info = {
+            "id": "ShellyWallDisplay-000822891495",
+            "model": "SAWD-0A1XX10EU1",
+            "fw_id": "20260313-152112/2.5.8-4ec844c8",
+            "auth_en": True,
+        }
+        update_info = {"stable": {"version": "2.6.0"}}
+        mock_rpc_client.make_rpc_request = AsyncMock(
+            side_effect=[(device_info, 0.1), (update_info, 0.05)]
+        )
+
+        result = await gateway.discover_device("192.168.1.100")
+
+        assert result is not None
+        assert result.auth_required is True
+        assert result.status == Status.UPDATE_AVAILABLE
+
+    async def test_it_propagates_auth_error_from_get_device_status(
+        self, mock_rpc_client, mock_legacy_gateway
+    ):
+        mock_rpc_client.auth_state_cache = None
+        gateway = ShellyDeviceGateway(
+            rpc_client=mock_rpc_client, legacy_gateway=mock_legacy_gateway
+        )
+
+        mock_rpc_client.make_rpc_request = AsyncMock(
+            side_effect=[
+                ({"name": "Test", "model": "SAWD-0A1XX10EU1"}, 0.05),
+                DeviceAuthenticationError("192.168.1.100", "No credentials stored"),
+            ]
+        )
+
+        with pytest.raises(DeviceAuthenticationError):
+            await gateway.get_device_status("192.168.1.100")
+
+    async def test_it_continues_on_generic_error_in_get_device_status(
+        self, gateway, mock_rpc_client
+    ):
+        components_data = {
+            "components": [],
+            "cfg_rev": 1,
+            "total": 0,
+        }
+        mock_rpc_client.make_rpc_request = AsyncMock(
+            side_effect=[
+                ({"name": "Test", "model": "SHPM-1"}, 0.05),
+                (components_data, 0.1),
+                Exception("Status temporarily unavailable"),
+                ({"methods": []}, 0.05),
+            ]
+        )
+
+        result = await gateway.get_device_status("192.168.1.100")
+
+        assert result is not None
+        assert isinstance(result, DeviceStatus)
 
     async def test_it_executes_component_update_action_successfully(
         self, gateway, mock_rpc_client

--- a/packages/core/tests/unit/gateways/network/test_shelly_digest_auth.py
+++ b/packages/core/tests/unit/gateways/network/test_shelly_digest_auth.py
@@ -1,0 +1,113 @@
+import httpx
+import pytest
+from core.gateways.network.shelly_digest_auth import ShellyDigestAuth
+
+
+class TestShellyDigestAuth:
+
+    def _run_auth_flow(
+        self, auth: ShellyDigestAuth, www_authenticate: str
+    ) -> httpx.Request:
+        """Drive auth_flow through a 401 challenge and return the authenticated request."""
+        request = httpx.Request("POST", "http://192.168.1.100/rpc")
+        flow = auth.auth_flow(request)
+
+        # First yield: initial probe (no auth header yet)
+        probe_request = next(flow)
+        assert "Authorization" not in probe_request.headers
+
+        # Simulate 401 challenge
+        response = httpx.Response(
+            401,
+            headers={"www-authenticate": www_authenticate},
+            request=probe_request,
+        )
+
+        # Second yield: authenticated request
+        try:
+            auth_request = flow.send(response)
+        except StopIteration:
+            pytest.fail("auth_flow did not yield an authenticated request")
+
+        assert "Authorization" in auth_request.headers
+        return auth_request
+
+    def test_it_includes_empty_opaque(self):
+        auth = ShellyDigestAuth(username="admin", password="secret")
+        challenge = (
+            'Digest realm="ShellyWallDisplay-000822891495", '
+            'qop="auth", nonce="0b00ddda", opaque="", algorithm=SHA-256'
+        )
+        request = self._run_auth_flow(auth, challenge)
+        header = request.headers["Authorization"]
+
+        assert 'opaque=""' in header
+
+    def test_it_includes_nonempty_opaque(self):
+        auth = ShellyDigestAuth(username="admin", password="secret")
+        challenge = (
+            'Digest realm="shellypro4pm-f008d1d8b8b8", '
+            'qop="auth", nonce="abc123", opaque="xyz789", algorithm=SHA-256'
+        )
+        request = self._run_auth_flow(auth, challenge)
+        header = request.headers["Authorization"]
+
+        assert 'opaque="xyz789"' in header
+
+    def test_it_omits_missing_opaque(self):
+        auth = ShellyDigestAuth(username="admin", password="secret")
+        challenge = (
+            'Digest realm="shellypro4pm-f008d1d8b8b8", '
+            'qop="auth", nonce="abc123", algorithm=SHA-256'
+        )
+        request = self._run_auth_flow(auth, challenge)
+        header = request.headers["Authorization"]
+
+        assert "opaque" not in header
+
+    def test_it_produces_valid_sha256_digest(self):
+        auth = ShellyDigestAuth(username="admin", password="pass123")
+        challenge = (
+            'Digest realm="ShellyWallDisplay-000822891495", '
+            'qop="auth", nonce="0b00ddda", opaque="", algorithm=SHA-256'
+        )
+        request = self._run_auth_flow(auth, challenge)
+        header = request.headers["Authorization"]
+
+        assert header.startswith("Digest ")
+        assert "algorithm=SHA-256" in header
+        assert 'realm="ShellyWallDisplay-000822891495"' in header
+        assert 'nonce="0b00ddda"' in header
+        assert "response=" in header
+        assert "nc=" in header
+        assert "cnonce=" in header
+
+    def test_it_supports_md5_algorithm(self):
+        auth = ShellyDigestAuth(username="admin", password="pass123")
+        challenge = (
+            'Digest realm="shelly1-abc", '
+            'qop="auth", nonce="def456", algorithm=MD5'
+        )
+        request = self._run_auth_flow(auth, challenge)
+        header = request.headers["Authorization"]
+
+        assert header.startswith("Digest ")
+        assert "algorithm=MD5" in header
+
+    def test_it_reuses_cached_challenge_on_subsequent_requests(self):
+        auth = ShellyDigestAuth(username="admin", password="secret")
+        challenge = (
+            'Digest realm="ShellyWallDisplay-000822891495", '
+            'qop="auth", nonce="0b00ddda", opaque="", algorithm=SHA-256'
+        )
+
+        # First flow: goes through 401 challenge
+        self._run_auth_flow(auth, challenge)
+
+        # Second flow: should use cached challenge (no 401 needed)
+        request2 = httpx.Request("POST", "http://192.168.1.100/rpc")
+        flow2 = auth.auth_flow(request2)
+
+        first_yield = next(flow2)
+        assert "Authorization" in first_yield.headers
+        assert 'opaque=""' in first_yield.headers["Authorization"]

--- a/packages/core/tests/unit/gateways/network/test_shelly_digest_auth.py
+++ b/packages/core/tests/unit/gateways/network/test_shelly_digest_auth.py
@@ -85,8 +85,7 @@ class TestShellyDigestAuth:
     def test_it_supports_md5_algorithm(self):
         auth = ShellyDigestAuth(username="admin", password="pass123")
         challenge = (
-            'Digest realm="shelly1-abc", '
-            'qop="auth", nonce="def456", algorithm=MD5'
+            'Digest realm="shelly1-abc", ' 'qop="auth", nonce="def456", algorithm=MD5'
         )
         request = self._run_auth_flow(auth, challenge)
         header = request.headers["Authorization"]


### PR DESCRIPTION
Fix authentication for Shelly Wall Display devices (and potentially other Gen2+ devices) that send `opaque=""` in their Digest Auth challenge.

**Root cause:** httpx's `DigestAuth` treats empty opaque as falsy and omits it from the Authorization header, violating RFC 7616. The Wall Display rejects responses without opaque, causing silent auth failure and empty device status.

**Changes:**
- Subclass `httpx.DigestAuth` to correctly echo empty opaque values
- Read `auth_en` from `Shelly.GetDeviceInfo` to proactively detect auth-enabled devices and prime the credential cache
- Propagate `DeviceAuthenticationError` instead of silently swallowing it in status retrieval — API now returns HTTP 401
- Include `AUTH_REQUIRED` devices in scan results so they appear in the UI
- Fix CLI credential commands (`set-global`, `list`, `delete`) crashing with `TypeError` due to `@common_options` decorator

Fixes #38