### PR TITLE
Scheduled backups with retention and a paginated backups UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Manage Shelly devices on your local network without connecting them to the Shell
 - Firmware update management (stable/beta channels)
 - Device configuration management with bulk export/apply
 - Per-device configuration backup and restore with encrypted snapshots
+- Scheduled backups with retention (keep last N, drop older than N days)
 - Bulk operations across multiple devices
 - Status monitoring
 - Component action discovery and execution
@@ -245,6 +246,12 @@ GET    /api/backups/{id}                                      # Get a backup (wi
 POST   /api/backups/{id}/restore                              # Restore a backup to a device
 DELETE /api/backups/{id}                                      # Delete a backup
 
+GET    /api/backup-schedules                                  # List backup schedules
+POST   /api/backup-schedules                                  # Create a schedule
+PUT    /api/backup-schedules/{id}                             # Update a schedule
+DELETE /api/backup-schedules/{id}                             # Delete a schedule
+POST   /api/backup-schedules/{id}/run                         # Run a schedule now
+
 # Component actions
 GET  /api/devices/{ip}/components/actions                     # Discover available actions
 POST /api/devices/{ip}/components/{key}/actions/{action}      # Execute component action
@@ -292,6 +299,11 @@ shelly-manager bulk config apply --target 192.168.1.0/24
 shelly-manager backup create --target 192.168.1.100
 shelly-manager backup list
 shelly-manager backup restore 1 --target 192.168.1.100
+
+# Scheduled backups with retention
+shelly-manager backup schedule create --name nightly --every daily --target 192.168.1.100 --keep-last 7
+shelly-manager backup schedule list
+shelly-manager backup schedule run 1
 
 # Export
 shelly-manager export devices --target 192.168.1.0/24

--- a/README.md
+++ b/README.md
@@ -101,6 +101,10 @@ services:
       - HOST=0.0.0.0
       - PORT=8000
       - SHELLY_SECRET_KEY=your-generated-key
+      # Scheduled backups run in-process on the API; keep it to one replica.
+      # Defaults shown; set SHELLY_BACKUP_SCHEDULER_ENABLED=false to disable.
+      - SHELLY_BACKUP_SCHEDULER_ENABLED=true
+      - SHELLY_BACKUP_POLL_INTERVAL_SECONDS=60
 
   shelly-manager-web:
     image: ghcr.io/jfmlima/shelly-manager-web:latest
@@ -123,6 +127,10 @@ services:
       - HOST=0.0.0.0
       - PORT=8000
       - SHELLY_SECRET_KEY=your-generated-key
+      # Scheduled backups run in-process on the API; keep it to one replica.
+      # Defaults shown; set SHELLY_BACKUP_SCHEDULER_ENABLED=false to disable.
+      - SHELLY_BACKUP_SCHEDULER_ENABLED=true
+      - SHELLY_BACKUP_POLL_INTERVAL_SECONDS=60
     labels:
       - "traefik.enable=true"
       - "traefik.http.routers.shelly-manager-api.rule=Host(`shelly-manager-api.your.domain`)"
@@ -201,6 +209,8 @@ docker run -p 8000:8000 \
 Shelly Manager is zero-configuration by default. All scan and management parameters are provided at runtime via the Web UI, CLI flags, API parameters or ENV variables. This ensures flexibility and removes the need for managing static configuration files.
 
 For persistent storage of discovered devices in the Web UI, the application leverages browser localStorage. For API-based integrations, the client is responsible for maintaining device lists.
+
+**Scheduled backups** run on the API server itself. When `SHELLY_BACKUP_SCHEDULER_ENABLED` is `true` (the default), an in-process poller captures backups for any due schedules every `SHELLY_BACKUP_POLL_INTERVAL_SECONDS` (default 60). Because the timer lives in-process, run the API as a single worker (the default); see the [API README](packages/api/README.md) for the full setting reference.
 
 ## Architecture
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,10 @@ services:
       PORT: "8000"
       DEBUG: "true"
       SHELLY_SECRET_KEY: "${SHELLY_SECRET_KEY:?SHELLY_SECRET_KEY must be set - generate with: python -c \"from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())\"}"
+      # Scheduled backups run in-process on the API and assume a single worker.
+      # Defaults shown; set SHELLY_BACKUP_SCHEDULER_ENABLED=false to disable.
+      SHELLY_BACKUP_SCHEDULER_ENABLED: "true"
+      SHELLY_BACKUP_POLL_INTERVAL_SECONDS: "60"
     volumes:
       - ./packages/api/src:/app/packages/api/src:rw
       - ./packages/core/src:/app/packages/core/src:rw

--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -108,6 +108,39 @@ by default** to avoid locking the device off-network; pass their keys in `compon
 include them. Restore is supported on Gen2+ devices only (Gen1 devices back up but cannot be
 restored per-component).
 
+### Scheduled Backups
+
+Run backups automatically on a schedule with optional retention. Schedules live in the database;
+an in-process scheduler on the API server polls for due schedules and runs them. This relies on
+the API running as a **single worker** (the default), since one scheduler instance must own the
+timer. With multiple workers each one would run the scheduler and duplicate every backup.
+
+```bash
+GET /api/backup-schedules                  # List schedules (newest first)
+
+POST /api/backup-schedules                 # Create a schedule
+  # Body: {"name": "nightly",
+  #        "every": "daily",                # or "interval_seconds": 21600 (exactly one)
+  #        "target_ips": ["192.168.1.100"], # plus optional "target_macs" and
+  #        "all_credentialed": false,       # "all_credentialed" (at least one target)
+  #        "retention_keep_last": 7,        # optional retention
+  #        "retention_max_age_days": 30}
+
+GET /api/backup-schedules/{id}             # Get one schedule
+PUT /api/backup-schedules/{id}             # Partial update
+DELETE /api/backup-schedules/{id}          # Delete
+
+POST /api/backup-schedules/{id}/enable     # Enable
+POST /api/backup-schedules/{id}/disable    # Disable
+POST /api/backup-schedules/{id}/run        # Run now, ignoring the next run time
+```
+
+Targets are the union of `target_ips` (single IPs, or ranges/CIDR that are scanned for live
+devices at run time), `target_macs` (each resolved to an IP through the device's last-seen
+address), and `all_credentialed` (every device with stored credentials). A MAC with no known IP
+is reported as skipped, not failed. Retention only prunes scheduled snapshots, so manual backups
+are never removed by a schedule. A missed run fires once on catch-up rather than backfilling.
+
 ### Component Actions
 
 The Component Actions system provides dynamic action discovery and execution for individual device components.
@@ -371,10 +404,13 @@ curl -X POST "http://localhost:8000/api/backups/1/restore" \
 | `PORT`               | `8000`        | API server port            |
 | `DEBUG`              | `false`       | Enable debug mode          |
 | `SHELLY_SECRET_KEY`  | (required)    | Fernet key for credential encryption. Generate with: `python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"` |
+| `SHELLY_BACKUP_SCHEDULER_ENABLED` | `true` | Run the in-process scheduled-backup poller |
+| `SHELLY_BACKUP_POLL_INTERVAL_SECONDS` | `60` | How often the scheduler checks for due backups |
 
 `SHELLY_SECRET_KEY` also encrypts configuration **backup snapshots** at rest. Backups are
 stored in the local database (`{data_dir}/data.db`); rotating the key makes existing snapshots
-undecryptable.
+undecryptable. Set `SHELLY_BACKUP_SCHEDULER_ENABLED=false` to turn off automated backups while
+still managing schedules through the API.
 
 ## Docker Deployment
 

--- a/packages/api/pyproject.toml
+++ b/packages/api/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
     "shelly-manager-core",  # Local package dependency
     "litestar[standard]==2.19.0",
     "uvicorn[standard]==0.40.0",
+    "apscheduler>=3.10.4,<4.0",
 ]
 
 [project.optional-dependencies]

--- a/packages/api/src/api/controllers/backup_schedules.py
+++ b/packages/api/src/api/controllers/backup_schedules.py
@@ -1,0 +1,228 @@
+"""Controller for automated backup schedules."""
+
+from core.domain.entities.backup_schedule import BackupSchedule
+from core.use_cases.manage_backup_schedules import (
+    ManageBackupSchedulesUseCase,
+    ScheduleAlreadyExistsError,
+    ScheduleNotFoundError,
+)
+from core.use_cases.run_due_backups import RunDueBackupsUseCase
+from litestar import Controller, Router, delete, get, post, put
+from litestar.exceptions import HTTPException, NotFoundException
+from litestar.status_codes import HTTP_409_CONFLICT
+
+from api.presentation.dto.requests import (
+    CreateBackupScheduleRequest,
+    UpdateBackupScheduleRequest,
+)
+from api.presentation.dto.responses import (
+    BackupScheduleResponse,
+    ScheduleRunResultResponse,
+)
+
+
+class BackupSchedulesController(Controller):
+    path = ""
+    tags = ["Backup Schedules"]
+
+    @get()
+    async def list_schedules(
+        self,
+        manage_schedules_use_case: ManageBackupSchedulesUseCase,
+    ) -> list[BackupScheduleResponse]:
+        """List all backup schedules, newest first."""
+        schedules = await manage_schedules_use_case.list_schedules()
+        return [_to_response(s) for s in schedules]
+
+    @post()
+    async def create_schedule(
+        self,
+        data: CreateBackupScheduleRequest,
+        manage_schedules_use_case: ManageBackupSchedulesUseCase,
+    ) -> BackupScheduleResponse:
+        """Create a new backup schedule."""
+        schedule = BackupSchedule(
+            name=data.name,
+            interval_seconds=data.resolved_interval_seconds(),
+            target_ips=data.target_ips,
+            target_macs=data.target_macs,
+            all_credentialed=data.all_credentialed,
+            enabled=data.enabled,
+            retention_keep_last=data.retention_keep_last,
+            retention_max_age_days=data.retention_max_age_days,
+        )
+        try:
+            created = await manage_schedules_use_case.create_schedule(schedule)
+        except ScheduleAlreadyExistsError as err:
+            raise HTTPException(
+                status_code=HTTP_409_CONFLICT,
+                detail=f"Schedule already exists: {data.name}",
+            ) from err
+        return _to_response(created)
+
+    @get("/{schedule_id:int}")
+    async def get_schedule(
+        self,
+        schedule_id: int,
+        manage_schedules_use_case: ManageBackupSchedulesUseCase,
+    ) -> BackupScheduleResponse:
+        """Get a backup schedule by ID."""
+        try:
+            schedule = await manage_schedules_use_case.get_schedule(schedule_id)
+        except ScheduleNotFoundError as err:
+            raise NotFoundException(
+                detail=f"Schedule not found: {schedule_id}"
+            ) from err
+        return _to_response(schedule)
+
+    @put("/{schedule_id:int}")
+    async def update_schedule(
+        self,
+        schedule_id: int,
+        data: UpdateBackupScheduleRequest,
+        manage_schedules_use_case: ManageBackupSchedulesUseCase,
+    ) -> BackupScheduleResponse:
+        """Partially update a backup schedule."""
+        try:
+            existing = await manage_schedules_use_case.get_schedule(schedule_id)
+        except ScheduleNotFoundError as err:
+            raise NotFoundException(
+                detail=f"Schedule not found: {schedule_id}"
+            ) from err
+
+        interval = data.resolved_interval_seconds()
+        updated = BackupSchedule(
+            id=schedule_id,
+            name=data.name if data.name is not None else existing.name,
+            interval_seconds=(
+                interval if interval is not None else existing.interval_seconds
+            ),
+            target_ips=(
+                data.target_ips if data.target_ips is not None else existing.target_ips
+            ),
+            target_macs=(
+                data.target_macs
+                if data.target_macs is not None
+                else existing.target_macs
+            ),
+            all_credentialed=(
+                data.all_credentialed
+                if data.all_credentialed is not None
+                else existing.all_credentialed
+            ),
+            enabled=data.enabled if data.enabled is not None else existing.enabled,
+            retention_keep_last=(
+                data.retention_keep_last
+                if data.retention_keep_last is not None
+                else existing.retention_keep_last
+            ),
+            retention_max_age_days=(
+                data.retention_max_age_days
+                if data.retention_max_age_days is not None
+                else existing.retention_max_age_days
+            ),
+            next_run_at=existing.next_run_at,
+        )
+        try:
+            result = await manage_schedules_use_case.update_schedule(updated)
+        except ScheduleAlreadyExistsError as err:
+            raise HTTPException(
+                status_code=HTTP_409_CONFLICT,
+                detail=f"Schedule name already exists: {data.name}",
+            ) from err
+        return _to_response(result)
+
+    @delete("/{schedule_id:int}")
+    async def delete_schedule(
+        self,
+        schedule_id: int,
+        manage_schedules_use_case: ManageBackupSchedulesUseCase,
+    ) -> None:
+        """Delete a backup schedule."""
+        try:
+            await manage_schedules_use_case.delete_schedule(schedule_id)
+        except ScheduleNotFoundError as err:
+            raise NotFoundException(
+                detail=f"Schedule not found: {schedule_id}"
+            ) from err
+
+    @post("/{schedule_id:int}/enable")
+    async def enable_schedule(
+        self,
+        schedule_id: int,
+        manage_schedules_use_case: ManageBackupSchedulesUseCase,
+    ) -> BackupScheduleResponse:
+        """Enable a backup schedule."""
+        return await self._set_enabled(manage_schedules_use_case, schedule_id, True)
+
+    @post("/{schedule_id:int}/disable")
+    async def disable_schedule(
+        self,
+        schedule_id: int,
+        manage_schedules_use_case: ManageBackupSchedulesUseCase,
+    ) -> BackupScheduleResponse:
+        """Disable a backup schedule."""
+        return await self._set_enabled(manage_schedules_use_case, schedule_id, False)
+
+    @post("/{schedule_id:int}/run")
+    async def run_schedule(
+        self,
+        schedule_id: int,
+        run_due_backups_use_case: RunDueBackupsUseCase,
+    ) -> ScheduleRunResultResponse:
+        """Run a backup schedule now, ignoring its next run time."""
+        try:
+            result = await run_due_backups_use_case.run_schedule(schedule_id)
+        except ScheduleNotFoundError as err:
+            raise NotFoundException(
+                detail=f"Schedule not found: {schedule_id}"
+            ) from err
+        return ScheduleRunResultResponse(
+            schedule_id=result.schedule_id,
+            schedule_name=result.schedule_name,
+            status=result.status,
+            targets=result.targets,
+            ok=result.ok,
+            failed=result.failed,
+            skipped=result.skipped,
+            message=result.message,
+        )
+
+    @staticmethod
+    async def _set_enabled(
+        use_case: ManageBackupSchedulesUseCase,
+        schedule_id: int,
+        enabled: bool,
+    ) -> BackupScheduleResponse:
+        try:
+            updated = await use_case.set_enabled(schedule_id, enabled)
+        except ScheduleNotFoundError as err:
+            raise NotFoundException(
+                detail=f"Schedule not found: {schedule_id}"
+            ) from err
+        return _to_response(updated)
+
+
+backup_schedules_router = Router(
+    path="/backup-schedules",
+    route_handlers=[BackupSchedulesController],
+)
+
+
+def _to_response(schedule: BackupSchedule) -> BackupScheduleResponse:
+    return BackupScheduleResponse(
+        id=schedule.id or 0,
+        name=schedule.name,
+        target_ips=schedule.target_ips,
+        target_macs=schedule.target_macs,
+        all_credentialed=schedule.all_credentialed,
+        interval_seconds=schedule.interval_seconds,
+        enabled=schedule.enabled,
+        retention_keep_last=schedule.retention_keep_last,
+        retention_max_age_days=schedule.retention_max_age_days,
+        last_run_at=schedule.last_run_at,
+        next_run_at=schedule.next_run_at,
+        last_status=schedule.last_status,
+        created_at=schedule.created_at,
+        updated_at=schedule.updated_at,
+    )

--- a/packages/api/src/api/controllers/backup_schedules.py
+++ b/packages/api/src/api/controllers/backup_schedules.py
@@ -9,7 +9,7 @@ from core.use_cases.manage_backup_schedules import (
 from core.use_cases.run_due_backups import RunDueBackupsUseCase
 from litestar import Controller, Router, delete, get, post, put
 from litestar.exceptions import HTTPException, NotFoundException
-from litestar.status_codes import HTTP_409_CONFLICT
+from litestar.status_codes import HTTP_400_BAD_REQUEST, HTTP_409_CONFLICT
 
 from api.presentation.dto.requests import (
     CreateBackupScheduleRequest,
@@ -123,6 +123,14 @@ class BackupSchedulesController(Controller):
             ),
             next_run_at=existing.next_run_at,
         )
+        if not (updated.target_ips or updated.target_macs or updated.all_credentialed):
+            raise HTTPException(
+                status_code=HTTP_400_BAD_REQUEST,
+                detail=(
+                    "A schedule needs at least one target "
+                    "(target_ips, target_macs, or all_credentialed)"
+                ),
+            )
         try:
             result = await manage_schedules_use_case.update_schedule(updated)
         except ScheduleAlreadyExistsError as err:

--- a/packages/api/src/api/controllers/backups.py
+++ b/packages/api/src/api/controllers/backups.py
@@ -19,9 +19,13 @@ from api.presentation.dto.responses import (
     BackupDetailResponse,
     BackupSummaryResponse,
     ComponentRestoreResultResponse,
+    PaginatedBackupsResponse,
     RestoreResultResponse,
 )
 from api.presentation.exceptions import DeviceNotFoundHTTPException
+
+DEFAULT_PAGE_SIZE = 50
+MAX_PAGE_SIZE = 200
 
 
 class BackupsController(Controller):
@@ -33,10 +37,22 @@ class BackupsController(Controller):
         self,
         backup_use_case: BackupDeviceConfig,
         device_mac: str | None = None,
-    ) -> list[BackupSummaryResponse]:
-        """List stored backups, newest first, optionally filtered by device MAC."""
-        summaries = await backup_use_case.list_backups(device_mac)
-        return [_to_summary(s) for s in summaries]
+        limit: int = DEFAULT_PAGE_SIZE,
+        offset: int = 0,
+    ) -> PaginatedBackupsResponse:
+        """List stored backups, newest first, optionally filtered by device MAC.
+
+        Paginated: ``limit`` is clamped to 1..200 and ``offset`` floored at 0.
+        """
+        limit = max(1, min(limit, MAX_PAGE_SIZE))
+        offset = max(0, offset)
+        page = await backup_use_case.list_backups_page(device_mac, limit, offset)
+        return PaginatedBackupsResponse(
+            items=[_to_summary(s) for s in page.items],
+            total=page.total,
+            limit=page.limit,
+            offset=page.offset,
+        )
 
     @post()
     async def create_backup(

--- a/packages/api/src/api/dependencies/container.py
+++ b/packages/api/src/api/dependencies/container.py
@@ -11,6 +11,9 @@ from core.repositories.db import async_session_factory
 from core.repositories.sqlalchemy_backup_repository import (
     SQLAlchemyBackupRepository,
 )
+from core.repositories.sqlalchemy_backup_schedule_repository import (
+    SQLAlchemyBackupScheduleRepository,
+)
 from core.repositories.sqlalchemy_credentials_repository import (
     SQLAlchemyCredentialsRepository,
 )
@@ -81,6 +84,16 @@ class APIContainer(BaseContainer):
         async with async_session_factory() as session:
             try:
                 yield SQLAlchemyBackupRepository(session, self.get_encryption_service())
+            finally:
+                await session.close()
+
+    @asynccontextmanager
+    async def create_backup_schedule_repository(
+        self,
+    ) -> AsyncGenerator[SQLAlchemyBackupScheduleRepository, None]:
+        async with async_session_factory() as session:
+            try:
+                yield SQLAlchemyBackupScheduleRepository(session)
             finally:
                 await session.close()
 
@@ -175,6 +188,14 @@ def get_dependencies(container: APIContainer) -> dict:
         ),
         "restore_use_case": Provide(
             lambda: container.get_restore_device_config_interactor(),
+            sync_to_thread=False,
+        ),
+        "manage_schedules_use_case": Provide(
+            lambda: container.get_manage_backup_schedules_interactor(),
+            sync_to_thread=False,
+        ),
+        "run_due_backups_use_case": Provide(
+            lambda: container.get_run_due_backups_interactor(),
             sync_to_thread=False,
         ),
     }

--- a/packages/api/src/api/main.py
+++ b/packages/api/src/api/main.py
@@ -4,11 +4,13 @@ from contextlib import asynccontextmanager
 
 from core.repositories.db import engine
 from core.repositories.models import Base
+from core.settings import settings as core_settings
 from litestar import Litestar, Router
 from litestar.config.cors import CORSConfig
 from litestar.openapi import OpenAPIConfig
 from litestar.openapi.config import Contact, License, Server, Tag
 
+from .controllers.backup_schedules import backup_schedules_router
 from .controllers.backups import backups_router
 from .controllers.credentials import credentials_router
 from .controllers.devices import devices_router
@@ -18,6 +20,7 @@ from .controllers.monitoring import (
 from .controllers.provisioning import provisioning_router
 from .dependencies.container import APIContainer, get_dependencies
 from .presentation.handlers import EXCEPTION_HANDLERS
+from .scheduler import BackupScheduler
 
 
 def create_app() -> Litestar:
@@ -54,6 +57,10 @@ def create_app() -> Litestar:
                 name="Backups",
                 description="Device configuration backup and restore",
             ),
+            Tag(
+                name="Backup Schedules",
+                description="Automated scheduled backups and retention",
+            ),
         ],
         servers=[
             Server(url="http://localhost:8000", description="Development server"),
@@ -71,6 +78,7 @@ def create_app() -> Litestar:
             credentials_router,
             provisioning_router,
             backups_router,
+            backup_schedules_router,
             health_check,
         ],
     )
@@ -80,9 +88,18 @@ def create_app() -> Litestar:
         async with engine.begin() as conn:
             await conn.run_sync(Base.metadata.create_all)
 
+        scheduler = BackupScheduler(
+            _container.get_run_due_backups_interactor(),
+            poll_interval_seconds=core_settings.backup.poll_interval_seconds,
+        )
+        if core_settings.backup.scheduler_enabled:
+            scheduler.start()
+
         try:
             yield
         finally:
+            # Stop the scheduler before tearing down the container it depends on.
+            await scheduler.stop()
             await _container.close()
 
     app = Litestar(

--- a/packages/api/src/api/main.py
+++ b/packages/api/src/api/main.py
@@ -9,6 +9,7 @@ from litestar import Litestar, Router
 from litestar.config.cors import CORSConfig
 from litestar.openapi import OpenAPIConfig
 from litestar.openapi.config import Contact, License, Server, Tag
+from sqlalchemy import text
 
 from .controllers.backup_schedules import backup_schedules_router
 from .controllers.backups import backups_router
@@ -87,6 +88,15 @@ def create_app() -> Litestar:
     async def lifespan(app: Litestar) -> AsyncGenerator[None, None]:
         async with engine.begin() as conn:
             await conn.run_sync(Base.metadata.create_all)
+            # create_all adds new indexes only to tables it creates fresh, not
+            # to a device_backups table that predates this index. Add it
+            # explicitly so existing deployments get the paginated-list speedup.
+            await conn.execute(
+                text(
+                    "CREATE INDEX IF NOT EXISTS ix_device_backups_created_at "
+                    "ON device_backups (created_at)"
+                )
+            )
 
         scheduler = BackupScheduler(
             _container.get_run_due_backups_interactor(),

--- a/packages/api/src/api/presentation/dto/requests.py
+++ b/packages/api/src/api/presentation/dto/requests.py
@@ -6,7 +6,14 @@ import ipaddress
 import re
 from typing import Any
 
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, Field, field_validator, model_validator
+
+EVERY_PRESETS: dict[str, int] = {
+    "hourly": 3600,
+    "daily": 86400,
+    "weekly": 604800,
+}
+MIN_INTERVAL_SECONDS = 60
 
 
 class CredentialCreateRequest(BaseModel):
@@ -290,6 +297,31 @@ class VerifyProvisionRequest(BaseModel):
     timeout: float = Field(default=30.0, ge=5.0, le=120.0)
 
 
+def _validate_targets(targets: list[str]) -> list[str]:
+    """Validate IP / range / CIDR target strings without expanding them."""
+    from core.utils.target_parser import validate_target
+
+    for target in targets:
+        try:
+            validate_target(target)
+        except ValueError as e:
+            raise ValueError(f"Invalid target '{target}': {e}") from e
+    return targets
+
+
+def _normalize_mac(mac: str) -> str:
+    mac_clean = mac.upper().replace(":", "").replace("-", "")
+    if not re.match(r"^[0-9A-F]{12}$", mac_clean):
+        raise ValueError(
+            "Invalid MAC address format. Expected AA:BB:CC:DD:EE:FF or AABBCCDDEEFF"
+        )
+    return mac_clean
+
+
+def _normalize_macs(macs: list[str]) -> list[str]:
+    return [_normalize_mac(mac) for mac in macs]
+
+
 def _validate_ip_address(ip: str) -> str:
     try:
         ipaddress.IPv4Address(ip)
@@ -357,6 +389,105 @@ class CreateBackupRequest(BaseModel):
         except ipaddress.AddressValueError as e:
             raise ValueError(f"Invalid IP address: {v}") from e
         return v
+
+
+class CreateBackupScheduleRequest(BaseModel):
+    """Request model for creating a backup schedule.
+
+    Cadence is set with exactly one of ``every`` (a preset) or ``interval_seconds``.
+    """
+
+    name: str = Field(..., min_length=1, max_length=100)
+    target_ips: list[str] = Field(default_factory=list)
+    target_macs: list[str] = Field(default_factory=list)
+    all_credentialed: bool = Field(default=False)
+    every: str | None = Field(
+        default=None, description="Preset cadence: hourly, daily, or weekly"
+    )
+    interval_seconds: int | None = Field(default=None, ge=MIN_INTERVAL_SECONDS)
+    enabled: bool = Field(default=True)
+    retention_keep_last: int | None = Field(default=None, ge=1)
+    retention_max_age_days: int | None = Field(default=None, ge=1)
+
+    @field_validator("target_ips")
+    @classmethod
+    def validate_target_ips(cls, v: list[str]) -> list[str]:
+        return _validate_targets(v)
+
+    @field_validator("target_macs")
+    @classmethod
+    def validate_target_macs(cls, v: list[str]) -> list[str]:
+        return _normalize_macs(v)
+
+    @field_validator("every")
+    @classmethod
+    def validate_every(cls, v: str | None) -> str | None:
+        if v is not None and v not in EVERY_PRESETS:
+            raise ValueError(
+                f"Invalid cadence '{v}'. Must be one of: {sorted(EVERY_PRESETS)}"
+            )
+        return v
+
+    @model_validator(mode="after")
+    def validate_cadence_and_targets(self) -> "CreateBackupScheduleRequest":
+        if (self.every is None) == (self.interval_seconds is None):
+            raise ValueError("Provide exactly one of 'every' or 'interval_seconds'")
+        if not (self.target_ips or self.target_macs or self.all_credentialed):
+            raise ValueError(
+                "A schedule needs at least one target "
+                "(target_ips, target_macs, or all_credentialed)"
+            )
+        return self
+
+    def resolved_interval_seconds(self) -> int:
+        if self.every is not None:
+            return EVERY_PRESETS[self.every]
+        assert self.interval_seconds is not None  # guaranteed by the validator
+        return self.interval_seconds
+
+
+class UpdateBackupScheduleRequest(BaseModel):
+    """Request model for partially updating a backup schedule."""
+
+    name: str | None = Field(default=None, min_length=1, max_length=100)
+    target_ips: list[str] | None = Field(default=None)
+    target_macs: list[str] | None = Field(default=None)
+    all_credentialed: bool | None = Field(default=None)
+    every: str | None = Field(default=None)
+    interval_seconds: int | None = Field(default=None, ge=MIN_INTERVAL_SECONDS)
+    enabled: bool | None = Field(default=None)
+    retention_keep_last: int | None = Field(default=None, ge=1)
+    retention_max_age_days: int | None = Field(default=None, ge=1)
+
+    @field_validator("target_ips")
+    @classmethod
+    def validate_target_ips(cls, v: list[str] | None) -> list[str] | None:
+        return _validate_targets(v) if v is not None else None
+
+    @field_validator("target_macs")
+    @classmethod
+    def validate_target_macs(cls, v: list[str] | None) -> list[str] | None:
+        return _normalize_macs(v) if v is not None else None
+
+    @field_validator("every")
+    @classmethod
+    def validate_every(cls, v: str | None) -> str | None:
+        if v is not None and v not in EVERY_PRESETS:
+            raise ValueError(
+                f"Invalid cadence '{v}'. Must be one of: {sorted(EVERY_PRESETS)}"
+            )
+        return v
+
+    @model_validator(mode="after")
+    def validate_cadence(self) -> "UpdateBackupScheduleRequest":
+        if self.every is not None and self.interval_seconds is not None:
+            raise ValueError("Provide at most one of 'every' or 'interval_seconds'")
+        return self
+
+    def resolved_interval_seconds(self) -> int | None:
+        if self.every is not None:
+            return EVERY_PRESETS[self.every]
+        return self.interval_seconds
 
 
 class RestoreBackupRequest(BaseModel):

--- a/packages/api/src/api/presentation/dto/responses.py
+++ b/packages/api/src/api/presentation/dto/responses.py
@@ -228,3 +228,35 @@ class RestoreResultResponse(BaseModel):
     skipped: int = 0
     message: str | None = None
     components: list[ComponentRestoreResultResponse] = Field(default_factory=list)
+
+
+class BackupScheduleResponse(BaseModel):
+    """Response model for a backup schedule."""
+
+    id: int
+    name: str
+    target_ips: list[str] = Field(default_factory=list)
+    target_macs: list[str] = Field(default_factory=list)
+    all_credentialed: bool = False
+    interval_seconds: int = 0
+    enabled: bool = True
+    retention_keep_last: int | None = None
+    retention_max_age_days: int | None = None
+    last_run_at: int | None = None
+    next_run_at: int | None = None
+    last_status: str | None = None
+    created_at: int | None = None
+    updated_at: int | None = None
+
+
+class ScheduleRunResultResponse(BaseModel):
+    """Response model for a single schedule run (run-now)."""
+
+    schedule_id: int
+    schedule_name: str
+    status: str
+    targets: int = 0
+    ok: int = 0
+    failed: int = 0
+    skipped: int = 0
+    message: str = ""

--- a/packages/api/src/api/presentation/dto/responses.py
+++ b/packages/api/src/api/presentation/dto/responses.py
@@ -205,6 +205,15 @@ class BackupDetailResponse(BackupSummaryResponse):
     snapshot: dict[str, Any] = Field(default_factory=dict)
 
 
+class PaginatedBackupsResponse(BaseModel):
+    """A page of backup summaries with the total count for pagination."""
+
+    items: list[BackupSummaryResponse] = Field(default_factory=list)
+    total: int = 0
+    limit: int = 50
+    offset: int = 0
+
+
 class ComponentRestoreResultResponse(BaseModel):
     """Per-component outcome of a restore."""
 

--- a/packages/api/src/api/scheduler.py
+++ b/packages/api/src/api/scheduler.py
@@ -1,0 +1,63 @@
+"""In-process poller that runs due scheduled backups.
+
+Wraps APScheduler's ``AsyncIOScheduler`` with a single interval job. This is only
+safe because the API runs as a single uvicorn worker (see ``run_server.py``): with
+multiple workers every worker would run the poller and duplicate every backup.
+"""
+
+import logging
+
+from apscheduler.schedulers.asyncio import AsyncIOScheduler
+from core.use_cases.run_due_backups import RunDueBackupsUseCase
+
+logger = logging.getLogger(__name__)
+
+_JOB_ID = "backup-poll"
+
+
+class BackupScheduler:
+    def __init__(
+        self,
+        run_due_use_case: RunDueBackupsUseCase,
+        poll_interval_seconds: int = 60,
+    ):
+        self._use_case = run_due_use_case
+        self._poll_interval = max(1, poll_interval_seconds)
+        self._scheduler = AsyncIOScheduler()
+        self._started = False
+
+    @property
+    def running(self) -> bool:
+        return self._started
+
+    def start(self) -> None:
+        if self._started:
+            return
+        self._scheduler.add_job(
+            self._tick,
+            trigger="interval",
+            seconds=self._poll_interval,
+            id=_JOB_ID,
+            max_instances=1,  # never overlap ticks
+            coalesce=True,  # collapse missed ticks into one
+            replace_existing=True,
+        )
+        self._scheduler.start()
+        self._started = True
+        logger.info("Backup scheduler started (poll interval %ds)", self._poll_interval)
+
+    async def _tick(self) -> None:
+        # A failing tick must never tear down the scheduler; swallow and log.
+        try:
+            results = await self._use_case.run_due()
+            if results:
+                logger.info("Backup scheduler ran %d due schedule(s)", len(results))
+        except Exception:
+            logger.exception("Backup scheduler tick failed")
+
+    async def stop(self) -> None:
+        if not self._started:
+            return
+        self._scheduler.shutdown(wait=False)
+        self._started = False
+        logger.info("Backup scheduler stopped")

--- a/packages/api/tests/unit/controllers/test_backup_schedules.py
+++ b/packages/api/tests/unit/controllers/test_backup_schedules.py
@@ -142,6 +142,32 @@ class TestBackupSchedulesController:
             response = client.get("/99")
             assert response.status_code == 404
 
+    def test_it_rejects_update_that_clears_all_targets(self):
+        existing = _schedule(
+            target_ips=["192.168.1.10"], target_macs=[], all_credentialed=False
+        )
+
+        class Mock(ManageBackupSchedulesUseCase):
+            def __init__(self):
+                pass
+
+            async def get_schedule(self, schedule_id):
+                return existing
+
+        with create_test_client(
+            route_handlers=[BackupSchedulesController],
+            dependencies=_manage_provider(Mock()),
+        ) as client:
+            response = client.put(
+                "/1",
+                json={
+                    "target_ips": [],
+                    "target_macs": [],
+                    "all_credentialed": False,
+                },
+            )
+            assert response.status_code == 400
+
     def test_it_disables_a_schedule(self):
         class Mock(ManageBackupSchedulesUseCase):
             def __init__(self):

--- a/packages/api/tests/unit/controllers/test_backup_schedules.py
+++ b/packages/api/tests/unit/controllers/test_backup_schedules.py
@@ -1,0 +1,199 @@
+"""Tests for the backup schedules API controller."""
+
+from api.controllers.backup_schedules import BackupSchedulesController
+from core.domain.entities.backup_schedule import BackupSchedule
+from core.use_cases.manage_backup_schedules import (
+    ManageBackupSchedulesUseCase,
+    ScheduleAlreadyExistsError,
+    ScheduleNotFoundError,
+)
+from core.use_cases.run_due_backups import RunDueBackupsUseCase, ScheduleRunResult
+from litestar.di import Provide
+from litestar.testing import create_test_client
+
+
+def _manage_provider(use_case):
+    return {
+        "manage_schedules_use_case": Provide(lambda: use_case, sync_to_thread=False)
+    }
+
+
+def _run_provider(use_case):
+    return {"run_due_backups_use_case": Provide(lambda: use_case, sync_to_thread=False)}
+
+
+def _schedule(**kwargs):
+    base = {"id": 1, "name": "nightly", "interval_seconds": 3600, "next_run_at": 1000}
+    base.update(kwargs)
+    return BackupSchedule(**base)
+
+
+class TestBackupSchedulesController:
+    def test_it_lists_schedules(self):
+        class Mock(ManageBackupSchedulesUseCase):
+            def __init__(self):
+                pass
+
+            async def list_schedules(self):
+                return [_schedule()]
+
+        with create_test_client(
+            route_handlers=[BackupSchedulesController],
+            dependencies=_manage_provider(Mock()),
+        ) as client:
+            response = client.get("/")
+            assert response.status_code == 200
+            assert response.json()[0]["name"] == "nightly"
+
+    def test_it_creates_with_preset_cadence(self):
+        captured = {}
+
+        class Mock(ManageBackupSchedulesUseCase):
+            def __init__(self):
+                pass
+
+            async def create_schedule(self, schedule):
+                captured["interval"] = schedule.interval_seconds
+                schedule.id = 5
+                return schedule
+
+        with create_test_client(
+            route_handlers=[BackupSchedulesController],
+            dependencies=_manage_provider(Mock()),
+        ) as client:
+            response = client.post(
+                "/",
+                json={
+                    "name": "daily-job",
+                    "every": "daily",
+                    "target_ips": ["192.168.1.10"],
+                },
+            )
+            assert response.status_code == 201
+            assert response.json()["id"] == 5
+            assert captured["interval"] == 86400
+
+    def test_it_rejects_schedule_without_targets(self):
+        class Mock(ManageBackupSchedulesUseCase):
+            def __init__(self):
+                pass
+
+        with create_test_client(
+            route_handlers=[BackupSchedulesController],
+            dependencies=_manage_provider(Mock()),
+        ) as client:
+            response = client.post("/", json={"name": "no-targets", "every": "daily"})
+            assert response.status_code in (400, 500)
+
+    def test_it_rejects_both_cadence_sources(self):
+        class Mock(ManageBackupSchedulesUseCase):
+            def __init__(self):
+                pass
+
+        with create_test_client(
+            route_handlers=[BackupSchedulesController],
+            dependencies=_manage_provider(Mock()),
+        ) as client:
+            response = client.post(
+                "/",
+                json={
+                    "name": "ambiguous",
+                    "every": "daily",
+                    "interval_seconds": 3600,
+                    "target_ips": ["192.168.1.10"],
+                },
+            )
+            assert response.status_code in (400, 500)
+
+    def test_it_returns_409_on_duplicate_name(self):
+        class Mock(ManageBackupSchedulesUseCase):
+            def __init__(self):
+                pass
+
+            async def create_schedule(self, schedule):
+                raise ScheduleAlreadyExistsError(schedule.name)
+
+        with create_test_client(
+            route_handlers=[BackupSchedulesController],
+            dependencies=_manage_provider(Mock()),
+        ) as client:
+            response = client.post(
+                "/",
+                json={
+                    "name": "dupe",
+                    "every": "daily",
+                    "target_ips": ["192.168.1.10"],
+                },
+            )
+            assert response.status_code == 409
+
+    def test_it_returns_404_on_missing_get(self):
+        class Mock(ManageBackupSchedulesUseCase):
+            def __init__(self):
+                pass
+
+            async def get_schedule(self, schedule_id):
+                raise ScheduleNotFoundError(schedule_id)
+
+        with create_test_client(
+            route_handlers=[BackupSchedulesController],
+            dependencies=_manage_provider(Mock()),
+        ) as client:
+            response = client.get("/99")
+            assert response.status_code == 404
+
+    def test_it_disables_a_schedule(self):
+        class Mock(ManageBackupSchedulesUseCase):
+            def __init__(self):
+                pass
+
+            async def set_enabled(self, schedule_id, enabled):
+                return _schedule(id=schedule_id, enabled=enabled)
+
+        with create_test_client(
+            route_handlers=[BackupSchedulesController],
+            dependencies=_manage_provider(Mock()),
+        ) as client:
+            response = client.post("/1/disable")
+            assert response.status_code == 201
+            assert response.json()["enabled"] is False
+
+    def test_it_runs_a_schedule_now(self):
+        class Mock(RunDueBackupsUseCase):
+            def __init__(self):
+                pass
+
+            async def run_schedule(self, schedule_id):
+                return ScheduleRunResult(
+                    schedule_id=schedule_id,
+                    schedule_name="nightly",
+                    status="ok",
+                    targets=2,
+                    ok=2,
+                    message="2 ok, 0 failed, 0 skipped",
+                )
+
+        with create_test_client(
+            route_handlers=[BackupSchedulesController],
+            dependencies=_run_provider(Mock()),
+        ) as client:
+            response = client.post("/1/run")
+            assert response.status_code == 201
+            data = response.json()
+            assert data["status"] == "ok"
+            assert data["ok"] == 2
+
+    def test_it_returns_404_running_missing_schedule(self):
+        class Mock(RunDueBackupsUseCase):
+            def __init__(self):
+                pass
+
+            async def run_schedule(self, schedule_id):
+                raise ScheduleNotFoundError(schedule_id)
+
+        with create_test_client(
+            route_handlers=[BackupSchedulesController],
+            dependencies=_run_provider(Mock()),
+        ) as client:
+            response = client.post("/99/run")
+            assert response.status_code == 404

--- a/packages/api/tests/unit/controllers/test_backups.py
+++ b/packages/api/tests/unit/controllers/test_backups.py
@@ -1,7 +1,11 @@
 """Tests for the backups API controller."""
 
 from api.controllers.backups import BackupsController
-from core.domain.entities.device_backup import DeviceBackup, DeviceBackupSummary
+from core.domain.entities.device_backup import (
+    BackupPage,
+    DeviceBackup,
+    DeviceBackupSummary,
+)
 from core.domain.entities.exceptions import DeviceNotFoundError
 from core.domain.value_objects.restore_result import (
     ComponentRestoreResult,
@@ -28,13 +32,18 @@ def _restore_provider(use_case):
 
 
 class TestBackupsController:
-    def test_list_backups_returns_summaries(self):
+    def test_list_backups_returns_paginated_summaries(self):
         class MockBackup(BackupDeviceConfig):
             def __init__(self):
                 pass
 
-            async def list_backups(self, device_mac=None):
-                return [DeviceBackupSummary(device_mac="AABBCCDDEEFF", id=1)]
+            async def list_backups_page(self, device_mac=None, limit=50, offset=0):
+                return BackupPage(
+                    items=[DeviceBackupSummary(device_mac="AABBCCDDEEFF", id=1)],
+                    total=1,
+                    limit=limit,
+                    offset=offset,
+                )
 
         with create_test_client(
             route_handlers=[BackupsController],
@@ -43,8 +52,31 @@ class TestBackupsController:
             response = client.get("/")
             assert response.status_code == 200
             data = response.json()
-            assert len(data) == 1
-            assert data[0]["device_mac"] == "AABBCCDDEEFF"
+            assert data["total"] == 1
+            assert len(data["items"]) == 1
+            assert data["items"][0]["device_mac"] == "AABBCCDDEEFF"
+
+    def test_list_backups_clamps_limit_and_offset(self):
+        captured = {}
+
+        class MockBackup(BackupDeviceConfig):
+            def __init__(self):
+                pass
+
+            async def list_backups_page(self, device_mac=None, limit=50, offset=0):
+                captured["limit"] = limit
+                captured["offset"] = offset
+                return BackupPage(items=[], total=0, limit=limit, offset=offset)
+
+        with create_test_client(
+            route_handlers=[BackupsController],
+            dependencies=_backup_provider(MockBackup()),
+        ) as client:
+            response = client.get("/", params={"limit": 9999, "offset": -5})
+            assert response.status_code == 200
+            # Over-large limit floored to the page-size ceiling, offset to zero.
+            assert captured["limit"] == 200
+            assert captured["offset"] == 0
 
     def test_create_backup_returns_detail(self):
         class MockBackup(BackupDeviceConfig):

--- a/packages/api/tests/unit/test_scheduler.py
+++ b/packages/api/tests/unit/test_scheduler.py
@@ -1,0 +1,46 @@
+"""Tests for the in-process backup scheduler."""
+
+from unittest.mock import AsyncMock
+
+from api.scheduler import BackupScheduler
+
+
+class TestBackupScheduler:
+    async def test_it_starts_and_stops_cleanly(self):
+        scheduler = BackupScheduler(AsyncMock(), poll_interval_seconds=60)
+        assert scheduler.running is False
+
+        scheduler.start()
+        assert scheduler.running is True
+
+        await scheduler.stop()
+        assert scheduler.running is False
+
+    async def test_it_is_idempotent_on_double_start(self):
+        scheduler = BackupScheduler(AsyncMock(), poll_interval_seconds=60)
+        scheduler.start()
+        scheduler.start()  # must not raise (job id already exists)
+        assert scheduler.running is True
+        await scheduler.stop()
+
+    async def test_it_tick_invokes_run_due(self):
+        use_case = AsyncMock(run_due=AsyncMock(return_value=[]))
+        scheduler = BackupScheduler(use_case)
+
+        await scheduler._tick()
+
+        use_case.run_due.assert_awaited_once()
+
+    async def test_it_tick_swallows_exceptions(self):
+        use_case = AsyncMock(run_due=AsyncMock(side_effect=RuntimeError("boom")))
+        scheduler = BackupScheduler(use_case)
+
+        # A failing tick must not propagate; it would otherwise kill the loop.
+        await scheduler._tick()
+
+        use_case.run_due.assert_awaited_once()
+
+    async def test_it_stop_without_start_is_safe(self):
+        scheduler = BackupScheduler(AsyncMock())
+        await scheduler.stop()
+        assert scheduler.running is False

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -232,6 +232,49 @@ shelly-manager backup delete 1
 > own snapshot. Use `bulk config apply` to push the same settings out to many devices at once.
 > Restore works on Gen2+ devices only.
 
+### Scheduled Backups
+
+Run backups automatically on a schedule and prune old snapshots with a retention policy. The
+schedules are stored in the same local database and executed by the API server's in-process
+scheduler, so the API needs to be running for them to fire. The CLI manages the schedules.
+
+```bash
+# Create a daily schedule for two devices, keeping the 7 newest snapshots per device
+shelly-manager backup schedule create --name nightly \
+  --every daily --target 192.168.1.100 --target 192.168.1.101 --keep-last 7
+
+# Use a custom cadence and target every device with stored credentials
+shelly-manager backup schedule create --name fleet \
+  --interval-seconds 21600 --all-credentialed --max-age-days 30
+
+# List, enable, disable, run now, and delete
+shelly-manager backup schedule list
+shelly-manager backup schedule disable 1
+shelly-manager backup schedule enable 1
+shelly-manager backup schedule run 1
+shelly-manager backup schedule delete 1 --force
+```
+
+**Create options:**
+
+- `--name`: Unique schedule name (required).
+- `--every`: Preset cadence (`hourly`, `daily`, `weekly`). Provide this or `--interval-seconds`,
+  not both.
+- `--interval-seconds`: Custom cadence in seconds (minimum 60).
+- `--target` / `-t`: Target device IP, range, or CIDR (repeatable). Ranges and CIDR are scanned
+  for live Shelly devices at run time, so only discovered devices are backed up.
+- `--mac`: Target device MAC (repeatable). Resolved to an IP through the device's last-seen
+  address; a MAC with no known IP is reported as skipped, not failed.
+- `--all-credentialed`: Back up every device that has stored credentials.
+- `--keep-last`: Keep only the newest N scheduled backups per device.
+- `--max-age-days`: Drop scheduled backups older than N days.
+- `--disabled`: Create the schedule without enabling it.
+
+Retention only ever removes scheduled snapshots, so a manual backup you captured by hand is never
+deleted by a schedule. A missed run (the device or API was down) fires once on catch-up rather
+than backfilling every slot it missed. The first run happens one interval after creation; use
+`backup schedule run` if you want a snapshot right away.
+
 ## Configuration
 
 ### Environment Variables

--- a/packages/cli/src/cli/commands/backup_commands.py
+++ b/packages/cli/src/cli/commands/backup_commands.py
@@ -4,6 +4,7 @@ from datetime import UTC, datetime
 
 import click
 from core.domain.entities.backup_schedule import BackupSchedule
+from core.utils.target_parser import validate_target
 from core.utils.validation import normalize_mac
 from rich.table import Table
 
@@ -282,6 +283,12 @@ async def create_schedule(
             )
         )
         raise click.Abort()
+    for target in targets:
+        try:
+            validate_target(target)
+        except ValueError as e:
+            console.print(Messages.error(f"Invalid target '{target}': {e}"))
+            raise click.Abort() from None
 
     interval = EVERY_PRESETS[every] if every is not None else interval_seconds
     schedule = BackupSchedule(

--- a/packages/cli/src/cli/commands/backup_commands.py
+++ b/packages/cli/src/cli/commands/backup_commands.py
@@ -3,10 +3,18 @@
 from datetime import UTC, datetime
 
 import click
+from core.domain.entities.backup_schedule import BackupSchedule
+from core.utils.validation import normalize_mac
 from rich.table import Table
 
 from cli.commands.common import async_command
 from cli.presentation.styles import Messages
+
+EVERY_PRESETS: dict[str, int] = {
+    "hourly": 3600,
+    "daily": 86400,
+    "weekly": 604800,
+}
 
 
 @click.group(name="backup")
@@ -188,3 +196,254 @@ async def delete_backup(ctx: click.Context, backup_id: int) -> None:
     except Exception as e:
         console.print(Messages.error(f"Failed to delete backup: {e}"))
         raise click.Abort() from None
+
+
+@backup_commands.group("schedule")
+def backup_schedule() -> None:
+    """⏰ Manage automated backup schedules."""
+    pass
+
+
+@backup_schedule.command("create")
+@click.option("--name", required=True, help="Unique schedule name")
+@click.option(
+    "--every",
+    type=click.Choice(sorted(EVERY_PRESETS)),
+    default=None,
+    help="Preset cadence (alternative to --interval-seconds)",
+)
+@click.option(
+    "--interval-seconds",
+    type=int,
+    default=None,
+    help="Custom cadence in seconds (minimum 60)",
+)
+@click.option(
+    "--target",
+    "-t",
+    "targets",
+    multiple=True,
+    help="Target device IP, range, or CIDR (repeatable). Ranges and CIDR are "
+    "scanned for live devices at run time.",
+)
+@click.option(
+    "--mac",
+    "macs",
+    multiple=True,
+    help="Target device MAC, resolved via last-seen IP (repeatable)",
+)
+@click.option(
+    "--all-credentialed",
+    is_flag=True,
+    help="Target every device we hold credentials for",
+)
+@click.option(
+    "--keep-last",
+    type=int,
+    default=None,
+    help="Retention: keep only the newest N scheduled backups per device",
+)
+@click.option(
+    "--max-age-days",
+    type=int,
+    default=None,
+    help="Retention: drop scheduled backups older than N days",
+)
+@click.option("--disabled", is_flag=True, help="Create the schedule disabled")
+@click.pass_context
+@async_command
+async def create_schedule(
+    ctx: click.Context,
+    name: str,
+    every: str | None,
+    interval_seconds: int | None,
+    targets: tuple[str, ...],
+    macs: tuple[str, ...],
+    all_credentialed: bool,
+    keep_last: int | None,
+    max_age_days: int | None,
+    disabled: bool,
+) -> None:
+    """Create an automated backup schedule."""
+    console = ctx.obj.console
+
+    if (every is None) == (interval_seconds is None):
+        console.print(
+            Messages.error("Provide exactly one of --every or --interval-seconds")
+        )
+        raise click.Abort()
+    if interval_seconds is not None and interval_seconds < 60:
+        console.print(Messages.error("--interval-seconds must be at least 60"))
+        raise click.Abort()
+    if not (targets or macs or all_credentialed):
+        console.print(
+            Messages.error(
+                "Provide at least one of --target, --mac, or --all-credentialed"
+            )
+        )
+        raise click.Abort()
+
+    interval = EVERY_PRESETS[every] if every is not None else interval_seconds
+    schedule = BackupSchedule(
+        name=name,
+        interval_seconds=interval,  # type: ignore[arg-type]
+        target_ips=list(targets),
+        target_macs=[normalize_mac(mac) for mac in macs],
+        all_credentialed=all_credentialed,
+        enabled=not disabled,
+        retention_keep_last=keep_last,
+        retention_max_age_days=max_age_days,
+    )
+
+    use_case = ctx.obj.container.get_manage_backup_schedules_interactor()
+    try:
+        created = await use_case.create_schedule(schedule)
+    except Exception as e:
+        console.print(Messages.error(f"Failed to create schedule: {e}"))
+        raise click.Abort() from None
+
+    state = "enabled" if created.enabled else "disabled"
+    console.print(
+        f"✅ Created schedule [bold]#{created.id}[/bold] "
+        f"[cyan]{created.name}[/cyan] ({state}, every {_format_interval(created.interval_seconds)})"
+    )
+
+
+@backup_schedule.command("list")
+@click.pass_context
+@async_command
+async def list_schedules(ctx: click.Context) -> None:
+    """List backup schedules."""
+    console = ctx.obj.console
+    use_case = ctx.obj.container.get_manage_backup_schedules_interactor()
+
+    schedules = await use_case.list_schedules()
+    if not schedules:
+        console.print(Messages.warning("No backup schedules configured."))
+        return
+
+    table = Table(show_header=True, header_style="bold magenta")
+    table.add_column("ID", style="cyan", justify="right")
+    table.add_column("Name", style="green")
+    table.add_column("Every", style="blue")
+    table.add_column("Targets")
+    table.add_column("Enabled")
+    table.add_column("Next run (UTC)")
+    table.add_column("Last status")
+
+    for s in schedules:
+        table.add_row(
+            str(s.id),
+            s.name,
+            _format_interval(s.interval_seconds),
+            _format_targets(s),
+            "✅" if s.enabled else "⛔",
+            _format_ts(s.next_run_at),
+            s.last_status or "-",
+        )
+
+    console.print(table)
+
+
+@backup_schedule.command("enable")
+@click.argument("schedule_id", type=int)
+@click.pass_context
+@async_command
+async def enable_schedule(ctx: click.Context, schedule_id: int) -> None:
+    """Enable a backup schedule."""
+    await _set_enabled(ctx, schedule_id, True)
+
+
+@backup_schedule.command("disable")
+@click.argument("schedule_id", type=int)
+@click.pass_context
+@async_command
+async def disable_schedule(ctx: click.Context, schedule_id: int) -> None:
+    """Disable a backup schedule."""
+    await _set_enabled(ctx, schedule_id, False)
+
+
+@backup_schedule.command("delete")
+@click.argument("schedule_id", type=int)
+@click.option("--force", is_flag=True, help="Skip the confirmation prompt.")
+@click.pass_context
+@async_command
+async def delete_schedule(ctx: click.Context, schedule_id: int, force: bool) -> None:
+    """Delete a backup schedule."""
+    console = ctx.obj.console
+    if not force:
+        click.confirm(f"Delete schedule #{schedule_id}?", abort=True)
+
+    use_case = ctx.obj.container.get_manage_backup_schedules_interactor()
+    try:
+        await use_case.delete_schedule(schedule_id)
+        console.print(f"✅ Deleted schedule [bold]#{schedule_id}[/bold]")
+    except Exception as e:
+        console.print(Messages.error(f"Failed to delete schedule: {e}"))
+        raise click.Abort() from None
+
+
+@backup_schedule.command("run")
+@click.argument("schedule_id", type=int)
+@click.pass_context
+@async_command
+async def run_schedule(ctx: click.Context, schedule_id: int) -> None:
+    """Run a backup schedule now, ignoring its next run time."""
+    console = ctx.obj.console
+    use_case = ctx.obj.container.get_run_due_backups_interactor()
+
+    try:
+        result = await use_case.run_schedule(schedule_id)
+    except Exception as e:
+        console.print(Messages.error(f"Failed to run schedule: {e}"))
+        raise click.Abort() from None
+
+    summary = (
+        f"{result.ok} ok, {result.failed} failed, {result.skipped} skipped "
+        f"across {result.targets} target(s)"
+    )
+    if result.status in ("ok", "skipped", "empty"):
+        console.print(f"✅ Schedule '{result.schedule_name}' run: {summary}")
+    else:
+        console.print(
+            Messages.warning(
+                f"Schedule '{result.schedule_name}' finished with issues: {summary}"
+            )
+        )
+        ctx.exit(1)
+
+
+async def _set_enabled(ctx: click.Context, schedule_id: int, enabled: bool) -> None:
+    console = ctx.obj.console
+    use_case = ctx.obj.container.get_manage_backup_schedules_interactor()
+    try:
+        updated = await use_case.set_enabled(schedule_id, enabled)
+    except Exception as e:
+        console.print(Messages.error(f"Failed to update schedule: {e}"))
+        raise click.Abort() from None
+    state = "enabled" if updated.enabled else "disabled"
+    console.print(f"✅ Schedule [bold]#{schedule_id}[/bold] {state}")
+
+
+def _format_interval(seconds: int) -> str:
+    for name, preset in EVERY_PRESETS.items():
+        if seconds == preset:
+            return name
+    return f"{seconds}s"
+
+
+def _format_targets(schedule: BackupSchedule) -> str:
+    parts: list[str] = []
+    if schedule.all_credentialed:
+        parts.append("all-credentialed")
+    if schedule.target_ips:
+        parts.append(f"{len(schedule.target_ips)} ip(s)")
+    if schedule.target_macs:
+        parts.append(f"{len(schedule.target_macs)} mac(s)")
+    return ", ".join(parts) or "-"
+
+
+def _format_ts(ts: int | None) -> str:
+    if not ts:
+        return "-"
+    return datetime.fromtimestamp(ts, tz=UTC).strftime("%Y-%m-%d %H:%M")

--- a/packages/cli/src/cli/dependencies/container.py
+++ b/packages/cli/src/cli/dependencies/container.py
@@ -10,6 +10,9 @@ from core.repositories.db import async_session_factory
 from core.repositories.sqlalchemy_backup_repository import (
     SQLAlchemyBackupRepository,
 )
+from core.repositories.sqlalchemy_backup_schedule_repository import (
+    SQLAlchemyBackupScheduleRepository,
+)
 from core.repositories.sqlalchemy_credentials_repository import (
     SQLAlchemyCredentialsRepository,
 )
@@ -64,6 +67,16 @@ class CLIContainer(BaseContainer):
         async with async_session_factory() as session:
             try:
                 yield SQLAlchemyBackupRepository(session, self.get_encryption_service())
+            finally:
+                await session.close()
+
+    @asynccontextmanager
+    async def create_backup_schedule_repository(
+        self,
+    ) -> AsyncGenerator[SQLAlchemyBackupScheduleRepository, None]:
+        async with async_session_factory() as session:
+            try:
+                yield SQLAlchemyBackupScheduleRepository(session)
             finally:
                 await session.close()
 

--- a/packages/cli/tests/unit/commands/test_backup_schedule_commands.py
+++ b/packages/cli/tests/unit/commands/test_backup_schedule_commands.py
@@ -1,0 +1,141 @@
+"""Tests for the backup schedule CLI subgroup."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from cli.commands.backup_commands import backup_commands
+from click.testing import CliRunner
+from core.domain.entities.backup_schedule import BackupSchedule
+from core.use_cases.run_due_backups import ScheduleRunResult
+
+
+def _schedule(**kwargs):
+    base = {"id": 1, "name": "nightly", "interval_seconds": 86400, "enabled": True}
+    base.update(kwargs)
+    return BackupSchedule(**base)
+
+
+class TestScheduleCommands:
+    @pytest.fixture
+    def runner(self):
+        return CliRunner()
+
+    def _obj(self, *, manage=None, runner_uc=None):
+        obj = MagicMock()
+        obj.console = MagicMock()
+        obj.container.get_manage_backup_schedules_interactor.return_value = (
+            manage or MagicMock()
+        )
+        obj.container.get_run_due_backups_interactor.return_value = (
+            runner_uc or MagicMock()
+        )
+        return obj
+
+    def test_it_create_resolves_preset_interval(self, runner):
+        captured = {}
+        manage = MagicMock()
+
+        async def create(schedule):
+            captured["interval"] = schedule.interval_seconds
+            captured["targets"] = schedule.target_ips
+            schedule.id = 7
+            return schedule
+
+        manage.create_schedule = AsyncMock(side_effect=create)
+
+        result = runner.invoke(
+            backup_commands,
+            [
+                "schedule",
+                "create",
+                "--name",
+                "daily-job",
+                "--every",
+                "daily",
+                "-t",
+                "192.168.1.10",
+            ],
+            obj=self._obj(manage=manage),
+        )
+
+        assert result.exit_code == 0
+        assert captured["interval"] == 86400
+        assert captured["targets"] == ["192.168.1.10"]
+
+    def test_it_create_rejects_both_cadence_sources(self, runner):
+        result = runner.invoke(
+            backup_commands,
+            [
+                "schedule",
+                "create",
+                "--name",
+                "x",
+                "--every",
+                "daily",
+                "--interval-seconds",
+                "3600",
+                "-t",
+                "192.168.1.10",
+            ],
+            obj=self._obj(),
+        )
+        assert result.exit_code != 0
+
+    def test_it_create_rejects_no_targets(self, runner):
+        result = runner.invoke(
+            backup_commands,
+            ["schedule", "create", "--name", "x", "--every", "daily"],
+            obj=self._obj(),
+        )
+        assert result.exit_code != 0
+
+    def test_it_list_renders_without_error(self, runner):
+        manage = MagicMock()
+        manage.list_schedules = AsyncMock(
+            return_value=[_schedule(target_ips=["192.168.1.10"], next_run_at=1000)]
+        )
+
+        result = runner.invoke(
+            backup_commands,
+            ["schedule", "list"],
+            obj=self._obj(manage=manage),
+        )
+        assert result.exit_code == 0
+
+    def test_it_run_exits_nonzero_on_failure(self, runner):
+        runner_uc = MagicMock()
+        runner_uc.run_schedule = AsyncMock(
+            return_value=ScheduleRunResult(
+                schedule_id=1,
+                schedule_name="nightly",
+                status="failed",
+                targets=1,
+                failed=1,
+            )
+        )
+
+        result = runner.invoke(
+            backup_commands,
+            ["schedule", "run", "1"],
+            obj=self._obj(runner_uc=runner_uc),
+        )
+        assert result.exit_code == 1
+
+    def test_it_run_exits_zero_on_ok(self, runner):
+        runner_uc = MagicMock()
+        runner_uc.run_schedule = AsyncMock(
+            return_value=ScheduleRunResult(
+                schedule_id=1,
+                schedule_name="nightly",
+                status="ok",
+                targets=1,
+                ok=1,
+            )
+        )
+
+        result = runner.invoke(
+            backup_commands,
+            ["schedule", "run", "1"],
+            obj=self._obj(runner_uc=runner_uc),
+        )
+        assert result.exit_code == 0

--- a/packages/cli/tests/unit/commands/test_backup_schedule_commands.py
+++ b/packages/cli/tests/unit/commands/test_backup_schedule_commands.py
@@ -89,6 +89,23 @@ class TestScheduleCommands:
         )
         assert result.exit_code != 0
 
+    def test_it_create_rejects_invalid_target(self, runner):
+        result = runner.invoke(
+            backup_commands,
+            [
+                "schedule",
+                "create",
+                "--name",
+                "x",
+                "--every",
+                "daily",
+                "-t",
+                "not-an-ip",
+            ],
+            obj=self._obj(),
+        )
+        assert result.exit_code != 0
+
     def test_it_list_renders_without_error(self, runner):
         manage = MagicMock()
         manage.list_schedules = AsyncMock(

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -34,6 +34,8 @@ packages/core/src/core/
 │   ├── get_component_actions.py       # Component action discovery
 │   ├── backup_device_config.py        # Capture & persist a config snapshot
 │   ├── restore_device_config.py       # Restore a snapshot to a device
+│   ├── manage_backup_schedules.py     # CRUD + enable/disable for schedules
+│   ├── run_due_backups.py             # Run due schedules with retention
 │   └── ...
 ├── gateways/                 # External interfaces (abstract)
 │   ├── device/              # Device communication contracts
@@ -68,6 +70,15 @@ The core package provides per-device configuration backup and restore:
 Backups are persisted through the `BackupRepository` abstraction
 (`repositories/backup_repository.py`), implemented by `SQLAlchemyBackupRepository`, with the
 `DeviceBackup` domain entity (`domain/entities/device_backup.py`) holding the decrypted snapshot.
+
+Two more use cases drive scheduled backups:
+
+- **ManageBackupSchedulesUseCase** - CRUD plus enable/disable for `BackupSchedule` entities
+  (`domain/entities/backup_schedule.py`), persisted via `BackupScheduleRepository`.
+- **RunDueBackupsUseCase** - resolves a schedule's targets, captures a backup of each, and applies
+  the retention policy. It takes an injectable clock so the runner is deterministic under test, and
+  opens its own repository sessions because it runs outside any HTTP request. Retention is scoped to
+  scheduled snapshots, so a manual backup is never pruned by a schedule.
 
 ## Quick Start
 

--- a/packages/core/src/core/dependencies/container_base.py
+++ b/packages/core/src/core/dependencies/container_base.py
@@ -17,11 +17,13 @@ from core.use_cases.bulk_operations import BulkOperationsUseCase
 from core.use_cases.check_device_status import CheckDeviceStatusUseCase
 from core.use_cases.execute_component_action import ExecuteComponentActionUseCase
 from core.use_cases.get_component_actions import GetComponentActionsUseCase
+from core.use_cases.manage_backup_schedules import ManageBackupSchedulesUseCase
 from core.use_cases.manage_provisioning_profiles import (
     ManageProvisioningProfilesUseCase,
 )
 from core.use_cases.provision_device import ProvisionDeviceUseCase
 from core.use_cases.restore_device_config import RestoreDeviceConfig
+from core.use_cases.run_due_backups import RunDueBackupsUseCase
 from core.use_cases.scan_devices import ScanDevicesUseCase
 
 
@@ -43,6 +45,10 @@ class BaseContainer:
         self._ap_device_detector: APDeviceDetector | None = None
         self._backup_device_config_interactor: BackupDeviceConfig | None = None
         self._restore_device_config_interactor: RestoreDeviceConfig | None = None
+        self._manage_backup_schedules_interactor: (
+            ManageBackupSchedulesUseCase | None
+        ) = None
+        self._run_due_backups_interactor: RunDueBackupsUseCase | None = None
 
     def get_rpc_client(self) -> Any:
         raise NotImplementedError
@@ -159,6 +165,24 @@ class BaseContainer:
             )
         return self._restore_device_config_interactor
 
+    def get_manage_backup_schedules_interactor(self) -> ManageBackupSchedulesUseCase:
+        if self._manage_backup_schedules_interactor is None:
+            self._manage_backup_schedules_interactor = ManageBackupSchedulesUseCase(
+                repository_factory=self.create_backup_schedule_repository,
+            )
+        return self._manage_backup_schedules_interactor
+
+    def get_run_due_backups_interactor(self) -> RunDueBackupsUseCase:
+        if self._run_due_backups_interactor is None:
+            self._run_due_backups_interactor = RunDueBackupsUseCase(
+                schedule_repository_factory=self.create_backup_schedule_repository,
+                backup_repository_factory=self.create_backup_repository,
+                credentials_repository_factory=self.create_credentials_repository,
+                backup_device_config=self.get_backup_device_config_interactor(),
+                scan_devices=self.get_scan_interactor(),
+            )
+        return self._run_due_backups_interactor
+
     def create_provisioning_profile_repository(self) -> Any:
         raise NotImplementedError
 
@@ -166,4 +190,7 @@ class BaseContainer:
         raise NotImplementedError
 
     def create_backup_repository(self) -> Any:
+        raise NotImplementedError
+
+    def create_backup_schedule_repository(self) -> Any:
         raise NotImplementedError

--- a/packages/core/src/core/domain/entities/backup_schedule.py
+++ b/packages/core/src/core/domain/entities/backup_schedule.py
@@ -1,0 +1,48 @@
+"""Domain entity for an automated backup schedule."""
+
+from dataclasses import dataclass, field
+
+
+@dataclass
+class BackupSchedule:
+    """A recurring, interval-based backup job over a set of target devices.
+
+    Targets are the union of three modes: explicit ``target_ips``, ``target_macs``
+    (resolved to an IP via the credentials store's last-seen IP), and
+    ``all_credentialed`` (every MAC we hold credentials for). MACs with no known IP
+    are reported skipped, never failed.
+    """
+
+    name: str
+    interval_seconds: int
+    id: int | None = None
+    target_ips: list[str] = field(default_factory=list)
+    target_macs: list[str] = field(default_factory=list)
+    all_credentialed: bool = False
+    enabled: bool = True
+    retention_keep_last: int | None = None
+    retention_max_age_days: int | None = None
+    last_run_at: int | None = None
+    next_run_at: int | None = None
+    last_status: str | None = None
+    created_at: int | None = None
+    updated_at: int | None = None
+
+    def compute_next_run(self, from_ts: int) -> int:
+        """Return the next run timestamp strictly after ``from_ts``.
+
+        Advances along the interval grid anchored on the current ``next_run_at`` so
+        a backup that fell behind (device offline for days) fires once on catch-up
+        rather than backfilling every missed slot. Computed arithmetically to stay
+        O(1) even when the gap spans a very long offline period.
+        """
+        interval = self.interval_seconds
+        if interval <= 0:
+            # Defensive: validation enforces interval >= 1, but never loop forever.
+            return from_ts + 1
+
+        anchor = self.next_run_at if self.next_run_at is not None else from_ts
+        if anchor > from_ts:
+            return anchor
+        steps = (from_ts - anchor) // interval + 1
+        return anchor + steps * interval

--- a/packages/core/src/core/domain/entities/device_backup.py
+++ b/packages/core/src/core/domain/entities/device_backup.py
@@ -56,3 +56,18 @@ class DeviceBackupSummary:
 
     def __post_init__(self) -> None:
         self.device_mac = normalize_mac(self.device_mac)
+
+
+@dataclass
+class BackupPage:
+    """A single page of backup summaries plus the total matching count.
+
+    ``total`` is the full number of backups matching the query (ignoring the
+    page window), so a client can render "showing N of total" and decide
+    whether more pages exist.
+    """
+
+    items: list[DeviceBackupSummary] = field(default_factory=list)
+    total: int = 0
+    limit: int = 50
+    offset: int = 0

--- a/packages/core/src/core/repositories/backup_repository.py
+++ b/packages/core/src/core/repositories/backup_repository.py
@@ -18,11 +18,25 @@ class BackupRepository(ABC):
 
     @abstractmethod
     async def list_summaries(
-        self, device_mac: str | None = None
+        self,
+        device_mac: str | None = None,
+        limit: int | None = None,
+        offset: int = 0,
     ) -> list[DeviceBackupSummary]:
         """List backup summaries (no snapshot), newest first.
 
-        Optionally filtered by device MAC.
+        Optionally filtered by device MAC. When ``limit`` is ``None`` every
+        match is returned; otherwise the result is windowed by ``limit``/
+        ``offset`` for pagination.
+        """
+        pass
+
+    @abstractmethod
+    async def count_summaries(self, device_mac: str | None = None) -> int:
+        """Count stored backups, optionally filtered by device MAC.
+
+        Counts every source (manual and scheduled) — this is the total a
+        paginated list view paginates over, not a retention scope.
         """
         pass
 

--- a/packages/core/src/core/repositories/backup_repository.py
+++ b/packages/core/src/core/repositories/backup_repository.py
@@ -41,8 +41,13 @@ class BackupRepository(ABC):
         pass
 
     @abstractmethod
-    async def delete(self, backup_id: int) -> None:
-        """Delete a backup by ID."""
+    async def delete(self, backup_id: int) -> bool:
+        """Delete a backup by ID. Returns ``True`` if a row was deleted.
+
+        Returning whether anything was removed lets callers check existence
+        with the same keyed lookup that performs the delete, instead of
+        scanning the full list first.
+        """
         pass
 
     @abstractmethod

--- a/packages/core/src/core/repositories/backup_repository.py
+++ b/packages/core/src/core/repositories/backup_repository.py
@@ -30,3 +30,28 @@ class BackupRepository(ABC):
     async def delete(self, backup_id: int) -> None:
         """Delete a backup by ID."""
         pass
+
+    @abstractmethod
+    async def count_for_device(
+        self, device_mac: str, source: str | None = "scheduled"
+    ) -> int:
+        """Count stored backups for a device. ``source=None`` counts every source."""
+        pass
+
+    @abstractmethod
+    async def delete_keeping_latest_n(
+        self, device_mac: str, n: int, source: str | None = "scheduled"
+    ) -> int:
+        """Delete all but the newest ``n`` backups for a device. Returns count deleted.
+
+        Defaults to pruning only scheduled backups so a retention policy never
+        deletes a user's manually captured snapshot.
+        """
+        pass
+
+    @abstractmethod
+    async def delete_older_than(
+        self, device_mac: str, cutoff_ts: int, source: str | None = "scheduled"
+    ) -> int:
+        """Delete backups older than ``cutoff_ts``. Returns count deleted."""
+        pass

--- a/packages/core/src/core/repositories/backup_schedule_repository.py
+++ b/packages/core/src/core/repositories/backup_schedule_repository.py
@@ -1,0 +1,56 @@
+"""Abstract repository for automated backup schedules."""
+
+from abc import ABC, abstractmethod
+
+from core.domain.entities.backup_schedule import BackupSchedule
+
+
+class BackupScheduleRepository(ABC):
+    @abstractmethod
+    async def create(self, schedule: BackupSchedule) -> BackupSchedule:
+        """Persist a schedule. Returns it with the assigned ID."""
+        pass
+
+    @abstractmethod
+    async def get(self, schedule_id: int) -> BackupSchedule | None:
+        """Retrieve a schedule by ID."""
+        pass
+
+    @abstractmethod
+    async def get_by_name(self, name: str) -> BackupSchedule | None:
+        """Retrieve a schedule by its unique name."""
+        pass
+
+    @abstractmethod
+    async def list_all(self) -> list[BackupSchedule]:
+        """List all schedules, newest first."""
+        pass
+
+    @abstractmethod
+    async def list_due(self, now_ts: int) -> list[BackupSchedule]:
+        """List enabled schedules whose next_run_at is at or before now_ts."""
+        pass
+
+    @abstractmethod
+    async def update(self, schedule: BackupSchedule) -> BackupSchedule:
+        """Update an existing schedule."""
+        pass
+
+    @abstractmethod
+    async def set_run_result(
+        self,
+        schedule_id: int,
+        last_run_at: int,
+        next_run_at: int,
+        last_status: str | None,
+    ) -> None:
+        """Record the outcome of a run and advance next_run_at.
+
+        A narrow single-row write so a long batch never holds a wide transaction.
+        """
+        pass
+
+    @abstractmethod
+    async def delete(self, schedule_id: int) -> None:
+        """Delete a schedule by ID."""
+        pass

--- a/packages/core/src/core/repositories/models.py
+++ b/packages/core/src/core/repositories/models.py
@@ -70,8 +70,10 @@ class DeviceBackups(Base):
     snapshot_ciphertext: Mapped[str] = mapped_column(String, nullable=False)
     sha256: Mapped[str | None] = mapped_column(String, nullable=True)
     size_bytes: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    # Indexed because every list view orders by created_at (newest first);
+    # see the API lifespan for the matching CREATE INDEX on pre-existing DBs.
     created_at: Mapped[int] = mapped_column(
-        Integer, default=lambda: int(datetime.now(UTC).timestamp())
+        Integer, index=True, default=lambda: int(datetime.now(UTC).timestamp())
     )
 
     def __repr__(self) -> str:

--- a/packages/core/src/core/repositories/models.py
+++ b/packages/core/src/core/repositories/models.py
@@ -79,3 +79,32 @@ class DeviceBackups(Base):
             f"<DeviceBackups(id={self.id}, device_mac='{self.device_mac}', "
             f"source='{self.source}')>"
         )
+
+
+class BackupSchedules(Base):
+    __tablename__ = "backup_schedules"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    name: Mapped[str] = mapped_column(String, unique=True, nullable=False, index=True)
+    target_ips: Mapped[str] = mapped_column(String, nullable=False, default="[]")
+    target_macs: Mapped[str] = mapped_column(String, nullable=False, default="[]")
+    all_credentialed: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, default=False
+    )
+    interval_seconds: Mapped[int] = mapped_column(Integer, nullable=False)
+    enabled: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True)
+    retention_keep_last: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    retention_max_age_days: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    last_run_at: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    next_run_at: Mapped[int] = mapped_column(Integer, nullable=False, index=True)
+    last_status: Mapped[str | None] = mapped_column(String, nullable=True)
+    created_at: Mapped[int] = mapped_column(
+        Integer, default=lambda: int(datetime.now(UTC).timestamp())
+    )
+    updated_at: Mapped[int | None] = mapped_column(Integer, nullable=True)
+
+    def __repr__(self) -> str:
+        return (
+            f"<BackupSchedules(id={self.id}, name='{self.name}', "
+            f"enabled={self.enabled})>"
+        )

--- a/packages/core/src/core/repositories/sqlalchemy_backup_repository.py
+++ b/packages/core/src/core/repositories/sqlalchemy_backup_repository.py
@@ -9,7 +9,7 @@ from core.repositories.backup_repository import BackupRepository
 from core.repositories.models import DeviceBackups as BackupModel
 from core.services.encryption_service import EncryptionService
 from core.utils.validation import normalize_mac
-from sqlalchemy import select
+from sqlalchemy import delete, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 logger = logging.getLogger(__name__)
@@ -73,6 +73,60 @@ class SQLAlchemyBackupRepository(BackupRepository):
         if record:
             await self.session.delete(record)
             await self.session.commit()
+
+    async def count_for_device(
+        self, device_mac: str, source: str | None = "scheduled"
+    ) -> int:
+        mac = normalize_mac(device_mac)
+        stmt = (
+            select(func.count())
+            .select_from(BackupModel)
+            .where(BackupModel.device_mac == mac)
+        )
+        if source is not None:
+            stmt = stmt.where(BackupModel.source == source)
+        result = await self.session.execute(stmt)
+        return int(result.scalar_one())
+
+    async def delete_keeping_latest_n(
+        self, device_mac: str, n: int, source: str | None = "scheduled"
+    ) -> int:
+        if n < 1:
+            # Refuse to interpret "keep 0" as "delete everything" — that is almost
+            # certainly a misconfiguration, not an intent to wipe all snapshots.
+            return 0
+        mac = normalize_mac(device_mac)
+        stmt = select(BackupModel.id).where(BackupModel.device_mac == mac)
+        if source is not None:
+            stmt = stmt.where(BackupModel.source == source)
+        stmt = stmt.order_by(BackupModel.created_at.desc(), BackupModel.id.desc())
+        ids = [row[0] for row in (await self.session.execute(stmt)).all()]
+        to_delete = ids[n:]
+        if not to_delete:
+            return 0
+        await self.session.execute(
+            delete(BackupModel).where(BackupModel.id.in_(to_delete))
+        )
+        await self.session.commit()
+        return len(to_delete)
+
+    async def delete_older_than(
+        self, device_mac: str, cutoff_ts: int, source: str | None = "scheduled"
+    ) -> int:
+        mac = normalize_mac(device_mac)
+        conditions = [
+            BackupModel.device_mac == mac,
+            BackupModel.created_at < cutoff_ts,
+        ]
+        if source is not None:
+            conditions.append(BackupModel.source == source)
+
+        count_stmt = select(func.count()).select_from(BackupModel).where(*conditions)
+        count = int((await self.session.execute(count_stmt)).scalar_one())
+        if count:
+            await self.session.execute(delete(BackupModel).where(*conditions))
+            await self.session.commit()
+        return count
 
     def _to_domain(self, record: BackupModel) -> DeviceBackup | None:
         try:

--- a/packages/core/src/core/repositories/sqlalchemy_backup_repository.py
+++ b/packages/core/src/core/repositories/sqlalchemy_backup_repository.py
@@ -57,14 +57,30 @@ class SQLAlchemyBackupRepository(BackupRepository):
         return self._to_domain(record)
 
     async def list_summaries(
-        self, device_mac: str | None = None
+        self,
+        device_mac: str | None = None,
+        limit: int | None = None,
+        offset: int = 0,
     ) -> list[DeviceBackupSummary]:
-        stmt = select(BackupModel).order_by(BackupModel.created_at.desc())
+        # Tie-break on id so rows sharing a created_at second keep a stable
+        # order across pages; without it pagination could repeat or drop rows.
+        stmt = select(BackupModel).order_by(
+            BackupModel.created_at.desc(), BackupModel.id.desc()
+        )
         if device_mac is not None:
             stmt = stmt.where(BackupModel.device_mac == normalize_mac(device_mac))
+        if limit is not None:
+            stmt = stmt.limit(limit).offset(offset)
         result = await self.session.execute(stmt)
         records = result.scalars().all()
         return [self._to_summary(record) for record in records]
+
+    async def count_summaries(self, device_mac: str | None = None) -> int:
+        stmt = select(func.count()).select_from(BackupModel)
+        if device_mac is not None:
+            stmt = stmt.where(BackupModel.device_mac == normalize_mac(device_mac))
+        result = await self.session.execute(stmt)
+        return int(result.scalar_one())
 
     async def delete(self, backup_id: int) -> None:
         stmt = select(BackupModel).where(BackupModel.id == backup_id)

--- a/packages/core/src/core/repositories/sqlalchemy_backup_repository.py
+++ b/packages/core/src/core/repositories/sqlalchemy_backup_repository.py
@@ -82,13 +82,15 @@ class SQLAlchemyBackupRepository(BackupRepository):
         result = await self.session.execute(stmt)
         return int(result.scalar_one())
 
-    async def delete(self, backup_id: int) -> None:
+    async def delete(self, backup_id: int) -> bool:
         stmt = select(BackupModel).where(BackupModel.id == backup_id)
         result = await self.session.execute(stmt)
         record = result.scalar_one_or_none()
-        if record:
-            await self.session.delete(record)
-            await self.session.commit()
+        if record is None:
+            return False
+        await self.session.delete(record)
+        await self.session.commit()
+        return True
 
     async def count_for_device(
         self, device_mac: str, source: str | None = "scheduled"

--- a/packages/core/src/core/repositories/sqlalchemy_backup_schedule_repository.py
+++ b/packages/core/src/core/repositories/sqlalchemy_backup_schedule_repository.py
@@ -1,0 +1,145 @@
+"""SQLAlchemy implementation of the backup schedule repository."""
+
+import json
+import logging
+from datetime import UTC, datetime
+
+from core.domain.entities.backup_schedule import BackupSchedule
+from core.repositories.backup_schedule_repository import BackupScheduleRepository
+from core.repositories.models import BackupSchedules as ScheduleModel
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+logger = logging.getLogger(__name__)
+
+
+class SQLAlchemyBackupScheduleRepository(BackupScheduleRepository):
+    def __init__(self, session: AsyncSession):
+        self.session = session
+
+    async def create(self, schedule: BackupSchedule) -> BackupSchedule:
+        record = ScheduleModel(
+            name=schedule.name,
+            target_ips=_encode(schedule.target_ips),
+            target_macs=_encode(schedule.target_macs),
+            all_credentialed=schedule.all_credentialed,
+            interval_seconds=schedule.interval_seconds,
+            enabled=schedule.enabled,
+            retention_keep_last=schedule.retention_keep_last,
+            retention_max_age_days=schedule.retention_max_age_days,
+            last_run_at=schedule.last_run_at,
+            next_run_at=schedule.next_run_at,
+            last_status=schedule.last_status,
+        )
+        self.session.add(record)
+        await self.session.commit()
+        await self.session.refresh(record)
+        return self._to_domain(record)
+
+    async def get(self, schedule_id: int) -> BackupSchedule | None:
+        stmt = select(ScheduleModel).where(ScheduleModel.id == schedule_id)
+        record = (await self.session.execute(stmt)).scalar_one_or_none()
+        return self._to_domain(record) if record else None
+
+    async def get_by_name(self, name: str) -> BackupSchedule | None:
+        stmt = select(ScheduleModel).where(ScheduleModel.name == name)
+        record = (await self.session.execute(stmt)).scalar_one_or_none()
+        return self._to_domain(record) if record else None
+
+    async def list_all(self) -> list[BackupSchedule]:
+        stmt = select(ScheduleModel).order_by(ScheduleModel.created_at.desc())
+        records = (await self.session.execute(stmt)).scalars().all()
+        return [self._to_domain(record) for record in records]
+
+    async def list_due(self, now_ts: int) -> list[BackupSchedule]:
+        stmt = (
+            select(ScheduleModel)
+            .where(ScheduleModel.enabled.is_(True))
+            .where(ScheduleModel.next_run_at <= now_ts)
+            .order_by(ScheduleModel.next_run_at)
+        )
+        records = (await self.session.execute(stmt)).scalars().all()
+        return [self._to_domain(record) for record in records]
+
+    async def update(self, schedule: BackupSchedule) -> BackupSchedule:
+        if schedule.id is None:
+            raise ValueError("Cannot update a schedule without an ID")
+
+        stmt = select(ScheduleModel).where(ScheduleModel.id == schedule.id)
+        record = (await self.session.execute(stmt)).scalar_one_or_none()
+        if not record:
+            raise ValueError(f"Schedule with ID {schedule.id} not found")
+
+        record.name = schedule.name
+        record.target_ips = _encode(schedule.target_ips)
+        record.target_macs = _encode(schedule.target_macs)
+        record.all_credentialed = schedule.all_credentialed
+        record.interval_seconds = schedule.interval_seconds
+        record.enabled = schedule.enabled
+        record.retention_keep_last = schedule.retention_keep_last
+        record.retention_max_age_days = schedule.retention_max_age_days
+        if schedule.next_run_at is not None:
+            record.next_run_at = schedule.next_run_at
+        record.updated_at = int(datetime.now(UTC).timestamp())
+
+        await self.session.commit()
+        await self.session.refresh(record)
+        return self._to_domain(record)
+
+    async def set_run_result(
+        self,
+        schedule_id: int,
+        last_run_at: int,
+        next_run_at: int,
+        last_status: str | None,
+    ) -> None:
+        stmt = select(ScheduleModel).where(ScheduleModel.id == schedule_id)
+        record = (await self.session.execute(stmt)).scalar_one_or_none()
+        if not record:
+            return
+        record.last_run_at = last_run_at
+        record.next_run_at = next_run_at
+        record.last_status = last_status
+        await self.session.commit()
+
+    async def delete(self, schedule_id: int) -> None:
+        stmt = select(ScheduleModel).where(ScheduleModel.id == schedule_id)
+        record = (await self.session.execute(stmt)).scalar_one_or_none()
+        if record:
+            await self.session.delete(record)
+            await self.session.commit()
+
+    def _to_domain(self, record: ScheduleModel) -> BackupSchedule:
+        return BackupSchedule(
+            id=record.id,
+            name=record.name,
+            interval_seconds=record.interval_seconds,
+            target_ips=_decode(record.target_ips),
+            target_macs=_decode(record.target_macs),
+            all_credentialed=record.all_credentialed,
+            enabled=record.enabled,
+            retention_keep_last=record.retention_keep_last,
+            retention_max_age_days=record.retention_max_age_days,
+            last_run_at=record.last_run_at,
+            next_run_at=record.next_run_at,
+            last_status=record.last_status,
+            created_at=record.created_at,
+            updated_at=record.updated_at,
+        )
+
+
+def _encode(values: list[str]) -> str:
+    return json.dumps(list(values))
+
+
+def _decode(raw: str | None) -> list[str]:
+    if not raw:
+        return []
+    try:
+        decoded = json.loads(raw)
+    except (ValueError, TypeError):
+        logger.warning("Could not decode schedule target list: %r", raw)
+        return []
+    if not isinstance(decoded, list):
+        return []
+    return [str(item) for item in decoded]

--- a/packages/core/src/core/settings.py
+++ b/packages/core/src/core/settings.py
@@ -158,6 +158,7 @@ class AppSettings(BaseSettings):
                 "logging": self.logging.model_dump(),
                 "network": self.network.model_dump(),
                 "api": self.api.model_dump(),
+                "backup": self.backup.model_dump(),
                 "config_file": self.config_file,
                 "data_dir": self.data_dir,
                 "cache_ttl": self.cache_ttl,

--- a/packages/core/src/core/settings.py
+++ b/packages/core/src/core/settings.py
@@ -62,6 +62,19 @@ class NetworkSettings(BaseSettings):
     verify_ssl: bool = Field(default=False, description="Verify SSL certificates")
 
 
+class BackupSettings(BaseSettings):
+    model_config = SettingsConfigDict(env_prefix="SHELLY_BACKUP_")
+
+    scheduler_enabled: bool = Field(
+        default=True, description="Run the in-process scheduled-backup poller"
+    )
+    poll_interval_seconds: int = Field(
+        default=60,
+        ge=1,
+        description="How often the scheduler checks for due backups, in seconds",
+    )
+
+
 class APISettings(BaseSettings):
     model_config = SettingsConfigDict(env_prefix="API_")
 
@@ -83,6 +96,7 @@ class AppSettings(BaseSettings):
     logging: LoggingSettings = Field(default_factory=LoggingSettings)
     network: NetworkSettings = Field(default_factory=NetworkSettings)
     api: APISettings = Field(default_factory=APISettings)
+    backup: BackupSettings = Field(default_factory=BackupSettings)
 
     config_file: str = Field(
         default="config.json", description="Configuration file path"
@@ -125,6 +139,8 @@ class AppSettings(BaseSettings):
                 self.network = NetworkSettings(**raw["network"])
             if isinstance(raw.get("api"), dict):
                 self.api = APISettings(**raw["api"])
+            if isinstance(raw.get("backup"), dict):
+                self.backup = BackupSettings(**raw["backup"])
 
             for field_name in ["config_file", "data_dir", "cache_ttl"]:
                 if field_name in raw:

--- a/packages/core/src/core/use_cases/backup_device_config.py
+++ b/packages/core/src/core/use_cases/backup_device_config.py
@@ -5,7 +5,11 @@ from collections.abc import Callable
 from contextlib import AbstractAsyncContextManager
 from typing import Any
 
-from core.domain.entities.device_backup import DeviceBackup, DeviceBackupSummary
+from core.domain.entities.device_backup import (
+    BackupPage,
+    DeviceBackup,
+    DeviceBackupSummary,
+)
 from core.domain.entities.exceptions import DeviceNotFoundError
 from core.gateways.device import DeviceGateway
 from core.repositories.backup_repository import BackupRepository
@@ -126,9 +130,25 @@ class BackupDeviceConfig:
     async def list_backups(
         self, device_mac: str | None = None
     ) -> list[DeviceBackupSummary]:
-        """List backup summaries, newest first, optionally filtered by MAC."""
+        """List every backup summary, newest first, optionally filtered by MAC.
+
+        Unbounded — used by callers that want the full set (the CLI listing).
+        UI/API list views should use :meth:`list_backups_page` instead.
+        """
         async with self._repository_factory() as repository:
             return await repository.list_summaries(device_mac)
+
+    async def list_backups_page(
+        self,
+        device_mac: str | None = None,
+        limit: int = 50,
+        offset: int = 0,
+    ) -> BackupPage:
+        """Return one page of backup summaries plus the total matching count."""
+        async with self._repository_factory() as repository:
+            items = await repository.list_summaries(device_mac, limit, offset)
+            total = await repository.count_summaries(device_mac)
+        return BackupPage(items=items, total=total, limit=limit, offset=offset)
 
     async def get_backup(self, backup_id: int) -> DeviceBackup:
         """Get a full backup including its snapshot.

--- a/packages/core/src/core/use_cases/backup_device_config.py
+++ b/packages/core/src/core/use_cases/backup_device_config.py
@@ -169,10 +169,9 @@ class BackupDeviceConfig:
             BackupNotFoundError: If the backup does not exist.
         """
         async with self._repository_factory() as repository:
-            summaries = await repository.list_summaries()
-            if not any(summary.id == backup_id for summary in summaries):
-                raise BackupNotFoundError(backup_id)
-            await repository.delete(backup_id)
+            deleted = await repository.delete(backup_id)
+        if not deleted:
+            raise BackupNotFoundError(backup_id)
         logger.info("Deleted backup id=%s", backup_id)
 
 

--- a/packages/core/src/core/use_cases/manage_backup_schedules.py
+++ b/packages/core/src/core/use_cases/manage_backup_schedules.py
@@ -1,0 +1,145 @@
+"""Use case for managing backup schedules (CRUD plus enable/disable)."""
+
+import logging
+from collections.abc import Callable
+from contextlib import AbstractAsyncContextManager
+from datetime import UTC, datetime
+
+from core.domain.entities.backup_schedule import BackupSchedule
+from core.repositories.backup_schedule_repository import BackupScheduleRepository
+
+logger = logging.getLogger(__name__)
+
+
+def _default_clock() -> int:
+    return int(datetime.now(UTC).timestamp())
+
+
+class ScheduleNotFoundError(Exception):
+    """Raised when a backup schedule is not found."""
+
+    def __init__(self, identifier: int | str):
+        self.identifier = identifier
+        super().__init__(f"Backup schedule not found: {identifier}")
+
+
+class ScheduleAlreadyExistsError(Exception):
+    """Raised when a schedule with the same name already exists."""
+
+    def __init__(self, name: str):
+        self.name = name
+        super().__init__(f"Backup schedule already exists: {name}")
+
+
+class ManageBackupSchedulesUseCase:
+    """CRUD plus enable/disable for backup schedules."""
+
+    def __init__(
+        self,
+        repository_factory: Callable[
+            [], AbstractAsyncContextManager[BackupScheduleRepository]
+        ],
+        clock: Callable[[], int] = _default_clock,
+    ):
+        self._repository_factory = repository_factory
+        self._clock = clock
+
+    async def list_schedules(self) -> list[BackupSchedule]:
+        """List all schedules, newest first."""
+        async with self._repository_factory() as repository:
+            return await repository.list_all()
+
+    async def get_schedule(self, schedule_id: int) -> BackupSchedule:
+        """Get a schedule by ID.
+
+        Raises:
+            ScheduleNotFoundError: If the schedule does not exist.
+        """
+        async with self._repository_factory() as repository:
+            schedule = await repository.get(schedule_id)
+            if schedule is None:
+                raise ScheduleNotFoundError(schedule_id)
+            return schedule
+
+    async def create_schedule(self, schedule: BackupSchedule) -> BackupSchedule:
+        """Create a new schedule.
+
+        The first run is one interval out, not immediate, so creating an
+        ``all_credentialed`` schedule does not back up the whole fleet at once;
+        use run-now for an immediate baseline.
+
+        Raises:
+            ScheduleAlreadyExistsError: If a schedule with the same name exists.
+        """
+        async with self._repository_factory() as repository:
+            if await repository.get_by_name(schedule.name) is not None:
+                raise ScheduleAlreadyExistsError(schedule.name)
+            if schedule.next_run_at is None:
+                schedule.next_run_at = self._clock() + schedule.interval_seconds
+            created = await repository.create(schedule)
+            logger.info("Created backup schedule: %s", schedule.name)
+            return created
+
+    async def update_schedule(self, schedule: BackupSchedule) -> BackupSchedule:
+        """Update an existing schedule.
+
+        Raises:
+            ScheduleNotFoundError: If the schedule does not exist.
+            ScheduleAlreadyExistsError: If the new name conflicts with another.
+        """
+        if schedule.id is None:
+            raise ScheduleNotFoundError("unknown (no ID)")
+
+        async with self._repository_factory() as repository:
+            existing = await repository.get(schedule.id)
+            if existing is None:
+                raise ScheduleNotFoundError(schedule.id)
+
+            if schedule.name != existing.name:
+                if await repository.get_by_name(schedule.name) is not None:
+                    raise ScheduleAlreadyExistsError(schedule.name)
+
+            # A changed cadence restarts the grid from now; otherwise keep the
+            # device's place in the existing schedule.
+            if schedule.interval_seconds != existing.interval_seconds:
+                schedule.next_run_at = self._clock() + schedule.interval_seconds
+            elif schedule.next_run_at is None:
+                schedule.next_run_at = existing.next_run_at
+
+            updated = await repository.update(schedule)
+            logger.info("Updated backup schedule: %s", schedule.name)
+            return updated
+
+    async def set_enabled(self, schedule_id: int, enabled: bool) -> BackupSchedule:
+        """Enable or disable a schedule.
+
+        Raises:
+            ScheduleNotFoundError: If the schedule does not exist.
+        """
+        async with self._repository_factory() as repository:
+            existing = await repository.get(schedule_id)
+            if existing is None:
+                raise ScheduleNotFoundError(schedule_id)
+            existing.enabled = enabled
+            updated = await repository.update(existing)
+            logger.info(
+                "%s backup schedule: %s",
+                "Enabled" if enabled else "Disabled",
+                existing.name,
+            )
+            return updated
+
+    async def delete_schedule(self, schedule_id: int) -> None:
+        """Delete a schedule.
+
+        Raises:
+            ScheduleNotFoundError: If the schedule does not exist.
+        """
+        async with self._repository_factory() as repository:
+            existing = await repository.get(schedule_id)
+            if existing is None:
+                raise ScheduleNotFoundError(schedule_id)
+            await repository.delete(schedule_id)
+            logger.info(
+                "Deleted backup schedule: %s (id=%s)", existing.name, schedule_id
+            )

--- a/packages/core/src/core/use_cases/run_due_backups.py
+++ b/packages/core/src/core/use_cases/run_due_backups.py
@@ -129,7 +129,9 @@ class RunDueBackupsUseCase:
         status = self._classify(ok, failed, skipped)
         message = f"{ok} ok, {failed} failed, {skipped} skipped"
         if schedule.id is not None:
-            next_run = schedule.compute_next_run(now)
+            # Anchor the next run after the actual completion time so a long
+            # backup does not remain immediately due and rerun back-to-back.
+            next_run = schedule.compute_next_run(self._clock())
             async with self._schedule_repository_factory() as repository:
                 await repository.set_run_result(
                     schedule.id,

--- a/packages/core/src/core/use_cases/run_due_backups.py
+++ b/packages/core/src/core/use_cases/run_due_backups.py
@@ -1,0 +1,272 @@
+"""Use case for running due scheduled backups with retention."""
+
+import logging
+from collections.abc import Callable
+from contextlib import AbstractAsyncContextManager
+from dataclasses import dataclass
+from datetime import UTC, datetime
+
+from core.domain.entities.backup_schedule import BackupSchedule
+from core.domain.entities.exceptions import DeviceNotFoundError
+from core.domain.value_objects.scan_request import ScanRequest
+from core.repositories.backup_repository import BackupRepository
+from core.repositories.backup_schedule_repository import BackupScheduleRepository
+from core.repositories.credentials_repository import CredentialsRepository
+from core.use_cases.backup_device_config import BackupDeviceConfig
+from core.use_cases.manage_backup_schedules import ScheduleNotFoundError
+from core.use_cases.scan_devices import ScanDevicesUseCase
+from core.utils.validation import normalize_mac
+
+logger = logging.getLogger(__name__)
+
+SECONDS_PER_DAY = 86400
+
+
+def _default_clock() -> int:
+    return int(datetime.now(UTC).timestamp())
+
+
+@dataclass
+class ScheduleRunResult:
+    """Outcome of running a single schedule once."""
+
+    schedule_id: int
+    schedule_name: str
+    status: str
+    targets: int = 0
+    ok: int = 0
+    failed: int = 0
+    skipped: int = 0
+    message: str = ""
+
+
+class RunDueBackupsUseCase:
+    """Run schedules that are due and prune snapshots per their retention policy.
+
+    The scheduler has no HTTP request, so every repository access opens its own
+    session via the injected factories. The ``clock`` is injectable purely so the
+    runner is deterministic under test.
+    """
+
+    def __init__(
+        self,
+        schedule_repository_factory: Callable[
+            [], AbstractAsyncContextManager[BackupScheduleRepository]
+        ],
+        backup_repository_factory: Callable[
+            [], AbstractAsyncContextManager[BackupRepository]
+        ],
+        credentials_repository_factory: Callable[
+            [], AbstractAsyncContextManager[CredentialsRepository]
+        ],
+        backup_device_config: BackupDeviceConfig,
+        scan_devices: ScanDevicesUseCase | None = None,
+        clock: Callable[[], int] = _default_clock,
+    ):
+        self._schedule_repository_factory = schedule_repository_factory
+        self._backup_repository_factory = backup_repository_factory
+        self._credentials_repository_factory = credentials_repository_factory
+        self._backup_device_config = backup_device_config
+        self._scan_devices = scan_devices
+        self._clock = clock
+
+    async def run_due(self) -> list[ScheduleRunResult]:
+        """Run every schedule whose next_run_at has passed, sequentially."""
+        now = self._clock()
+        async with self._schedule_repository_factory() as repository:
+            due = await repository.list_due(now)
+        results: list[ScheduleRunResult] = []
+        # Sequential on purpose: backing up many devices at once would hammer the LAN.
+        for schedule in due:
+            results.append(await self._run_one(schedule, now))
+        return results
+
+    async def run_schedule(self, schedule_id: int) -> ScheduleRunResult:
+        """Run one schedule now, ignoring its next_run_at.
+
+        Raises:
+            ScheduleNotFoundError: If the schedule does not exist.
+        """
+        async with self._schedule_repository_factory() as repository:
+            schedule = await repository.get(schedule_id)
+        if schedule is None:
+            raise ScheduleNotFoundError(schedule_id)
+        return await self._run_one(schedule, self._clock())
+
+    async def _run_one(self, schedule: BackupSchedule, now: int) -> ScheduleRunResult:
+        target_ips, skipped_macs = await self._resolve_targets(schedule)
+        ok = 0
+        failed = 0
+        skipped = len(skipped_macs)
+        touched_macs: set[str] = set()
+
+        for ip in target_ips:
+            try:
+                backup = await self._backup_device_config.create_backup(
+                    ip, source="scheduled"
+                )
+                ok += 1
+                touched_macs.add(normalize_mac(backup.device_mac))
+            except DeviceNotFoundError:
+                skipped += 1
+                logger.warning(
+                    "Schedule '%s': device %s unreachable, skipped",
+                    schedule.name,
+                    ip,
+                )
+            except Exception:
+                failed += 1
+                logger.exception(
+                    "Schedule '%s': backup failed for %s", schedule.name, ip
+                )
+
+        await self._apply_retention(schedule, touched_macs, now)
+
+        status = self._classify(ok, failed, skipped)
+        message = f"{ok} ok, {failed} failed, {skipped} skipped"
+        if schedule.id is not None:
+            next_run = schedule.compute_next_run(now)
+            async with self._schedule_repository_factory() as repository:
+                await repository.set_run_result(
+                    schedule.id,
+                    last_run_at=now,
+                    next_run_at=next_run,
+                    last_status=f"{status}: {message}",
+                )
+
+        return ScheduleRunResult(
+            schedule_id=schedule.id or 0,
+            schedule_name=schedule.name,
+            status=status,
+            targets=len(target_ips),
+            ok=ok,
+            failed=failed,
+            skipped=skipped,
+            message=message,
+        )
+
+    async def _resolve_targets(
+        self, schedule: BackupSchedule
+    ) -> tuple[list[str], list[str]]:
+        """Resolve a schedule's targets to a deduped IP list plus unresolved MACs.
+
+        Union of explicit IPs, range/CIDR targets expanded by scanning for live
+        Shelly devices, MACs resolved via the credentials store's last-seen IP, and
+        (optionally) every credentialed MAC. A MAC with no known IP is returned as
+        skipped rather than silently dropped.
+        """
+        ips = {t for t in schedule.target_ips if t and not _is_discoverable_target(t)}
+        discover_targets = [
+            t for t in schedule.target_ips if t and _is_discoverable_target(t)
+        ]
+        if discover_targets:
+            ips |= await self._discover_targets(schedule, discover_targets)
+
+        requested_macs = {normalize_mac(m) for m in schedule.target_macs if m}
+        skipped_macs: list[str] = []
+
+        if schedule.all_credentialed or requested_macs:
+            async with self._credentials_repository_factory() as repository:
+                credentials = await repository.list_all()
+            by_mac = {c.mac: c for c in credentials if c is not None and c.mac != "*"}
+
+            macs = set(requested_macs)
+            if schedule.all_credentialed:
+                macs |= set(by_mac.keys())
+
+            for mac in sorted(macs):
+                credential = by_mac.get(mac)
+                if credential and credential.last_seen_ip:
+                    ips.add(credential.last_seen_ip)
+                else:
+                    skipped_macs.append(mac)
+
+        return sorted(ips), skipped_macs
+
+    async def _discover_targets(
+        self, schedule: BackupSchedule, targets: list[str]
+    ) -> set[str]:
+        """Scan range/CIDR targets and return the IPs of the Shelly devices found.
+
+        Only discovered devices are backed up, so a /24 never turns into hundreds of
+        backup attempts against IPs that hold no device.
+        """
+        if self._scan_devices is None:
+            logger.warning(
+                "Schedule '%s': targets %s need discovery but no scanner is "
+                "configured; skipping them",
+                schedule.name,
+                targets,
+            )
+            return set()
+        try:
+            devices = await self._scan_devices.execute(ScanRequest(targets=targets))
+        except Exception:
+            logger.exception(
+                "Schedule '%s': discovery scan failed for %s",
+                schedule.name,
+                targets,
+            )
+            return set()
+        return {device.ip for device in devices if device.ip}
+
+    async def _apply_retention(
+        self, schedule: BackupSchedule, touched_macs: set[str], now: int
+    ) -> None:
+        if not touched_macs:
+            return
+        if (
+            schedule.retention_keep_last is None
+            and schedule.retention_max_age_days is None
+        ):
+            return
+
+        async with self._backup_repository_factory() as repository:
+            for mac in sorted(touched_macs):
+                try:
+                    if schedule.retention_keep_last is not None:
+                        deleted = await repository.delete_keeping_latest_n(
+                            mac, schedule.retention_keep_last
+                        )
+                        if deleted:
+                            logger.info(
+                                "Retention pruned %d scheduled backups for %s "
+                                "(keep_last=%d)",
+                                deleted,
+                                mac,
+                                schedule.retention_keep_last,
+                            )
+                    if schedule.retention_max_age_days is not None:
+                        cutoff = now - schedule.retention_max_age_days * SECONDS_PER_DAY
+                        deleted = await repository.delete_older_than(mac, cutoff)
+                        if deleted:
+                            logger.info(
+                                "Retention pruned %d scheduled backups older than "
+                                "%d days for %s",
+                                deleted,
+                                schedule.retention_max_age_days,
+                                mac,
+                            )
+                except Exception:
+                    logger.exception(
+                        "Retention failed for %s on schedule '%s'",
+                        mac,
+                        schedule.name,
+                    )
+
+    @staticmethod
+    def _classify(ok: int, failed: int, skipped: int) -> str:
+        if failed and ok:
+            return "partial"
+        if failed:
+            return "failed"
+        if ok:
+            return "ok"
+        if skipped:
+            return "skipped"
+        return "empty"
+
+
+def _is_discoverable_target(target: str) -> bool:
+    """True for a range or CIDR target that must be expanded by scanning."""
+    return "/" in target or "-" in target

--- a/packages/core/src/core/use_cases/run_due_backups.py
+++ b/packages/core/src/core/use_cases/run_due_backups.py
@@ -1,5 +1,6 @@
 """Use case for running due scheduled backups with retention."""
 
+import asyncio
 import logging
 from collections.abc import Callable
 from contextlib import AbstractAsyncContextManager
@@ -69,17 +70,19 @@ class RunDueBackupsUseCase:
         self._backup_device_config = backup_device_config
         self._scan_devices = scan_devices
         self._clock = clock
+        self._run_lock = asyncio.Lock()
 
     async def run_due(self) -> list[ScheduleRunResult]:
         """Run every schedule whose next_run_at has passed, sequentially."""
-        now = self._clock()
-        async with self._schedule_repository_factory() as repository:
-            due = await repository.list_due(now)
-        results: list[ScheduleRunResult] = []
-        # Sequential on purpose: backing up many devices at once would hammer the LAN.
-        for schedule in due:
-            results.append(await self._run_one(schedule, now))
-        return results
+        async with self._run_lock:
+            now = self._clock()
+            async with self._schedule_repository_factory() as repository:
+                due = await repository.list_due(now)
+            results: list[ScheduleRunResult] = []
+            # Sequential on purpose: backing up many devices at once would hammer the LAN.
+            for schedule in due:
+                results.append(await self._run_one(schedule, now))
+            return results
 
     async def run_schedule(self, schedule_id: int) -> ScheduleRunResult:
         """Run one schedule now, ignoring its next_run_at.
@@ -87,11 +90,12 @@ class RunDueBackupsUseCase:
         Raises:
             ScheduleNotFoundError: If the schedule does not exist.
         """
-        async with self._schedule_repository_factory() as repository:
-            schedule = await repository.get(schedule_id)
-        if schedule is None:
-            raise ScheduleNotFoundError(schedule_id)
-        return await self._run_one(schedule, self._clock())
+        async with self._run_lock:
+            async with self._schedule_repository_factory() as repository:
+                schedule = await repository.get(schedule_id)
+            if schedule is None:
+                raise ScheduleNotFoundError(schedule_id)
+            return await self._run_one(schedule, self._clock())
 
     async def _run_one(self, schedule: BackupSchedule, now: int) -> ScheduleRunResult:
         target_ips, skipped_macs = await self._resolve_targets(schedule)

--- a/packages/core/tests/unit/domain/entities/test_backup_schedule.py
+++ b/packages/core/tests/unit/domain/entities/test_backup_schedule.py
@@ -1,0 +1,35 @@
+"""Tests for the BackupSchedule entity's next-run arithmetic."""
+
+from core.domain.entities.backup_schedule import BackupSchedule
+
+
+def _schedule(interval=3600, next_run_at=None):
+    return BackupSchedule(
+        name="nightly",
+        interval_seconds=interval,
+        next_run_at=next_run_at,
+    )
+
+
+class TestComputeNextRun:
+    def test_it_future_next_run_is_unchanged(self):
+        schedule = _schedule(interval=3600, next_run_at=2000)
+        assert schedule.compute_next_run(1000) == 2000
+
+    def test_it_boundary_next_run_equal_to_now_advances_one_interval(self):
+        schedule = _schedule(interval=100, next_run_at=1000)
+        assert schedule.compute_next_run(1000) == 1100
+
+    def test_it_far_past_next_run_fires_once_on_the_grid(self):
+        # Anchored at 100, interval 100, now 350: the next slot strictly after now
+        # is 400, not a backfill of 200/300/400.
+        schedule = _schedule(interval=100, next_run_at=100)
+        assert schedule.compute_next_run(350) == 400
+
+    def test_it_none_next_run_anchors_on_now(self):
+        schedule = _schedule(interval=3600, next_run_at=None)
+        assert schedule.compute_next_run(1000) == 4600
+
+    def test_it_non_positive_interval_never_loops(self):
+        schedule = _schedule(interval=0, next_run_at=10)
+        assert schedule.compute_next_run(1000) == 1001

--- a/packages/core/tests/unit/repositories/test_sqlalchemy_backup_repository.py
+++ b/packages/core/tests/unit/repositories/test_sqlalchemy_backup_repository.py
@@ -107,9 +107,14 @@ class TestSQLAlchemyBackupRepository:
             repo = SQLAlchemyBackupRepository(session, EncryptionService())
             created = await repo.create(_backup())
 
-            await repo.delete(created.id)
-
+            assert await repo.delete(created.id) is True
             assert await repo.get(created.id) is None
+
+    async def test_it_returns_false_when_deleting_missing_backup(self, session_factory):
+        async with session_factory() as session:
+            repo = SQLAlchemyBackupRepository(session, EncryptionService())
+
+            assert await repo.delete(9999) is False
 
     async def test_it_rejects_a_tampered_backup_on_read(self, session_factory):
         from core.repositories.models import DeviceBackups

--- a/packages/core/tests/unit/repositories/test_sqlalchemy_backup_repository.py
+++ b/packages/core/tests/unit/repositories/test_sqlalchemy_backup_repository.py
@@ -21,7 +21,7 @@ async def session_factory():
     await engine.dispose()
 
 
-def _backup(mac="AABBCCDDEEFF", name="b1"):
+def _backup(mac="AABBCCDDEEFF", name="b1", source="manual"):
     return DeviceBackup(
         device_mac=mac,
         snapshot={"components": {"switch:0": {"type": "switch", "config": {"x": 1}}}},
@@ -29,6 +29,7 @@ def _backup(mac="AABBCCDDEEFF", name="b1"):
         device_name="Test",
         generation="gen2",
         name=name,
+        source=source,
     )
 
 
@@ -60,7 +61,7 @@ class TestSQLAlchemyBackupRepository:
             row = (await session.execute(select(DeviceBackups))).scalar_one()
             assert "switch:0" not in row.snapshot_ciphertext
 
-    async def test_list_summaries_omits_snapshot_and_filters_by_mac(
+    async def test_it_list_summaries_omits_snapshot_and_filters_by_mac(
         self, session_factory
     ):
         async with session_factory() as session:
@@ -104,3 +105,69 @@ class TestSQLAlchemyBackupRepository:
             await session.commit()
 
             assert await repo.get(created.id) is None
+
+
+class TestRetention:
+    async def test_it_count_for_device_scopes_to_scheduled_by_default(
+        self, session_factory
+    ):
+        async with session_factory() as session:
+            repo = SQLAlchemyBackupRepository(session, EncryptionService())
+            await repo.create(_backup(source="scheduled"))
+            await repo.create(_backup(source="scheduled"))
+            await repo.create(_backup(source="manual"))
+
+            assert await repo.count_for_device("AABBCCDDEEFF") == 2
+            assert await repo.count_for_device("AABBCCDDEEFF", source=None) == 3
+
+    async def test_it_keep_latest_n_never_touches_manual_backups(self, session_factory):
+        async with session_factory() as session:
+            repo = SQLAlchemyBackupRepository(session, EncryptionService())
+            for _ in range(4):
+                await repo.create(_backup(source="scheduled"))
+            manual = await repo.create(_backup(source="manual", name="milestone"))
+
+            deleted = await repo.delete_keeping_latest_n("AABBCCDDEEFF", 2)
+
+            assert deleted == 2
+            assert await repo.count_for_device("AABBCCDDEEFF") == 2
+            # the manually captured snapshot survives retention
+            assert await repo.get(manual.id) is not None
+
+    async def test_it_keep_latest_n_refuses_zero(self, session_factory):
+        async with session_factory() as session:
+            repo = SQLAlchemyBackupRepository(session, EncryptionService())
+            await repo.create(_backup(source="scheduled"))
+
+            deleted = await repo.delete_keeping_latest_n("AABBCCDDEEFF", 0)
+
+            assert deleted == 0
+            assert await repo.count_for_device("AABBCCDDEEFF") == 1
+
+    async def test_it_delete_older_than_uses_created_at_and_source(
+        self, session_factory
+    ):
+        from core.repositories.models import DeviceBackups
+        from sqlalchemy import select
+
+        async with session_factory() as session:
+            repo = SQLAlchemyBackupRepository(session, EncryptionService())
+            old = await repo.create(_backup(source="scheduled", name="old"))
+            await repo.create(_backup(source="scheduled", name="new"))
+            old_manual = await repo.create(_backup(source="manual", name="old-manual"))
+
+            # Backdate the "old" rows well before the cutoff.
+            for backup_id in (old.id, old_manual.id):
+                row = (
+                    await session.execute(
+                        select(DeviceBackups).where(DeviceBackups.id == backup_id)
+                    )
+                ).scalar_one()
+                row.created_at = 100
+                await session.commit()
+
+            deleted = await repo.delete_older_than("AABBCCDDEEFF", cutoff_ts=1000)
+
+            assert deleted == 1  # only the scheduled old one
+            assert await repo.get(old.id) is None
+            assert await repo.get(old_manual.id) is not None

--- a/packages/core/tests/unit/repositories/test_sqlalchemy_backup_repository.py
+++ b/packages/core/tests/unit/repositories/test_sqlalchemy_backup_repository.py
@@ -78,6 +78,30 @@ class TestSQLAlchemyBackupRepository:
             # summary type carries no snapshot attribute
             assert not hasattr(filtered[0], "snapshot")
 
+    async def test_it_paginates_summaries_newest_first(self, session_factory):
+        async with session_factory() as session:
+            repo = SQLAlchemyBackupRepository(session, EncryptionService())
+            created = [await repo.create(_backup(name=f"b{i}")) for i in range(5)]
+            newest_first = [c.id for c in reversed(created)]
+
+            page0 = await repo.list_summaries(limit=2, offset=0)
+            page1 = await repo.list_summaries(limit=2, offset=2)
+            page2 = await repo.list_summaries(limit=2, offset=4)
+
+            assert [s.id for s in page0] == newest_first[0:2]
+            assert [s.id for s in page1] == newest_first[2:4]
+            assert [s.id for s in page2] == newest_first[4:5]
+
+    async def test_it_counts_summaries_all_and_by_mac(self, session_factory):
+        async with session_factory() as session:
+            repo = SQLAlchemyBackupRepository(session, EncryptionService())
+            await repo.create(_backup(mac="AABBCCDDEEFF"))
+            await repo.create(_backup(mac="AABBCCDDEEFF"))
+            await repo.create(_backup(mac="112233445566"))
+
+            assert await repo.count_summaries() == 3
+            assert await repo.count_summaries("AA:BB:CC:DD:EE:FF") == 2
+
     async def test_it_deletes_a_backup(self, session_factory):
         async with session_factory() as session:
             repo = SQLAlchemyBackupRepository(session, EncryptionService())

--- a/packages/core/tests/unit/repositories/test_sqlalchemy_backup_schedule_repository.py
+++ b/packages/core/tests/unit/repositories/test_sqlalchemy_backup_schedule_repository.py
@@ -1,0 +1,101 @@
+"""Tests for the SQLAlchemy backup schedule repository."""
+
+import pytest
+from core.domain.entities.backup_schedule import BackupSchedule
+from core.repositories.models import Base
+from core.repositories.sqlalchemy_backup_schedule_repository import (
+    SQLAlchemyBackupScheduleRepository,
+)
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+from sqlalchemy.pool import StaticPool
+
+
+@pytest.fixture
+async def session_factory():
+    engine = create_async_engine(
+        "sqlite+aiosqlite://",
+        poolclass=StaticPool,
+        connect_args={"check_same_thread": False},
+    )
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    factory = async_sessionmaker(engine, expire_on_commit=False)
+    yield factory
+    await engine.dispose()
+
+
+def _schedule(name="nightly", **kwargs):
+    base = {
+        "name": name,
+        "interval_seconds": 3600,
+        "target_ips": ["192.168.1.10"],
+        "target_macs": ["AABBCCDDEEFF"],
+        "all_credentialed": False,
+        "next_run_at": 1000,
+    }
+    base.update(kwargs)
+    return BackupSchedule(**base)
+
+
+class TestScheduleRepository:
+    async def test_it_round_trips_json_targets(self, session_factory):
+        async with session_factory() as session:
+            repo = SQLAlchemyBackupScheduleRepository(session)
+            created = await repo.create(_schedule())
+
+            fetched = await repo.get(created.id)
+            assert fetched is not None
+            assert fetched.target_ips == ["192.168.1.10"]
+            assert fetched.target_macs == ["AABBCCDDEEFF"]
+            assert fetched.interval_seconds == 3600
+
+    async def test_it_get_by_name(self, session_factory):
+        async with session_factory() as session:
+            repo = SQLAlchemyBackupScheduleRepository(session)
+            await repo.create(_schedule(name="weekly"))
+
+            assert (await repo.get_by_name("weekly")) is not None
+            assert (await repo.get_by_name("missing")) is None
+
+    async def test_it_list_due_boundary_includes_equal_to_now(self, session_factory):
+        async with session_factory() as session:
+            repo = SQLAlchemyBackupScheduleRepository(session)
+            await repo.create(_schedule(name="due-equal", next_run_at=1000))
+            await repo.create(_schedule(name="due-past", next_run_at=500))
+            await repo.create(_schedule(name="not-due", next_run_at=2000))
+            await repo.create(
+                _schedule(name="disabled", next_run_at=100, enabled=False)
+            )
+
+            due = await repo.list_due(1000)
+
+            names = {s.name for s in due}
+            assert names == {"due-equal", "due-past"}
+
+    async def test_it_set_run_result_advances_row(self, session_factory):
+        async with session_factory() as session:
+            repo = SQLAlchemyBackupScheduleRepository(session)
+            created = await repo.create(_schedule(next_run_at=1000))
+
+            await repo.set_run_result(
+                created.id, last_run_at=1000, next_run_at=4600, last_status="ok: 1 ok"
+            )
+
+            fetched = await repo.get(created.id)
+            assert fetched.last_run_at == 1000
+            assert fetched.next_run_at == 4600
+            assert fetched.last_status == "ok: 1 ok"
+
+    async def test_it_update_and_delete(self, session_factory):
+        async with session_factory() as session:
+            repo = SQLAlchemyBackupScheduleRepository(session)
+            created = await repo.create(_schedule())
+
+            created.enabled = False
+            created.target_ips = ["10.0.0.1"]
+            updated = await repo.update(created)
+            assert updated.enabled is False
+            assert updated.target_ips == ["10.0.0.1"]
+
+            await repo.delete(created.id)
+            assert (await repo.get(created.id)) is None

--- a/packages/core/tests/unit/test_settings.py
+++ b/packages/core/tests/unit/test_settings.py
@@ -24,3 +24,22 @@ def test_it_loads_backup_settings_from_config_file(tmp_path, monkeypatch):
 
     assert settings.backup.scheduler_enabled is False
     assert settings.backup.poll_interval_seconds == 300
+
+
+def test_it_saves_backup_settings_to_config_file(tmp_path, monkeypatch):
+    config_path = tmp_path / "config.json"
+
+    monkeypatch.setenv(
+        "SHELLY_SECRET_KEY", "0N6fK7YkEmvA0I4d1sD4v15uvB94H4A1N1nMG8vLMOg="
+    )
+
+    settings = AppSettings(config_file=str(config_path))
+    settings.backup.scheduler_enabled = False
+    settings.backup.poll_interval_seconds = 300
+    settings.save_config()
+
+    saved = json.loads(config_path.read_text())
+    assert saved["backup"] == {
+        "scheduler_enabled": False,
+        "poll_interval_seconds": 300,
+    }

--- a/packages/core/tests/unit/test_settings.py
+++ b/packages/core/tests/unit/test_settings.py
@@ -1,0 +1,26 @@
+import json
+
+from core.settings import AppSettings
+
+
+def test_it_loads_backup_settings_from_config_file(tmp_path, monkeypatch):
+    config_path = tmp_path / "config.json"
+    config_path.write_text(
+        json.dumps(
+            {
+                "backup": {
+                    "scheduler_enabled": False,
+                    "poll_interval_seconds": 300,
+                }
+            }
+        )
+    )
+
+    monkeypatch.setenv(
+        "SHELLY_SECRET_KEY", "0N6fK7YkEmvA0I4d1sD4v15uvB94H4A1N1nMG8vLMOg="
+    )
+
+    settings = AppSettings(config_file=str(config_path))
+
+    assert settings.backup.scheduler_enabled is False
+    assert settings.backup.poll_interval_seconds == 300

--- a/packages/core/tests/unit/use_cases/test_backup_device_config.py
+++ b/packages/core/tests/unit/use_cases/test_backup_device_config.py
@@ -3,7 +3,7 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
 import pytest
-from core.domain.entities.device_backup import DeviceBackup, DeviceBackupSummary
+from core.domain.entities.device_backup import DeviceBackupSummary
 from core.domain.entities.exceptions import DeviceNotFoundError
 from core.use_cases.backup_device_config import (
     BackupDeviceConfig,
@@ -277,16 +277,13 @@ class TestBackupDeviceConfig:
     async def test_it_raises_when_deleting_missing_backup(
         self, use_case, mock_repository
     ):
-        mock_repository.list_summaries = AsyncMock(return_value=[])
+        mock_repository.delete = AsyncMock(return_value=False)
 
         with pytest.raises(BackupNotFoundError):
             await use_case.delete_backup(99)
 
     async def test_it_deletes_existing_backup(self, use_case, mock_repository):
-        mock_repository.list_summaries = AsyncMock(
-            return_value=[DeviceBackup(device_mac="AABBCCDDEEFF", id=5)]
-        )
-        mock_repository.delete = AsyncMock()
+        mock_repository.delete = AsyncMock(return_value=True)
 
         await use_case.delete_backup(5)
 

--- a/packages/core/tests/unit/use_cases/test_backup_device_config.py
+++ b/packages/core/tests/unit/use_cases/test_backup_device_config.py
@@ -249,6 +249,23 @@ class TestBackupDeviceConfig:
         assert len(result) == 1
         mock_repository.list_summaries.assert_awaited_once_with("AA:BB:CC:DD:EE:FF")
 
+    async def test_it_lists_a_page_with_total(self, use_case, mock_repository):
+        mock_repository.list_summaries = AsyncMock(
+            return_value=[DeviceBackupSummary(device_mac="AABBCCDDEEFF", id=3)]
+        )
+        mock_repository.count_summaries = AsyncMock(return_value=7)
+
+        page = await use_case.list_backups_page("AA:BB:CC:DD:EE:FF", limit=1, offset=2)
+
+        assert [s.id for s in page.items] == [3]
+        assert page.total == 7
+        assert page.limit == 1
+        assert page.offset == 2
+        mock_repository.list_summaries.assert_awaited_once_with(
+            "AA:BB:CC:DD:EE:FF", 1, 2
+        )
+        mock_repository.count_summaries.assert_awaited_once_with("AA:BB:CC:DD:EE:FF")
+
     async def test_it_raises_when_backup_missing_on_get(
         self, use_case, mock_repository
     ):

--- a/packages/core/tests/unit/use_cases/test_manage_backup_schedules.py
+++ b/packages/core/tests/unit/use_cases/test_manage_backup_schedules.py
@@ -1,0 +1,112 @@
+"""Tests for the backup-schedule management use case."""
+
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock
+
+import pytest
+from core.domain.entities.backup_schedule import BackupSchedule
+from core.use_cases.manage_backup_schedules import (
+    ManageBackupSchedulesUseCase,
+    ScheduleAlreadyExistsError,
+    ScheduleNotFoundError,
+)
+
+NOW = 500_000
+
+
+def _factory(repo):
+    @asynccontextmanager
+    async def factory():
+        yield repo
+
+    return factory
+
+
+def _use_case(repo, clock=NOW):
+    return ManageBackupSchedulesUseCase(
+        repository_factory=_factory(repo), clock=lambda: clock
+    )
+
+
+def _schedule(**kwargs):
+    base = {"name": "nightly", "interval_seconds": 3600, "target_ips": ["192.168.1.10"]}
+    base.update(kwargs)
+    return BackupSchedule(**base)
+
+
+class TestCreate:
+    async def test_it_sets_next_run_one_interval_out(self):
+        repo = AsyncMock(
+            get_by_name=AsyncMock(return_value=None),
+            create=AsyncMock(side_effect=lambda s: s),
+        )
+        use_case = _use_case(repo)
+
+        created = await use_case.create_schedule(_schedule(interval_seconds=3600))
+
+        assert created.next_run_at == NOW + 3600
+
+    async def test_it_rejects_duplicate_name(self):
+        repo = AsyncMock(get_by_name=AsyncMock(return_value=_schedule(id=1)))
+        use_case = _use_case(repo)
+
+        with pytest.raises(ScheduleAlreadyExistsError):
+            await use_case.create_schedule(_schedule())
+
+
+class TestUpdate:
+    async def test_it_recomputes_next_run_when_interval_changes(self):
+        existing = _schedule(id=1, interval_seconds=3600, next_run_at=NOW + 100)
+        repo = AsyncMock(
+            get=AsyncMock(return_value=existing),
+            get_by_name=AsyncMock(return_value=None),
+            update=AsyncMock(side_effect=lambda s: s),
+        )
+        use_case = _use_case(repo)
+
+        incoming = _schedule(id=1, interval_seconds=7200, next_run_at=NOW + 100)
+        updated = await use_case.update_schedule(incoming)
+
+        assert updated.next_run_at == NOW + 7200
+
+    async def test_it_keeps_next_run_when_interval_unchanged(self):
+        existing = _schedule(id=1, interval_seconds=3600, next_run_at=NOW + 100)
+        repo = AsyncMock(
+            get=AsyncMock(return_value=existing),
+            get_by_name=AsyncMock(return_value=None),
+            update=AsyncMock(side_effect=lambda s: s),
+        )
+        use_case = _use_case(repo)
+
+        incoming = _schedule(id=1, interval_seconds=3600, next_run_at=None)
+        updated = await use_case.update_schedule(incoming)
+
+        assert updated.next_run_at == NOW + 100
+
+    async def test_it_missing_raises(self):
+        repo = AsyncMock(get=AsyncMock(return_value=None))
+        use_case = _use_case(repo)
+
+        with pytest.raises(ScheduleNotFoundError):
+            await use_case.update_schedule(_schedule(id=99))
+
+
+class TestEnableDisableDelete:
+    async def test_it_set_enabled_toggles(self):
+        existing = _schedule(id=1, enabled=True)
+        repo = AsyncMock(
+            get=AsyncMock(return_value=existing),
+            update=AsyncMock(side_effect=lambda s: s),
+        )
+        use_case = _use_case(repo)
+
+        updated = await use_case.set_enabled(1, False)
+
+        assert updated.enabled is False
+
+    async def test_it_delete_missing_raises(self):
+        repo = AsyncMock(get=AsyncMock(return_value=None))
+        use_case = _use_case(repo)
+
+        with pytest.raises(ScheduleNotFoundError):
+            await use_case.delete_schedule(99)

--- a/packages/core/tests/unit/use_cases/test_run_due_backups.py
+++ b/packages/core/tests/unit/use_cases/test_run_due_backups.py
@@ -458,6 +458,36 @@ class TestRunSchedule:
         backup_device_config.create_backup.assert_awaited_once()
         assert result.ok == 1
 
+    async def test_it_advances_next_run_past_completion_time_for_long_run(self):
+        current = NOW
+        schedule = _schedule(interval_seconds=60, next_run_at=NOW)
+        schedule_repo = AsyncMock(
+            get=AsyncMock(return_value=schedule),
+            set_run_result=AsyncMock(),
+        )
+
+        async def create(ip, source="scheduled"):
+            nonlocal current
+            current = NOW + 5 * 60
+            return _backup_for(ip)
+
+        backup_device_config = AsyncMock(create_backup=AsyncMock(side_effect=create))
+        use_case = RunDueBackupsUseCase(
+            schedule_repository_factory=_factory(schedule_repo),
+            backup_repository_factory=_factory(AsyncMock()),
+            credentials_repository_factory=_factory(
+                AsyncMock(list_all=AsyncMock(return_value=[]))
+            ),
+            backup_device_config=backup_device_config,
+            clock=lambda: current,
+        )
+
+        await use_case.run_schedule(1)
+
+        kwargs = schedule_repo.set_run_result.call_args.kwargs
+        assert kwargs["last_run_at"] == NOW
+        assert kwargs["next_run_at"] > current
+
     async def test_it_run_schedule_missing_raises(self):
         schedule_repo = AsyncMock(get=AsyncMock(return_value=None))
         use_case = _make_use_case(schedule_repo=schedule_repo)

--- a/packages/core/tests/unit/use_cases/test_run_due_backups.py
+++ b/packages/core/tests/unit/use_cases/test_run_due_backups.py
@@ -1,5 +1,6 @@
 """Tests for the scheduled-backup runner."""
 
+import asyncio
 from contextlib import asynccontextmanager
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
@@ -149,6 +150,43 @@ class TestRunDue:
         assert results[0].ok == 1
         assert results[0].failed == 1
         assert results[0].status == "partial"
+
+    async def test_it_serializes_tick_and_manual_run_in_one_worker(self):
+        schedule = _schedule()
+        schedule_repo = AsyncMock(
+            list_due=AsyncMock(return_value=[schedule]),
+            get=AsyncMock(return_value=schedule),
+            set_run_result=AsyncMock(),
+        )
+        started = asyncio.Event()
+        release = asyncio.Event()
+        calls: list[str] = []
+
+        async def create(ip, source="scheduled"):
+            calls.append(ip)
+            started.set()
+            await release.wait()
+            return _backup_for(ip)
+
+        backup_device_config = AsyncMock(create_backup=AsyncMock(side_effect=create))
+        use_case = _make_use_case(
+            schedule_repo=schedule_repo, backup_device_config=backup_device_config
+        )
+
+        due_task = asyncio.create_task(use_case.run_due())
+        await started.wait()
+
+        manual_task = asyncio.create_task(use_case.run_schedule(1))
+        await asyncio.sleep(0)
+
+        schedule_repo.get.assert_not_awaited()
+
+        release.set()
+        await due_task
+        await manual_task
+
+        schedule_repo.get.assert_awaited_once_with(1)
+        assert calls == ["192.168.1.10", "192.168.1.10"]
 
 
 class TestTargetResolution:

--- a/packages/core/tests/unit/use_cases/test_run_due_backups.py
+++ b/packages/core/tests/unit/use_cases/test_run_due_backups.py
@@ -1,0 +1,428 @@
+"""Tests for the scheduled-backup runner."""
+
+from contextlib import asynccontextmanager
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+from core.domain.credentials import Credential
+from core.domain.entities.backup_schedule import BackupSchedule
+from core.domain.entities.exceptions import DeviceNotFoundError
+from core.use_cases.manage_backup_schedules import ScheduleNotFoundError
+from core.use_cases.run_due_backups import RunDueBackupsUseCase
+
+NOW = 1_000_000
+
+
+def _factory(obj):
+    @asynccontextmanager
+    async def factory():
+        yield obj
+
+    return factory
+
+
+def _backup_for(ip, mac="AABBCCDDEEFF"):
+    return SimpleNamespace(device_mac=mac)
+
+
+def _make_use_case(
+    *,
+    schedule_repo,
+    backup_repo=None,
+    credentials_repo=None,
+    backup_device_config=None,
+    scan_devices=None,
+    clock=NOW,
+):
+    backup_repo = backup_repo or AsyncMock()
+    credentials_repo = credentials_repo or AsyncMock(
+        list_all=AsyncMock(return_value=[])
+    )
+    backup_device_config = backup_device_config or AsyncMock(
+        create_backup=AsyncMock(
+            side_effect=lambda ip, source="scheduled": _backup_for(ip)
+        )
+    )
+    return RunDueBackupsUseCase(
+        schedule_repository_factory=_factory(schedule_repo),
+        backup_repository_factory=_factory(backup_repo),
+        credentials_repository_factory=_factory(credentials_repo),
+        backup_device_config=backup_device_config,
+        scan_devices=scan_devices,
+        clock=lambda: clock,
+    )
+
+
+def _schedule(**kwargs):
+    base = {
+        "id": 1,
+        "name": "nightly",
+        "interval_seconds": 3600,
+        "target_ips": ["192.168.1.10"],
+        "next_run_at": NOW - 10,
+    }
+    base.update(kwargs)
+    return BackupSchedule(**base)
+
+
+class TestRunDue:
+    async def test_it_runs_only_due_schedules(self):
+        schedule_repo = AsyncMock(
+            list_due=AsyncMock(return_value=[_schedule()]),
+            set_run_result=AsyncMock(),
+        )
+        backup_device_config = AsyncMock(
+            create_backup=AsyncMock(
+                side_effect=lambda ip, source="scheduled": _backup_for(ip)
+            )
+        )
+        use_case = _make_use_case(
+            schedule_repo=schedule_repo, backup_device_config=backup_device_config
+        )
+
+        results = await use_case.run_due()
+
+        schedule_repo.list_due.assert_awaited_once_with(NOW)
+        backup_device_config.create_backup.assert_awaited_once_with(
+            "192.168.1.10", source="scheduled"
+        )
+        assert results[0].status == "ok"
+        assert results[0].ok == 1
+
+    async def test_it_advances_next_run_strictly_into_future(self):
+        schedule_repo = AsyncMock(
+            list_due=AsyncMock(return_value=[_schedule(next_run_at=NOW - 5000)]),
+            set_run_result=AsyncMock(),
+        )
+        use_case = _make_use_case(schedule_repo=schedule_repo)
+
+        await use_case.run_due()
+
+        kwargs = schedule_repo.set_run_result.call_args.kwargs
+        assert kwargs["last_run_at"] == NOW
+        assert kwargs["next_run_at"] > NOW
+
+    async def test_it_unreachable_device_is_skipped_others_still_run(self):
+        def create(ip, source="scheduled"):
+            if ip == "192.168.1.10":
+                raise DeviceNotFoundError(ip)
+            return _backup_for(ip, mac="112233445566")
+
+        schedule_repo = AsyncMock(
+            list_due=AsyncMock(
+                return_value=[_schedule(target_ips=["192.168.1.10", "192.168.1.11"])]
+            ),
+            set_run_result=AsyncMock(),
+        )
+        backup_device_config = AsyncMock(create_backup=AsyncMock(side_effect=create))
+        use_case = _make_use_case(
+            schedule_repo=schedule_repo, backup_device_config=backup_device_config
+        )
+
+        results = await use_case.run_due()
+
+        assert results[0].ok == 1
+        assert results[0].skipped == 1
+        assert results[0].failed == 0
+        assert results[0].status == "ok"
+
+    async def test_it_generic_error_counts_as_failed_and_partial(self):
+        def create(ip, source="scheduled"):
+            if ip == "192.168.1.11":
+                raise RuntimeError("boom")
+            return _backup_for(ip)
+
+        schedule_repo = AsyncMock(
+            list_due=AsyncMock(
+                return_value=[_schedule(target_ips=["192.168.1.10", "192.168.1.11"])]
+            ),
+            set_run_result=AsyncMock(),
+        )
+        backup_device_config = AsyncMock(create_backup=AsyncMock(side_effect=create))
+        use_case = _make_use_case(
+            schedule_repo=schedule_repo, backup_device_config=backup_device_config
+        )
+
+        results = await use_case.run_due()
+
+        assert results[0].ok == 1
+        assert results[0].failed == 1
+        assert results[0].status == "partial"
+
+
+class TestTargetResolution:
+    async def test_it_resolves_mac_via_last_seen_ip(self):
+        schedule_repo = AsyncMock(
+            list_due=AsyncMock(
+                return_value=[
+                    _schedule(target_ips=[], target_macs=["AA:BB:CC:DD:EE:FF"])
+                ]
+            ),
+            set_run_result=AsyncMock(),
+        )
+        credentials_repo = AsyncMock(
+            list_all=AsyncMock(
+                return_value=[
+                    Credential(
+                        mac="AABBCCDDEEFF",
+                        username="admin",
+                        password="x",
+                        last_seen_ip="192.168.1.50",
+                    )
+                ]
+            )
+        )
+        backup_device_config = AsyncMock(
+            create_backup=AsyncMock(
+                side_effect=lambda ip, source="scheduled": _backup_for(ip)
+            )
+        )
+        use_case = _make_use_case(
+            schedule_repo=schedule_repo,
+            credentials_repo=credentials_repo,
+            backup_device_config=backup_device_config,
+        )
+
+        results = await use_case.run_due()
+
+        backup_device_config.create_backup.assert_awaited_once_with(
+            "192.168.1.50", source="scheduled"
+        )
+        assert results[0].ok == 1
+
+    async def test_it_mac_without_ip_is_skipped_not_failed(self):
+        schedule_repo = AsyncMock(
+            list_due=AsyncMock(
+                return_value=[_schedule(target_ips=[], target_macs=["AABBCCDDEEFF"])]
+            ),
+            set_run_result=AsyncMock(),
+        )
+        credentials_repo = AsyncMock(
+            list_all=AsyncMock(
+                return_value=[
+                    Credential(
+                        mac="AABBCCDDEEFF",
+                        username="admin",
+                        password="x",
+                        last_seen_ip=None,
+                    )
+                ]
+            )
+        )
+        backup_device_config = AsyncMock(create_backup=AsyncMock())
+        use_case = _make_use_case(
+            schedule_repo=schedule_repo,
+            credentials_repo=credentials_repo,
+            backup_device_config=backup_device_config,
+        )
+
+        results = await use_case.run_due()
+
+        backup_device_config.create_backup.assert_not_awaited()
+        assert results[0].skipped == 1
+        assert results[0].status == "skipped"
+
+    async def test_it_all_credentialed_unions_with_explicit_ips(self):
+        schedule_repo = AsyncMock(
+            list_due=AsyncMock(
+                return_value=[
+                    _schedule(
+                        target_ips=["192.168.1.10"],
+                        all_credentialed=True,
+                    )
+                ]
+            ),
+            set_run_result=AsyncMock(),
+        )
+        credentials_repo = AsyncMock(
+            list_all=AsyncMock(
+                return_value=[
+                    Credential(
+                        mac="AABBCCDDEEFF",
+                        username="admin",
+                        password="x",
+                        last_seen_ip="192.168.1.20",
+                    ),
+                    None,  # an undecryptable credential is ignored
+                ]
+            )
+        )
+        seen = []
+        backup_device_config = AsyncMock(
+            create_backup=AsyncMock(
+                side_effect=lambda ip, source="scheduled": seen.append(ip)
+                or _backup_for(ip)
+            )
+        )
+        use_case = _make_use_case(
+            schedule_repo=schedule_repo,
+            credentials_repo=credentials_repo,
+            backup_device_config=backup_device_config,
+        )
+
+        await use_case.run_due()
+
+        assert sorted(seen) == ["192.168.1.10", "192.168.1.20"]
+
+    async def test_it_all_credentialed_ignores_global_fallback_credential(self):
+        schedule_repo = AsyncMock(
+            list_due=AsyncMock(
+                return_value=[
+                    _schedule(
+                        target_ips=["192.168.1.10"],
+                        all_credentialed=True,
+                    )
+                ]
+            ),
+            set_run_result=AsyncMock(),
+        )
+        credentials_repo = AsyncMock(
+            list_all=AsyncMock(
+                return_value=[
+                    Credential(
+                        mac="*",
+                        username="admin",
+                        password="x",
+                    ),
+                    Credential(
+                        mac="AABBCCDDEEFF",
+                        username="admin",
+                        password="x",
+                        last_seen_ip="192.168.1.20",
+                    ),
+                ]
+            )
+        )
+        use_case = _make_use_case(
+            schedule_repo=schedule_repo,
+            credentials_repo=credentials_repo,
+        )
+
+        results = await use_case.run_due()
+
+        assert results[0].skipped == 0
+        assert results[0].ok == 2
+
+    async def test_it_discovers_devices_for_cidr_targets(self):
+        schedule_repo = AsyncMock(
+            list_due=AsyncMock(return_value=[_schedule(target_ips=["192.168.1.0/30"])]),
+            set_run_result=AsyncMock(),
+        )
+        scan_devices = AsyncMock(
+            execute=AsyncMock(
+                return_value=[
+                    SimpleNamespace(ip="192.168.1.1"),
+                    SimpleNamespace(ip="192.168.1.2"),
+                ]
+            )
+        )
+        seen = []
+        backup_device_config = AsyncMock(
+            create_backup=AsyncMock(
+                side_effect=lambda ip, source="scheduled": seen.append(ip)
+                or _backup_for(ip)
+            )
+        )
+        use_case = _make_use_case(
+            schedule_repo=schedule_repo,
+            backup_device_config=backup_device_config,
+            scan_devices=scan_devices,
+        )
+
+        results = await use_case.run_due()
+
+        scan_devices.execute.assert_awaited_once()
+        # Only discovered device IPs are backed up; the CIDR string itself is not.
+        assert sorted(seen) == ["192.168.1.1", "192.168.1.2"]
+        assert results[0].ok == 2
+
+    async def test_it_skips_cidr_targets_when_no_scanner_configured(self):
+        schedule_repo = AsyncMock(
+            list_due=AsyncMock(return_value=[_schedule(target_ips=["192.168.1.0/30"])]),
+            set_run_result=AsyncMock(),
+        )
+        backup_device_config = AsyncMock(create_backup=AsyncMock())
+        use_case = _make_use_case(
+            schedule_repo=schedule_repo,
+            backup_device_config=backup_device_config,
+            scan_devices=None,
+        )
+
+        results = await use_case.run_due()
+
+        backup_device_config.create_backup.assert_not_awaited()
+        assert results[0].status == "empty"
+
+
+class TestRetention:
+    async def test_it_retention_keep_last_and_max_age_called_with_correct_args(self):
+        schedule_repo = AsyncMock(
+            list_due=AsyncMock(
+                return_value=[
+                    _schedule(retention_keep_last=3, retention_max_age_days=7)
+                ]
+            ),
+            set_run_result=AsyncMock(),
+        )
+        backup_repo = AsyncMock(
+            delete_keeping_latest_n=AsyncMock(return_value=0),
+            delete_older_than=AsyncMock(return_value=0),
+        )
+        use_case = _make_use_case(schedule_repo=schedule_repo, backup_repo=backup_repo)
+
+        await use_case.run_due()
+
+        backup_repo.delete_keeping_latest_n.assert_awaited_once_with("AABBCCDDEEFF", 3)
+        backup_repo.delete_older_than.assert_awaited_once_with(
+            "AABBCCDDEEFF", NOW - 7 * 86400
+        )
+
+    async def test_it_no_retention_when_no_devices_touched(self):
+        schedule_repo = AsyncMock(
+            list_due=AsyncMock(return_value=[_schedule(retention_keep_last=3)]),
+            set_run_result=AsyncMock(),
+        )
+        backup_repo = AsyncMock(delete_keeping_latest_n=AsyncMock())
+        backup_device_config = AsyncMock(
+            create_backup=AsyncMock(side_effect=DeviceNotFoundError("192.168.1.10"))
+        )
+        use_case = _make_use_case(
+            schedule_repo=schedule_repo,
+            backup_repo=backup_repo,
+            backup_device_config=backup_device_config,
+        )
+
+        await use_case.run_due()
+
+        backup_repo.delete_keeping_latest_n.assert_not_awaited()
+
+
+class TestRunSchedule:
+    async def test_it_run_schedule_ignores_next_run_at(self):
+        # next_run_at far in the future, but run-now executes anyway.
+        schedule = _schedule(next_run_at=NOW + 999_999)
+        schedule_repo = AsyncMock(
+            get=AsyncMock(return_value=schedule),
+            set_run_result=AsyncMock(),
+        )
+        backup_device_config = AsyncMock(
+            create_backup=AsyncMock(
+                side_effect=lambda ip, source="scheduled": _backup_for(ip)
+            )
+        )
+        use_case = _make_use_case(
+            schedule_repo=schedule_repo, backup_device_config=backup_device_config
+        )
+
+        result = await use_case.run_schedule(1)
+
+        backup_device_config.create_backup.assert_awaited_once()
+        assert result.ok == 1
+
+    async def test_it_run_schedule_missing_raises(self):
+        schedule_repo = AsyncMock(get=AsyncMock(return_value=None))
+        use_case = _make_use_case(schedule_repo=schedule_repo)
+
+        with pytest.raises(ScheduleNotFoundError):
+            await use_case.run_schedule(999)

--- a/packages/web/README.md
+++ b/packages/web/README.md
@@ -9,6 +9,7 @@ A modern, responsive web interface for managing Shelly IoT devices built with Re
 - **📊 Bulk Operations**: Perform actions on multiple devices simultaneously
 - **🔧 Device Management**: Update firmware, reboot devices, and manage configurations
 - **💾 Backup & Restore**: Snapshot a device's configuration and restore selected components from the device page
+- **⏰ Scheduled Backups**: Manage automated backup schedules and retention from a dedicated Backups page
 
 ## 🛠️ Tech Stack
 

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -7,6 +7,7 @@ import { Layout } from "@/components/layout/layout";
 import { Dashboard } from "@/pages/dashboard";
 import { DeviceDetail } from "@/pages/device-detail";
 import { Provisioning } from "@/pages/provisioning";
+import { BackupSchedules } from "@/pages/backup-schedules";
 import { Settings } from "@/pages/settings";
 import { queryClient, persister } from "@/lib/query-client";
 
@@ -38,6 +39,7 @@ function App() {
               <Route index element={<Dashboard />} />
               <Route path="devices/:ip" element={<DeviceDetail />} />
               <Route path="provisioning" element={<Provisioning />} />
+              <Route path="backups" element={<BackupSchedules />} />
               <Route path="settings" element={<Settings />} />
             </Route>
           </Routes>

--- a/packages/web/src/components/backup-schedules/backups-table-section.tsx
+++ b/packages/web/src/components/backup-schedules/backups-table-section.tsx
@@ -41,6 +41,7 @@ export function BackupsTableSection() {
   } = useQuery({
     queryKey: ["backups", "all"],
     queryFn: () => backupApi.listBackups(),
+    enabled: true,
   });
 
   const deleteMutation = useMutation({

--- a/packages/web/src/components/backup-schedules/backups-table-section.tsx
+++ b/packages/web/src/components/backup-schedules/backups-table-section.tsx
@@ -1,0 +1,144 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { Trash2, Loader2, Save } from "lucide-react";
+import { toast } from "sonner";
+
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { backupApi, handleApiError } from "@/lib/api";
+
+function formatSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+function formatTimestamp(ts: number | null): string {
+  if (!ts) return "-";
+  return new Date(ts * 1000).toLocaleString();
+}
+
+export function BackupsTableSection() {
+  const queryClient = useQueryClient();
+  const {
+    data: backups,
+    isLoading,
+    error,
+  } = useQuery({
+    queryKey: ["backups", "all"],
+    queryFn: () => backupApi.listBackups(),
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: (id: number) => backupApi.deleteBackup(id),
+    onSuccess: () => {
+      toast.success("Backup deleted");
+      queryClient.invalidateQueries({ queryKey: ["backups"] });
+    },
+    onError: (err) => toast.error(handleApiError(err)),
+  });
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center space-x-2">
+          <Save className="h-5 w-5" />
+          <span>Stored Backups</span>
+        </CardTitle>
+        <CardDescription>
+          Every captured snapshot across all devices, newest first.
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        {isLoading && (
+          <div className="flex justify-center py-8">
+            <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+          </div>
+        )}
+        {error && (
+          <p className="text-sm text-destructive">
+            Failed to load backups: {handleApiError(error)}
+          </p>
+        )}
+        {backups && backups.length === 0 && (
+          <p className="text-sm text-muted-foreground text-center py-8">
+            No backups stored yet.
+          </p>
+        )}
+        {backups && backups.length > 0 && (
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>ID</TableHead>
+                <TableHead>Device</TableHead>
+                <TableHead>MAC</TableHead>
+                <TableHead>Source</TableHead>
+                <TableHead>Size</TableHead>
+                <TableHead>Created</TableHead>
+                <TableHead className="text-right">Actions</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {backups.map((backup) => (
+                <TableRow key={backup.id}>
+                  <TableCell className="font-mono text-xs">
+                    {backup.id}
+                  </TableCell>
+                  <TableCell className="font-medium">
+                    {backup.name ||
+                      backup.device_name ||
+                      backup.device_ip ||
+                      "-"}
+                  </TableCell>
+                  <TableCell className="font-mono text-xs">
+                    {backup.device_mac}
+                  </TableCell>
+                  <TableCell>
+                    <Badge
+                      variant={
+                        backup.source === "scheduled" ? "secondary" : "outline"
+                      }
+                    >
+                      {backup.source}
+                    </Badge>
+                  </TableCell>
+                  <TableCell className="text-muted-foreground">
+                    {formatSize(backup.size_bytes)}
+                  </TableCell>
+                  <TableCell className="text-muted-foreground">
+                    {formatTimestamp(backup.created_at)}
+                  </TableCell>
+                  <TableCell className="text-right">
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      title="Delete"
+                      disabled={deleteMutation.isPending}
+                      onClick={() => deleteMutation.mutate(backup.id)}
+                    >
+                      <Trash2 className="h-4 w-4 text-destructive" />
+                    </Button>
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/packages/web/src/components/backup-schedules/backups-table-section.tsx
+++ b/packages/web/src/components/backup-schedules/backups-table-section.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Trash2, Loader2, Save } from "lucide-react";
 import { toast } from "sonner";
@@ -21,6 +22,8 @@ import {
 } from "@/components/ui/table";
 import { backupApi, handleApiError } from "@/lib/api";
 
+const PAGE_SIZE = 50;
+
 function formatSize(bytes: number): string {
   if (bytes < 1024) return `${bytes} B`;
   if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
@@ -34,15 +37,24 @@ function formatTimestamp(ts: number | null): string {
 
 export function BackupsTableSection() {
   const queryClient = useQueryClient();
-  const {
-    data: backups,
-    isLoading,
-    error,
-  } = useQuery({
-    queryKey: ["backups", "all"],
-    queryFn: () => backupApi.listBackups(),
+  const [offset, setOffset] = useState(0);
+
+  const { data, isLoading, isSuccess, error } = useQuery({
+    queryKey: ["backups", "all", offset],
+    queryFn: () => backupApi.listBackups({ limit: PAGE_SIZE, offset }),
     enabled: true,
   });
+
+  const items = data?.items ?? [];
+  const total = data?.total ?? 0;
+
+  // Step back only on a *successful* empty page — not on a transient error,
+  // which also yields items=[] and would otherwise rewind pagination state.
+  useEffect(() => {
+    if (isSuccess && items.length === 0 && offset >= PAGE_SIZE) {
+      setOffset((current) => Math.max(0, current - PAGE_SIZE));
+    }
+  }, [isSuccess, items.length, offset]);
 
   const deleteMutation = useMutation({
     mutationFn: (id: number) => backupApi.deleteBackup(id),
@@ -52,6 +64,11 @@ export function BackupsTableSection() {
     },
     onError: (err) => toast.error(handleApiError(err)),
   });
+
+  const rangeStart = total === 0 ? 0 : offset + 1;
+  const rangeEnd = offset + items.length;
+  const canPrev = offset > 0;
+  const canNext = offset + PAGE_SIZE < total;
 
   return (
     <Card>
@@ -75,69 +92,98 @@ export function BackupsTableSection() {
             Failed to load backups: {handleApiError(error)}
           </p>
         )}
-        {backups && backups.length === 0 && (
+        {!isLoading && !error && total === 0 && (
           <p className="text-sm text-muted-foreground text-center py-8">
             No backups stored yet.
           </p>
         )}
-        {backups && backups.length > 0 && (
-          <Table>
-            <TableHeader>
-              <TableRow>
-                <TableHead>ID</TableHead>
-                <TableHead>Device</TableHead>
-                <TableHead>MAC</TableHead>
-                <TableHead>Source</TableHead>
-                <TableHead>Size</TableHead>
-                <TableHead>Created</TableHead>
-                <TableHead className="text-right">Actions</TableHead>
-              </TableRow>
-            </TableHeader>
-            <TableBody>
-              {backups.map((backup) => (
-                <TableRow key={backup.id}>
-                  <TableCell className="font-mono text-xs">
-                    {backup.id}
-                  </TableCell>
-                  <TableCell className="font-medium">
-                    {backup.name ||
-                      backup.device_name ||
-                      backup.device_ip ||
-                      "-"}
-                  </TableCell>
-                  <TableCell className="font-mono text-xs">
-                    {backup.device_mac}
-                  </TableCell>
-                  <TableCell>
-                    <Badge
-                      variant={
-                        backup.source === "scheduled" ? "secondary" : "outline"
-                      }
-                    >
-                      {backup.source}
-                    </Badge>
-                  </TableCell>
-                  <TableCell className="text-muted-foreground">
-                    {formatSize(backup.size_bytes)}
-                  </TableCell>
-                  <TableCell className="text-muted-foreground">
-                    {formatTimestamp(backup.created_at)}
-                  </TableCell>
-                  <TableCell className="text-right">
-                    <Button
-                      variant="ghost"
-                      size="sm"
-                      title="Delete"
-                      disabled={deleteMutation.isPending}
-                      onClick={() => deleteMutation.mutate(backup.id)}
-                    >
-                      <Trash2 className="h-4 w-4 text-destructive" />
-                    </Button>
-                  </TableCell>
+        {items.length > 0 && (
+          <>
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>ID</TableHead>
+                  <TableHead>Device</TableHead>
+                  <TableHead>MAC</TableHead>
+                  <TableHead>Source</TableHead>
+                  <TableHead>Size</TableHead>
+                  <TableHead>Created</TableHead>
+                  <TableHead className="text-right">Actions</TableHead>
                 </TableRow>
-              ))}
-            </TableBody>
-          </Table>
+              </TableHeader>
+              <TableBody>
+                {items.map((backup) => (
+                  <TableRow key={backup.id}>
+                    <TableCell className="font-mono text-xs">
+                      {backup.id}
+                    </TableCell>
+                    <TableCell className="font-medium">
+                      {backup.name ||
+                        backup.device_name ||
+                        backup.device_ip ||
+                        "-"}
+                    </TableCell>
+                    <TableCell className="font-mono text-xs">
+                      {backup.device_mac}
+                    </TableCell>
+                    <TableCell>
+                      <Badge
+                        variant={
+                          backup.source === "scheduled"
+                            ? "secondary"
+                            : "outline"
+                        }
+                      >
+                        {backup.source}
+                      </Badge>
+                    </TableCell>
+                    <TableCell className="text-muted-foreground">
+                      {formatSize(backup.size_bytes)}
+                    </TableCell>
+                    <TableCell className="text-muted-foreground">
+                      {formatTimestamp(backup.created_at)}
+                    </TableCell>
+                    <TableCell className="text-right">
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        title="Delete"
+                        disabled={deleteMutation.isPending}
+                        onClick={() => deleteMutation.mutate(backup.id)}
+                      >
+                        <Trash2 className="h-4 w-4 text-destructive" />
+                      </Button>
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+            <div className="flex items-center justify-between pt-4">
+              <p className="text-sm text-muted-foreground">
+                Showing {rangeStart}–{rangeEnd} of {total}
+              </p>
+              <div className="space-x-2">
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() =>
+                    setOffset((current) => Math.max(0, current - PAGE_SIZE))
+                  }
+                  disabled={!canPrev}
+                >
+                  Previous
+                </Button>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => setOffset((current) => current + PAGE_SIZE)}
+                  disabled={!canNext}
+                >
+                  Next
+                </Button>
+              </div>
+            </div>
+          </>
         )}
       </CardContent>
     </Card>

--- a/packages/web/src/components/backup-schedules/schedule-form-utils.ts
+++ b/packages/web/src/components/backup-schedules/schedule-form-utils.ts
@@ -1,0 +1,106 @@
+import type {
+  CreateBackupScheduleRequest,
+  BackupSchedule,
+} from "@/types/api";
+
+export type Cadence = "hourly" | "daily" | "weekly" | "custom";
+
+export interface ScheduleFormState {
+  name: string;
+  cadence: Cadence;
+  intervalSeconds: string;
+  targetIps: string;
+  targetMacs: string;
+  allCredentialed: boolean;
+  enabled: boolean;
+  keepLast: string;
+  maxAgeDays: string;
+}
+
+export const EMPTY_FORM: ScheduleFormState = {
+  name: "",
+  cadence: "daily",
+  intervalSeconds: "3600",
+  targetIps: "",
+  targetMacs: "",
+  allCredentialed: false,
+  enabled: true,
+  keepLast: "",
+  maxAgeDays: "",
+};
+
+const CADENCE_SECONDS: Record<Exclude<Cadence, "custom">, number> = {
+  hourly: 3600,
+  daily: 86400,
+  weekly: 604800,
+};
+
+export function scheduleToForm(schedule: BackupSchedule): ScheduleFormState {
+  const preset = (Object.entries(CADENCE_SECONDS).find(
+    ([, seconds]) => seconds === schedule.interval_seconds,
+  )?.[0] ?? "custom") as Cadence;
+  return {
+    name: schedule.name,
+    cadence: preset,
+    intervalSeconds: String(schedule.interval_seconds),
+    targetIps: schedule.target_ips.join(", "),
+    targetMacs: schedule.target_macs.join(", "),
+    allCredentialed: schedule.all_credentialed,
+    enabled: schedule.enabled,
+    keepLast:
+      schedule.retention_keep_last != null
+        ? String(schedule.retention_keep_last)
+        : "",
+    maxAgeDays:
+      schedule.retention_max_age_days != null
+        ? String(schedule.retention_max_age_days)
+        : "",
+  };
+}
+
+function splitList(raw: string): string[] {
+  return raw
+    .split(/[\s,]+/)
+    .map((item) => item.trim())
+    .filter(Boolean);
+}
+
+/** Build a request payload, or return an error string if the form is invalid. */
+export function formToRequest(
+  form: ScheduleFormState,
+): { request: CreateBackupScheduleRequest } | { error: string } {
+  const name = form.name.trim();
+  if (!name) {
+    return { error: "Name is required" };
+  }
+
+  const targetIps = splitList(form.targetIps);
+  const targetMacs = splitList(form.targetMacs);
+  if (!targetIps.length && !targetMacs.length && !form.allCredentialed) {
+    return {
+      error: "Add at least one target IP, MAC, or enable all-credentialed",
+    };
+  }
+
+  const request: CreateBackupScheduleRequest = {
+    name,
+    target_ips: targetIps,
+    target_macs: targetMacs,
+    all_credentialed: form.allCredentialed,
+    enabled: form.enabled,
+    retention_keep_last: form.keepLast ? Number(form.keepLast) : null,
+    retention_max_age_days: form.maxAgeDays ? Number(form.maxAgeDays) : null,
+  };
+
+  if (form.cadence === "custom") {
+    const interval = Number(form.intervalSeconds);
+    if (!Number.isFinite(interval) || interval < 60) {
+      return { error: "Custom interval must be at least 60 seconds" };
+    }
+    request.interval_seconds = interval;
+  } else {
+    request.every = form.cadence;
+  }
+
+  return { request };
+}

--- a/packages/web/src/components/backup-schedules/schedule-form-utils.ts
+++ b/packages/web/src/components/backup-schedules/schedule-form-utils.ts
@@ -1,7 +1,4 @@
-import type {
-  CreateBackupScheduleRequest,
-  BackupSchedule,
-} from "@/types/api";
+import type { CreateBackupScheduleRequest, BackupSchedule } from "@/types/api";
 
 export type Cadence = "hourly" | "daily" | "weekly" | "custom";
 

--- a/packages/web/src/components/backup-schedules/schedule-form.tsx
+++ b/packages/web/src/components/backup-schedules/schedule-form.tsx
@@ -103,7 +103,12 @@ export function ScheduleForm({ value, onChange }: ScheduleFormProps) {
           {pickable.length > 0 && (
             <DropdownMenu>
               <DropdownMenuTrigger asChild>
-                <Button type="button" variant="outline" size="sm" className="h-7">
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  className="h-7"
+                >
                   <Plus className="h-3.5 w-3.5 mr-1" />
                   Scanned devices
                   <ChevronDown className="h-3.5 w-3.5 ml-1" />

--- a/packages/web/src/components/backup-schedules/schedule-form.tsx
+++ b/packages/web/src/components/backup-schedules/schedule-form.tsx
@@ -104,7 +104,7 @@ export function ScheduleForm({ value, onChange }: ScheduleFormProps) {
               <DropdownMenuTrigger asChild>
                 <Button type="button" variant="outline" size="sm" className="h-7">
                   <Plus className="h-3.5 w-3.5 mr-1" />
-                  Scanned device
+                  Scanned devices
                   <ChevronDown className="h-3.5 w-3.5 ml-1" />
                 </Button>
               </DropdownMenuTrigger>
@@ -112,15 +112,17 @@ export function ScheduleForm({ value, onChange }: ScheduleFormProps) {
                 align="end"
                 className="max-h-64 overflow-y-auto"
               >
-                <DropdownMenuLabel>Add a scanned device</DropdownMenuLabel>
+                <DropdownMenuLabel>Add scanned devices</DropdownMenuLabel>
                 <DropdownMenuSeparator />
                 {pickable.map((device) => (
                   <DropdownMenuItem
                     key={device.ip}
                     disabled={selected.has(device.ip)}
-                    onSelect={() =>
-                      set("targetIps", addTargetIp(value.targetIps, device.ip))
-                    }
+                    onSelect={(event) => {
+                      // Keep the menu open so several devices can be added at once.
+                      event.preventDefault();
+                      set("targetIps", addTargetIp(value.targetIps, device.ip));
+                    }}
                   >
                     <span className="font-medium">
                       {device.device_name || device.ip}

--- a/packages/web/src/components/backup-schedules/schedule-form.tsx
+++ b/packages/web/src/components/backup-schedules/schedule-form.tsx
@@ -1,0 +1,145 @@
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Checkbox } from "@/components/ui/checkbox";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import type { Cadence, ScheduleFormState } from "./schedule-form-utils";
+
+interface ScheduleFormProps {
+  value: ScheduleFormState;
+  onChange: (next: ScheduleFormState) => void;
+}
+
+export function ScheduleForm({ value, onChange }: ScheduleFormProps) {
+  const set = <K extends keyof ScheduleFormState>(
+    key: K,
+    fieldValue: ScheduleFormState[K],
+  ) => onChange({ ...value, [key]: fieldValue });
+
+  return (
+    <div className="space-y-4 py-2">
+      <div className="space-y-1.5">
+        <Label htmlFor="schedule-name">Name</Label>
+        <Input
+          id="schedule-name"
+          value={value.name}
+          onChange={(e) => set("name", e.target.value)}
+          placeholder="nightly-backup"
+        />
+      </div>
+
+      <div className="grid grid-cols-2 gap-3">
+        <div className="space-y-1.5">
+          <Label>Cadence</Label>
+          <Select
+            value={value.cadence}
+            onValueChange={(v) => set("cadence", v as Cadence)}
+          >
+            <SelectTrigger>
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="hourly">Hourly</SelectItem>
+              <SelectItem value="daily">Daily</SelectItem>
+              <SelectItem value="weekly">Weekly</SelectItem>
+              <SelectItem value="custom">Custom</SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+        {value.cadence === "custom" && (
+          <div className="space-y-1.5">
+            <Label htmlFor="schedule-interval">Interval (seconds)</Label>
+            <Input
+              id="schedule-interval"
+              type="number"
+              min={60}
+              value={value.intervalSeconds}
+              onChange={(e) => set("intervalSeconds", e.target.value)}
+            />
+          </div>
+        )}
+      </div>
+
+      <div className="space-y-1.5">
+        <Label htmlFor="schedule-ips">Target IPs</Label>
+        <Input
+          id="schedule-ips"
+          value={value.targetIps}
+          onChange={(e) => set("targetIps", e.target.value)}
+          placeholder="192.168.1.10, 192.168.1.0/24"
+        />
+        <p className="text-xs text-muted-foreground">
+          Comma or space separated. IPs, ranges, or CIDR. Ranges and CIDR are
+          scanned for live devices at run time.
+        </p>
+      </div>
+
+      <div className="space-y-1.5">
+        <Label htmlFor="schedule-macs">Target MACs</Label>
+        <Input
+          id="schedule-macs"
+          value={value.targetMacs}
+          onChange={(e) => set("targetMacs", e.target.value)}
+          placeholder="AABBCCDDEEFF"
+        />
+        <p className="text-xs text-muted-foreground">
+          Resolved to an IP via the device's last-seen address.
+        </p>
+      </div>
+
+      <div className="flex items-center space-x-2">
+        <Checkbox
+          id="schedule-all"
+          checked={value.allCredentialed}
+          onCheckedChange={(checked) =>
+            set("allCredentialed", checked === true)
+          }
+        />
+        <Label htmlFor="schedule-all" className="font-normal">
+          Back up every device with stored credentials
+        </Label>
+      </div>
+
+      <div className="grid grid-cols-2 gap-3">
+        <div className="space-y-1.5">
+          <Label htmlFor="schedule-keep">Keep last N</Label>
+          <Input
+            id="schedule-keep"
+            type="number"
+            min={1}
+            value={value.keepLast}
+            onChange={(e) => set("keepLast", e.target.value)}
+            placeholder="optional"
+          />
+        </div>
+        <div className="space-y-1.5">
+          <Label htmlFor="schedule-age">Max age (days)</Label>
+          <Input
+            id="schedule-age"
+            type="number"
+            min={1}
+            value={value.maxAgeDays}
+            onChange={(e) => set("maxAgeDays", e.target.value)}
+            placeholder="optional"
+          />
+        </div>
+      </div>
+
+      <div className="flex items-center space-x-2">
+        <Checkbox
+          id="schedule-enabled"
+          checked={value.enabled}
+          onCheckedChange={(checked) => set("enabled", checked === true)}
+        />
+        <Label htmlFor="schedule-enabled" className="font-normal">
+          Enabled
+        </Label>
+      </div>
+    </div>
+  );
+}

--- a/packages/web/src/components/backup-schedules/schedule-form.tsx
+++ b/packages/web/src/components/backup-schedules/schedule-form.tsx
@@ -1,3 +1,4 @@
+import type { Dispatch, SetStateAction } from "react";
 import { ChevronDown, Plus } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
@@ -24,7 +25,7 @@ import type { Cadence, ScheduleFormState } from "./schedule-form-utils";
 
 interface ScheduleFormProps {
   value: ScheduleFormState;
-  onChange: (next: ScheduleFormState) => void;
+  onChange: Dispatch<SetStateAction<ScheduleFormState>>;
 }
 
 function addTargetIp(current: string, ip: string): string {
@@ -41,7 +42,7 @@ export function ScheduleForm({ value, onChange }: ScheduleFormProps) {
   const set = <K extends keyof ScheduleFormState>(
     key: K,
     fieldValue: ScheduleFormState[K],
-  ) => onChange({ ...value, [key]: fieldValue });
+  ) => onChange((current) => ({ ...current, [key]: fieldValue }));
 
   const { data: scannedDevices = [] } = useScannedDevices();
   const pickable = scannedDevices.filter((device) => device.ip);
@@ -121,7 +122,10 @@ export function ScheduleForm({ value, onChange }: ScheduleFormProps) {
                     onSelect={(event) => {
                       // Keep the menu open so several devices can be added at once.
                       event.preventDefault();
-                      set("targetIps", addTargetIp(value.targetIps, device.ip));
+                      onChange((current) => ({
+                        ...current,
+                        targetIps: addTargetIp(current.targetIps, device.ip),
+                      }));
                     }}
                   >
                     <span className="font-medium">

--- a/packages/web/src/components/backup-schedules/schedule-form.tsx
+++ b/packages/web/src/components/backup-schedules/schedule-form.tsx
@@ -1,6 +1,17 @@
+import { ChevronDown, Plus } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Checkbox } from "@/components/ui/checkbox";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 import {
   Select,
   SelectContent,
@@ -8,6 +19,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import { useScannedDevices } from "@/hooks/useScannedDevices";
 import type { Cadence, ScheduleFormState } from "./schedule-form-utils";
 
 interface ScheduleFormProps {
@@ -15,11 +27,30 @@ interface ScheduleFormProps {
   onChange: (next: ScheduleFormState) => void;
 }
 
+function addTargetIp(current: string, ip: string): string {
+  const parts = current
+    .split(/[\s,]+/)
+    .map((part) => part.trim())
+    .filter(Boolean);
+  if (parts.includes(ip)) return current;
+  parts.push(ip);
+  return parts.join(", ");
+}
+
 export function ScheduleForm({ value, onChange }: ScheduleFormProps) {
   const set = <K extends keyof ScheduleFormState>(
     key: K,
     fieldValue: ScheduleFormState[K],
   ) => onChange({ ...value, [key]: fieldValue });
+
+  const { data: scannedDevices = [] } = useScannedDevices();
+  const pickable = scannedDevices.filter((device) => device.ip);
+  const selected = new Set(
+    value.targetIps
+      .split(/[\s,]+/)
+      .map((part) => part.trim())
+      .filter(Boolean),
+  );
 
   return (
     <div className="space-y-4 py-2">
@@ -66,7 +97,43 @@ export function ScheduleForm({ value, onChange }: ScheduleFormProps) {
       </div>
 
       <div className="space-y-1.5">
-        <Label htmlFor="schedule-ips">Target IPs</Label>
+        <div className="flex items-center justify-between">
+          <Label htmlFor="schedule-ips">Target IPs</Label>
+          {pickable.length > 0 && (
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button type="button" variant="outline" size="sm" className="h-7">
+                  <Plus className="h-3.5 w-3.5 mr-1" />
+                  Scanned device
+                  <ChevronDown className="h-3.5 w-3.5 ml-1" />
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent
+                align="end"
+                className="max-h-64 overflow-y-auto"
+              >
+                <DropdownMenuLabel>Add a scanned device</DropdownMenuLabel>
+                <DropdownMenuSeparator />
+                {pickable.map((device) => (
+                  <DropdownMenuItem
+                    key={device.ip}
+                    disabled={selected.has(device.ip)}
+                    onSelect={() =>
+                      set("targetIps", addTargetIp(value.targetIps, device.ip))
+                    }
+                  >
+                    <span className="font-medium">
+                      {device.device_name || device.ip}
+                    </span>
+                    <span className="ml-2 text-muted-foreground">
+                      {device.ip}
+                    </span>
+                  </DropdownMenuItem>
+                ))}
+              </DropdownMenuContent>
+            </DropdownMenu>
+          )}
+        </div>
         <Input
           id="schedule-ips"
           value={value.targetIps}
@@ -76,6 +143,8 @@ export function ScheduleForm({ value, onChange }: ScheduleFormProps) {
         <p className="text-xs text-muted-foreground">
           Comma or space separated. IPs, ranges, or CIDR. Ranges and CIDR are
           scanned for live devices at run time.
+          {pickable.length === 0 &&
+            " Scan devices on the dashboard to pick them from a list here."}
         </p>
       </div>
 

--- a/packages/web/src/components/backup-schedules/schedules-section.tsx
+++ b/packages/web/src/components/backup-schedules/schedules-section.tsx
@@ -191,7 +191,9 @@ export function BackupSchedulesSection() {
                       </Badge>
                     )}
                   </TableCell>
-                  <TableCell>{formatInterval(schedule.interval_seconds)}</TableCell>
+                  <TableCell>
+                    {formatInterval(schedule.interval_seconds)}
+                  </TableCell>
                   <TableCell>{formatTargets(schedule)}</TableCell>
                   <TableCell>
                     {schedule.last_status ? (

--- a/packages/web/src/components/backup-schedules/schedules-section.tsx
+++ b/packages/web/src/components/backup-schedules/schedules-section.tsx
@@ -1,0 +1,313 @@
+import { useState } from "react";
+import {
+  CalendarClock,
+  Plus,
+  Play,
+  Pencil,
+  Trash2,
+  Power,
+  Loader2,
+} from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { toast } from "sonner";
+import { handleApiError } from "@/lib/api";
+import {
+  useBackupSchedules,
+  useCreateBackupSchedule,
+  useDeleteBackupSchedule,
+  useRunBackupSchedule,
+  useSetScheduleEnabled,
+  useUpdateBackupSchedule,
+} from "@/hooks/useBackupSchedules";
+import type { BackupSchedule } from "@/types/api";
+import { ScheduleForm } from "./schedule-form";
+import {
+  EMPTY_FORM,
+  type ScheduleFormState,
+  formToRequest,
+  scheduleToForm,
+} from "./schedule-form-utils";
+
+function formatInterval(seconds: number): string {
+  if (seconds === 3600) return "hourly";
+  if (seconds === 86400) return "daily";
+  if (seconds === 604800) return "weekly";
+  if (seconds % 86400 === 0) return `every ${seconds / 86400}d`;
+  if (seconds % 3600 === 0) return `every ${seconds / 3600}h`;
+  return `every ${seconds}s`;
+}
+
+function formatTargets(schedule: BackupSchedule): string {
+  const parts: string[] = [];
+  if (schedule.all_credentialed) parts.push("all credentialed");
+  if (schedule.target_ips.length)
+    parts.push(`${schedule.target_ips.length} IP`);
+  if (schedule.target_macs.length)
+    parts.push(`${schedule.target_macs.length} MAC`);
+  return parts.join(", ") || "-";
+}
+
+function formatTimestamp(ts: number | null): string {
+  if (!ts) return "-";
+  return new Date(ts * 1000).toLocaleString();
+}
+
+function statusVariant(
+  status: string | null,
+): "default" | "secondary" | "destructive" | "outline" {
+  if (!status) return "outline";
+  if (status.startsWith("ok")) return "default";
+  if (status.startsWith("partial")) return "secondary";
+  if (status.startsWith("failed")) return "destructive";
+  return "outline";
+}
+
+export function BackupSchedulesSection() {
+  const { data: schedules, isLoading, error } = useBackupSchedules();
+  const createMutation = useCreateBackupSchedule();
+  const updateMutation = useUpdateBackupSchedule();
+  const deleteMutation = useDeleteBackupSchedule();
+  const runMutation = useRunBackupSchedule();
+  const enabledMutation = useSetScheduleEnabled();
+
+  const [createOpen, setCreateOpen] = useState(false);
+  const [editing, setEditing] = useState<BackupSchedule | null>(null);
+  const [form, setForm] = useState<ScheduleFormState>(EMPTY_FORM);
+
+  const openCreate = () => {
+    setForm(EMPTY_FORM);
+    setCreateOpen(true);
+  };
+
+  const openEdit = (schedule: BackupSchedule) => {
+    setForm(scheduleToForm(schedule));
+    setEditing(schedule);
+  };
+
+  const submitCreate = () => {
+    const result = formToRequest(form);
+    if ("error" in result) {
+      toast.error(result.error);
+      return;
+    }
+    createMutation.mutate(result.request, {
+      onSuccess: () => setCreateOpen(false),
+    });
+  };
+
+  const submitEdit = () => {
+    if (!editing) return;
+    const result = formToRequest(form);
+    if ("error" in result) {
+      toast.error(result.error);
+      return;
+    }
+    updateMutation.mutate(
+      { id: editing.id, data: result.request },
+      { onSuccess: () => setEditing(null) },
+    );
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <div className="flex items-center justify-between">
+          <div>
+            <CardTitle className="flex items-center space-x-2">
+              <CalendarClock className="h-5 w-5" />
+              <span>Backup Schedules</span>
+            </CardTitle>
+            <CardDescription>
+              Automatically back up device configurations on a schedule, with
+              optional retention.
+            </CardDescription>
+          </div>
+          <Button size="sm" onClick={openCreate}>
+            <Plus className="h-4 w-4 mr-1" /> New Schedule
+          </Button>
+        </div>
+      </CardHeader>
+      <CardContent>
+        {isLoading && (
+          <div className="flex justify-center py-8">
+            <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+          </div>
+        )}
+        {error && (
+          <p className="text-sm text-destructive">
+            Failed to load schedules: {handleApiError(error)}
+          </p>
+        )}
+        {schedules && schedules.length === 0 && (
+          <p className="text-sm text-muted-foreground text-center py-8">
+            No backup schedules yet.
+          </p>
+        )}
+        {schedules && schedules.length > 0 && (
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Name</TableHead>
+                <TableHead>Cadence</TableHead>
+                <TableHead>Targets</TableHead>
+                <TableHead>Status</TableHead>
+                <TableHead>Next run</TableHead>
+                <TableHead className="text-right">Actions</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {schedules.map((schedule) => (
+                <TableRow key={schedule.id}>
+                  <TableCell className="font-medium">
+                    {schedule.name}
+                    {!schedule.enabled && (
+                      <Badge variant="outline" className="ml-2">
+                        disabled
+                      </Badge>
+                    )}
+                  </TableCell>
+                  <TableCell>{formatInterval(schedule.interval_seconds)}</TableCell>
+                  <TableCell>{formatTargets(schedule)}</TableCell>
+                  <TableCell>
+                    {schedule.last_status ? (
+                      <Badge variant={statusVariant(schedule.last_status)}>
+                        {schedule.last_status}
+                      </Badge>
+                    ) : (
+                      <span className="text-muted-foreground">never run</span>
+                    )}
+                  </TableCell>
+                  <TableCell className="text-muted-foreground">
+                    {schedule.enabled
+                      ? formatTimestamp(schedule.next_run_at)
+                      : "-"}
+                  </TableCell>
+                  <TableCell className="text-right space-x-1">
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      title="Run now"
+                      disabled={runMutation.isPending}
+                      onClick={() => runMutation.mutate(schedule.id)}
+                    >
+                      <Play className="h-4 w-4" />
+                    </Button>
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      title={schedule.enabled ? "Disable" : "Enable"}
+                      onClick={() =>
+                        enabledMutation.mutate({
+                          id: schedule.id,
+                          enabled: !schedule.enabled,
+                        })
+                      }
+                    >
+                      <Power
+                        className={
+                          schedule.enabled
+                            ? "h-4 w-4 text-green-600"
+                            : "h-4 w-4 text-muted-foreground"
+                        }
+                      />
+                    </Button>
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      title="Edit"
+                      onClick={() => openEdit(schedule)}
+                    >
+                      <Pencil className="h-4 w-4" />
+                    </Button>
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      title="Delete"
+                      onClick={() => deleteMutation.mutate(schedule.id)}
+                    >
+                      <Trash2 className="h-4 w-4 text-destructive" />
+                    </Button>
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        )}
+      </CardContent>
+
+      <Dialog open={createOpen} onOpenChange={setCreateOpen}>
+        <DialogContent className="max-w-lg">
+          <DialogHeader>
+            <DialogTitle>New Backup Schedule</DialogTitle>
+            <DialogDescription>
+              Schedules run in the background on the API server.
+            </DialogDescription>
+          </DialogHeader>
+          <ScheduleForm value={form} onChange={setForm} />
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setCreateOpen(false)}>
+              Cancel
+            </Button>
+            <Button onClick={submitCreate} disabled={createMutation.isPending}>
+              {createMutation.isPending && (
+                <Loader2 className="h-4 w-4 mr-1 animate-spin" />
+              )}
+              Create
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      <Dialog
+        open={editing !== null}
+        onOpenChange={(open) => !open && setEditing(null)}
+      >
+        <DialogContent className="max-w-lg">
+          <DialogHeader>
+            <DialogTitle>Edit Backup Schedule</DialogTitle>
+            <DialogDescription>
+              Changing the cadence restarts the schedule from now.
+            </DialogDescription>
+          </DialogHeader>
+          <ScheduleForm value={form} onChange={setForm} />
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setEditing(null)}>
+              Cancel
+            </Button>
+            <Button onClick={submitEdit} disabled={updateMutation.isPending}>
+              {updateMutation.isPending && (
+                <Loader2 className="h-4 w-4 mr-1 animate-spin" />
+              )}
+              Save
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </Card>
+  );
+}

--- a/packages/web/src/components/device-detail/backups-section.tsx
+++ b/packages/web/src/components/device-detail/backups-section.tsx
@@ -65,7 +65,9 @@ export function BackupsSection({
     offset,
   });
   const createBackup = useCreateBackup();
-  const [restoreTarget, setRestoreTarget] = useState<BackupSummary | null>(null);
+  const [restoreTarget, setRestoreTarget] = useState<BackupSummary | null>(
+    null,
+  );
 
   const items = backups?.items ?? [];
   const total = backups?.total ?? 0;
@@ -101,9 +103,7 @@ export function BackupsSection({
           </CardDescription>
         </div>
         <Button
-          onClick={() =>
-            createBackup.mutate({ deviceIp, name: undefined })
-          }
+          onClick={() => createBackup.mutate({ deviceIp, name: undefined })}
           disabled={createBackup.isPending}
         >
           <Save className="h-4 w-4 mr-2" />

--- a/packages/web/src/components/device-detail/backups-section.tsx
+++ b/packages/web/src/components/device-detail/backups-section.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { Save, RotateCcw, Trash2, AlertTriangle } from "lucide-react";
 
@@ -38,6 +38,7 @@ import {
 import type { BackupSummary } from "@/types/api";
 
 const NETWORK_TYPES = new Set(["wifi", "eth", "mqtt", "ws", "cloud"]);
+const PAGE_SIZE = 50;
 
 interface BackupsSectionProps {
   deviceIp: string;
@@ -54,12 +55,41 @@ export function BackupsSection({
   deviceMac,
   deviceName,
 }: BackupsSectionProps) {
-  const { data: backups, isLoading } = useBackups(deviceMac);
-  const createBackup = useCreateBackup(deviceMac);
+  const [offset, setOffset] = useState(0);
+  const {
+    data: backups,
+    isLoading,
+    isSuccess,
+  } = useBackups(deviceMac, {
+    limit: PAGE_SIZE,
+    offset,
+  });
+  const createBackup = useCreateBackup();
   const [restoreTarget, setRestoreTarget] = useState<BackupSummary | null>(null);
+
+  const items = backups?.items ?? [];
+  const total = backups?.total ?? 0;
+
+  // A device switch should start from the first page, not inherit the old one.
+  useEffect(() => {
+    setOffset(0);
+  }, [deviceMac]);
+
+  // Step back only on a *successful* empty page — not on a transient error,
+  // which also yields items=[] and would otherwise rewind pagination state.
+  useEffect(() => {
+    if (isSuccess && items.length === 0 && offset >= PAGE_SIZE) {
+      setOffset((current) => Math.max(0, current - PAGE_SIZE));
+    }
+  }, [isSuccess, items.length, offset]);
 
   const formatDate = (ts: number | null) =>
     ts ? new Date(ts * 1000).toLocaleString() : "-";
+
+  const rangeStart = total === 0 ? 0 : offset + 1;
+  const rangeEnd = offset + items.length;
+  const canPrev = offset > 0;
+  const canNext = offset + PAGE_SIZE < total;
 
   return (
     <Card>
@@ -87,31 +117,59 @@ export function BackupsSection({
           </p>
         ) : isLoading ? (
           <p className="text-sm text-muted-foreground">Loading backups...</p>
-        ) : !backups || backups.length === 0 ? (
+        ) : total === 0 ? (
           <p className="text-sm text-muted-foreground">No backups yet.</p>
         ) : (
-          <Table>
-            <TableHeader>
-              <TableRow>
-                <TableHead>ID</TableHead>
-                <TableHead>Created</TableHead>
-                <TableHead>Firmware</TableHead>
-                <TableHead>Source</TableHead>
-                <TableHead className="text-right">Actions</TableHead>
-              </TableRow>
-            </TableHeader>
-            <TableBody>
-              {backups.map((backup) => (
-                <BackupRow
-                  key={backup.id}
-                  backup={backup}
-                  deviceMac={deviceMac}
-                  formatDate={formatDate}
-                  onRestore={() => setRestoreTarget(backup)}
-                />
-              ))}
-            </TableBody>
-          </Table>
+          <>
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>ID</TableHead>
+                  <TableHead>Created</TableHead>
+                  <TableHead>Firmware</TableHead>
+                  <TableHead>Source</TableHead>
+                  <TableHead className="text-right">Actions</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {items.map((backup) => (
+                  <BackupRow
+                    key={backup.id}
+                    backup={backup}
+                    formatDate={formatDate}
+                    onRestore={() => setRestoreTarget(backup)}
+                  />
+                ))}
+              </TableBody>
+            </Table>
+            {total > PAGE_SIZE && (
+              <div className="flex items-center justify-between pt-4">
+                <p className="text-sm text-muted-foreground">
+                  Showing {rangeStart}–{rangeEnd} of {total}
+                </p>
+                <div className="space-x-2">
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={() =>
+                      setOffset((current) => Math.max(0, current - PAGE_SIZE))
+                    }
+                    disabled={!canPrev}
+                  >
+                    Previous
+                  </Button>
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={() => setOffset((current) => current + PAGE_SIZE)}
+                    disabled={!canNext}
+                  >
+                    Next
+                  </Button>
+                </div>
+              </div>
+            )}
+          </>
         )}
       </CardContent>
 
@@ -129,16 +187,14 @@ export function BackupsSection({
 
 function BackupRow({
   backup,
-  deviceMac,
   formatDate,
   onRestore,
 }: {
   backup: BackupSummary;
-  deviceMac: string | null;
   formatDate: (ts: number | null) => string;
   onRestore: () => void;
 }) {
-  const deleteBackup = useDeleteBackup(deviceMac);
+  const deleteBackup = useDeleteBackup();
   return (
     <TableRow>
       <TableCell>#{backup.id}</TableCell>
@@ -178,6 +234,10 @@ function RestoreDialog({
   const { data: detail, isLoading } = useQuery({
     queryKey: ["backup", backup.id],
     queryFn: () => backupApi.getBackup(backup.id),
+    // The app sets a global `enabled: false` default, so every query must opt
+    // in explicitly; without this the snapshot never loads and the restore
+    // dialog shows no components (Restore stays disabled).
+    enabled: true,
   });
 
   const componentTypes = useMemo(() => {

--- a/packages/web/src/components/layout/navbar.tsx
+++ b/packages/web/src/components/layout/navbar.tsx
@@ -1,5 +1,5 @@
 import { Link, useLocation } from "react-router-dom";
-import { Settings, Home, Radio } from "lucide-react";
+import { Settings, Home, Radio, CalendarClock } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { ThemeToggle } from "@/components/theme-toggle";
 import { Button } from "@/components/ui/button";
@@ -58,6 +58,20 @@ export function Navbar() {
               <Link to="/provisioning">
                 <Radio className="h-4 w-4" />
                 <span>{t("navigation.provisioning")}</span>
+              </Link>
+            </Button>
+            <Button
+              variant={isActive("/backups") ? "default" : "ghost"}
+              size="sm"
+              asChild
+              className={cn(
+                "flex items-center space-x-2",
+                isActive("/backups") && "bg-primary text-primary-foreground",
+              )}
+            >
+              <Link to="/backups">
+                <CalendarClock className="h-4 w-4" />
+                <span>Backups</span>
               </Link>
             </Button>
           </div>

--- a/packages/web/src/hooks/useBackupSchedules.ts
+++ b/packages/web/src/hooks/useBackupSchedules.ts
@@ -13,6 +13,7 @@ export function useBackupSchedules() {
   return useQuery({
     queryKey: QUERY_KEY,
     queryFn: backupScheduleApi.listSchedules,
+    enabled: true,
   });
 }
 

--- a/packages/web/src/hooks/useBackupSchedules.ts
+++ b/packages/web/src/hooks/useBackupSchedules.ts
@@ -1,0 +1,87 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+
+import { backupScheduleApi, handleApiError } from "@/lib/api";
+import type {
+  CreateBackupScheduleRequest,
+  UpdateBackupScheduleRequest,
+} from "@/types/api";
+
+const QUERY_KEY = ["backup-schedules"];
+
+export function useBackupSchedules() {
+  return useQuery({
+    queryKey: QUERY_KEY,
+    queryFn: backupScheduleApi.listSchedules,
+  });
+}
+
+export function useCreateBackupSchedule() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (data: CreateBackupScheduleRequest) =>
+      backupScheduleApi.createSchedule(data),
+    onSuccess: (schedule) => {
+      toast.success(`Schedule "${schedule.name}" created`);
+      queryClient.invalidateQueries({ queryKey: QUERY_KEY });
+    },
+    onError: (error) => toast.error(handleApiError(error)),
+  });
+}
+
+export function useUpdateBackupSchedule() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (params: { id: number; data: UpdateBackupScheduleRequest }) =>
+      backupScheduleApi.updateSchedule(params.id, params.data),
+    onSuccess: (schedule) => {
+      toast.success(`Schedule "${schedule.name}" updated`);
+      queryClient.invalidateQueries({ queryKey: QUERY_KEY });
+    },
+    onError: (error) => toast.error(handleApiError(error)),
+  });
+}
+
+export function useDeleteBackupSchedule() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (id: number) => backupScheduleApi.deleteSchedule(id),
+    onSuccess: () => {
+      toast.success("Schedule deleted");
+      queryClient.invalidateQueries({ queryKey: QUERY_KEY });
+    },
+    onError: (error) => toast.error(handleApiError(error)),
+  });
+}
+
+export function useSetScheduleEnabled() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (params: { id: number; enabled: boolean }) =>
+      backupScheduleApi.setEnabled(params.id, params.enabled),
+    onSuccess: (schedule) => {
+      toast.success(
+        `Schedule "${schedule.name}" ${schedule.enabled ? "enabled" : "disabled"}`,
+      );
+      queryClient.invalidateQueries({ queryKey: QUERY_KEY });
+    },
+    onError: (error) => toast.error(handleApiError(error)),
+  });
+}
+
+export function useRunBackupSchedule() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (id: number) => backupScheduleApi.runSchedule(id),
+    onSuccess: (result) => {
+      const summary = `${result.ok} ok, ${result.failed} failed, ${result.skipped} skipped`;
+      if (result.failed > 0) {
+        toast.warning(`Run finished with issues: ${summary}`);
+      } else {
+        toast.success(`Run complete: ${summary}`);
+      }
+      queryClient.invalidateQueries({ queryKey: QUERY_KEY });
+    },
+    onError: (error) => toast.error(handleApiError(error)),
+  });
+}

--- a/packages/web/src/hooks/useBackups.ts
+++ b/packages/web/src/hooks/useBackups.ts
@@ -4,34 +4,44 @@ import { toast } from "sonner";
 import { backupApi, handleApiError } from "@/lib/api";
 import type { RestoreBackupRequest } from "@/types/api";
 
-export function useBackups(deviceMac: string | null | undefined) {
+export function useBackups(
+  deviceMac: string | null | undefined,
+  options?: { limit?: number; offset?: number },
+) {
+  const limit = options?.limit ?? 50;
+  const offset = options?.offset ?? 0;
   return useQuery({
-    queryKey: ["backups", deviceMac],
-    queryFn: () => backupApi.listBackups(deviceMac ?? undefined),
+    queryKey: ["backups", deviceMac, limit, offset],
+    queryFn: () =>
+      backupApi.listBackups({
+        deviceMac: deviceMac ?? undefined,
+        limit,
+        offset,
+      }),
     enabled: !!deviceMac,
   });
 }
 
-export function useCreateBackup(deviceMac: string | null | undefined) {
+export function useCreateBackup() {
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: (params: { deviceIp: string; name?: string }) =>
       backupApi.createBackup({ device_ip: params.deviceIp, name: params.name }),
     onSuccess: (backup) => {
       toast.success(`Backup #${backup.id} created`);
-      queryClient.invalidateQueries({ queryKey: ["backups", deviceMac] });
+      queryClient.invalidateQueries({ queryKey: ["backups"] });
     },
     onError: (error) => toast.error(handleApiError(error)),
   });
 }
 
-export function useDeleteBackup(deviceMac: string | null | undefined) {
+export function useDeleteBackup() {
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: (backupId: number) => backupApi.deleteBackup(backupId),
     onSuccess: () => {
       toast.success("Backup deleted");
-      queryClient.invalidateQueries({ queryKey: ["backups", deviceMac] });
+      queryClient.invalidateQueries({ queryKey: ["backups"] });
     },
     onError: (error) => toast.error(handleApiError(error)),
   });

--- a/packages/web/src/hooks/useScannedDevices.ts
+++ b/packages/web/src/hooks/useScannedDevices.ts
@@ -1,0 +1,22 @@
+import { useQuery } from "@tanstack/react-query";
+
+import { loadScanResults } from "@/lib/storage";
+import type { Device } from "@/types/api";
+
+/**
+ * Read the devices from the most recent network scan.
+ *
+ * Shares the ["devices", "scan"] query key with the dashboard, so it reflects
+ * whatever was last scanned (and never triggers a scan of its own).
+ */
+export function useScannedDevices() {
+  return useQuery<Device[]>({
+    queryKey: ["devices", "scan"],
+    queryFn: () => {
+      const cached = loadScanResults();
+      return cached ? cached.devices : [];
+    },
+    staleTime: Infinity,
+    gcTime: Infinity,
+  });
+}

--- a/packages/web/src/hooks/useScannedDevices.ts
+++ b/packages/web/src/hooks/useScannedDevices.ts
@@ -18,5 +18,6 @@ export function useScannedDevices() {
     },
     staleTime: Infinity,
     gcTime: Infinity,
+    enabled: true,
   });
 }

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -14,7 +14,7 @@ import type {
   APDeviceInfo,
   ProvisionResult,
   VerifyResult,
-  BackupSummary,
+  PaginatedBackups,
   BackupDetail,
   CreateBackupRequest,
   RestoreBackupRequest,
@@ -352,9 +352,17 @@ export const provisioningApi = {
 };
 
 export const backupApi = {
-  listBackups: async (deviceMac?: string): Promise<BackupSummary[]> => {
+  listBackups: async (params?: {
+    deviceMac?: string;
+    limit?: number;
+    offset?: number;
+  }): Promise<PaginatedBackups> => {
     const response = await apiClient.get("/backups", {
-      params: deviceMac ? { device_mac: deviceMac } : undefined,
+      params: {
+        ...(params?.deviceMac ? { device_mac: params.deviceMac } : {}),
+        ...(params?.limit !== undefined ? { limit: params.limit } : {}),
+        ...(params?.offset !== undefined ? { offset: params.offset } : {}),
+      },
     });
     return response.data;
   },

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -19,6 +19,10 @@ import type {
   CreateBackupRequest,
   RestoreBackupRequest,
   RestoreResult,
+  BackupSchedule,
+  CreateBackupScheduleRequest,
+  UpdateBackupScheduleRequest,
+  ScheduleRunResult,
 } from "@/types/api";
 import { loadAppSettings } from "./settings";
 
@@ -377,6 +381,47 @@ export const backupApi = {
 
   deleteBackup: async (backupId: number): Promise<void> => {
     await apiClient.delete(`/backups/${backupId}`);
+  },
+};
+
+export const backupScheduleApi = {
+  listSchedules: async (): Promise<BackupSchedule[]> => {
+    const response = await apiClient.get("/backup-schedules");
+    return response.data;
+  },
+
+  createSchedule: async (
+    data: CreateBackupScheduleRequest,
+  ): Promise<BackupSchedule> => {
+    const response = await apiClient.post("/backup-schedules", data);
+    return response.data;
+  },
+
+  updateSchedule: async (
+    id: number,
+    data: UpdateBackupScheduleRequest,
+  ): Promise<BackupSchedule> => {
+    const response = await apiClient.put(`/backup-schedules/${id}`, data);
+    return response.data;
+  },
+
+  deleteSchedule: async (id: number): Promise<void> => {
+    await apiClient.delete(`/backup-schedules/${id}`);
+  },
+
+  setEnabled: async (id: number, enabled: boolean): Promise<BackupSchedule> => {
+    const action = enabled ? "enable" : "disable";
+    const response = await apiClient.post(`/backup-schedules/${id}/${action}`);
+    return response.data;
+  },
+
+  runSchedule: async (id: number): Promise<ScheduleRunResult> => {
+    const response = await apiClient.post(
+      `/backup-schedules/${id}/run`,
+      undefined,
+      { timeout: 120000 },
+    );
+    return response.data;
   },
 };
 

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -381,9 +381,13 @@ export const backupApi = {
     backupId: number,
     data: RestoreBackupRequest,
   ): Promise<RestoreResult> => {
-    const response = await apiClient.post(`/backups/${backupId}/restore`, data, {
-      timeout: 60000,
-    });
+    const response = await apiClient.post(
+      `/backups/${backupId}/restore`,
+      data,
+      {
+        timeout: 60000,
+      },
+    );
     return response.data;
   },
 

--- a/packages/web/src/pages/backup-schedules.tsx
+++ b/packages/web/src/pages/backup-schedules.tsx
@@ -1,0 +1,25 @@
+import { BackupSchedulesSection } from "@/components/backup-schedules/schedules-section";
+import { BackupsTableSection } from "@/components/backup-schedules/backups-table-section";
+import { Footer } from "@/components/ui/footer";
+
+export function BackupSchedules() {
+  return (
+    <div className="min-h-[calc(100vh-8rem)] flex flex-col">
+      <div className="flex-1 space-y-6">
+        <div>
+          <h1 className="text-3xl font-bold tracking-tight">Backups</h1>
+          <p className="text-muted-foreground">
+            Manage automated backup schedules and browse stored snapshots.
+          </p>
+        </div>
+
+        <div className="grid grid-cols-1 gap-6">
+          <BackupSchedulesSection />
+          <BackupsTableSection />
+        </div>
+      </div>
+
+      <Footer className="mt-6" />
+    </div>
+  );
+}

--- a/packages/web/src/types/api.ts
+++ b/packages/web/src/types/api.ts
@@ -631,6 +631,58 @@ export interface ComponentRestoreResult {
   error: string | null;
 }
 
+export interface BackupSchedule {
+  id: number;
+  name: string;
+  target_ips: string[];
+  target_macs: string[];
+  all_credentialed: boolean;
+  interval_seconds: number;
+  enabled: boolean;
+  retention_keep_last: number | null;
+  retention_max_age_days: number | null;
+  last_run_at: number | null;
+  next_run_at: number | null;
+  last_status: string | null;
+  created_at: number | null;
+  updated_at: number | null;
+}
+
+export interface CreateBackupScheduleRequest {
+  name: string;
+  target_ips?: string[];
+  target_macs?: string[];
+  all_credentialed?: boolean;
+  every?: string | null;
+  interval_seconds?: number | null;
+  enabled?: boolean;
+  retention_keep_last?: number | null;
+  retention_max_age_days?: number | null;
+}
+
+export interface UpdateBackupScheduleRequest {
+  name?: string | null;
+  target_ips?: string[] | null;
+  target_macs?: string[] | null;
+  all_credentialed?: boolean | null;
+  every?: string | null;
+  interval_seconds?: number | null;
+  enabled?: boolean | null;
+  retention_keep_last?: number | null;
+  retention_max_age_days?: number | null;
+}
+
+export interface ScheduleRunResult {
+  schedule_id: number;
+  schedule_name: string;
+  status: string;
+  targets: number;
+  ok: number;
+  failed: number;
+  skipped: number;
+  message: string;
+}
+
 export interface RestoreResult {
   success: boolean;
   device_ip: string;

--- a/packages/web/src/types/api.ts
+++ b/packages/web/src/types/api.ts
@@ -610,6 +610,13 @@ export interface BackupDetail extends BackupSummary {
   snapshot: Record<string, unknown>;
 }
 
+export interface PaginatedBackups {
+  items: BackupSummary[];
+  total: number;
+  limit: number;
+  offset: number;
+}
+
 export interface CreateBackupRequest {
   device_ip: string;
   name?: string | null;

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,6 +101,7 @@ module = [
     "structlog.*",
     "click.*",
     "rich.*",
+    "apscheduler.*",
 ]
 ignore_missing_imports = true
 

--- a/uv.lock
+++ b/uv.lock
@@ -43,6 +43,18 @@ wheels = [
 ]
 
 [[package]]
+name = "apscheduler"
+version = "3.11.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "tzlocal" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/07/12/3e4389e5920b4c1763390c6d371162f3784f86f85cd6d6c1bfe68eef14e2/apscheduler-3.11.2.tar.gz", hash = "sha256:2a9966b052ec805f020c8c4c3ae6e6a06e24b1bf19f2e11d91d8cca0473eef41", size = 108683, upload-time = "2025-12-22T00:39:34.884Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9f/64/2e54428beba8d9992aa478bb8f6de9e4ecaa5f8f513bcfd567ed7fb0262d/apscheduler-3.11.2-py3-none-any.whl", hash = "sha256:ce005177f741409db4e4dd40a7431b76feb856b9dd69d57e0da49d6715bfd26d", size = 64439, upload-time = "2025-12-22T00:39:33.303Z" },
+]
+
+[[package]]
 name = "black"
 version = "25.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -213,14 +225,14 @@ wheels = [
 
 [[package]]
 name = "click"
-version = "8.2.1"
+version = "8.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/60/6c/8ca2efa64cf75a977a0d7fac081354553ebe483345c734fb6b6515d96bbc/click-8.2.1.tar.gz", hash = "sha256:27c491cc05d968d271d5a1db13e3b5a184636d9d930f148c50b038f0d0646202", size = 286342, upload-time = "2025-05-20T23:19:49.832Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3d/fa/656b739db8587d7b5dfa22e22ed02566950fbfbcdc20311993483657a5c0/click-8.3.1.tar.gz", hash = "sha256:12ff4785d337a1bb490bb7e9c2b1ee5da3112e94a8622f26a6c77f5d2fc6842a", size = 295065, upload-time = "2025-11-15T20:45:42.706Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/85/32/10bb5764d90a8eee674e9dc6f4db6a0ab47c8c4d0d83c27f7c39ac415a4d/click-8.2.1-py3-none-any.whl", hash = "sha256:61a3265b914e850b85317d0b3109c7f8cd35a670f963866005d6ef1d5175a12b", size = 102215, upload-time = "2025-05-20T23:19:47.796Z" },
+    { url = "https://files.pythonhosted.org/packages/98/78/01c019cdb5d6498122777c1a43056ebb3ebfeef2076d9d026bfe15583b2b/click-8.3.1-py3-none-any.whl", hash = "sha256:981153a64e25f12d547d3426c367a4857371575ee7ad18df2a6183ab0545b2a6", size = 108274, upload-time = "2025-11-15T20:45:41.139Z" },
 ]
 
 [[package]]
@@ -612,7 +624,7 @@ wheels = [
 
 [[package]]
 name = "litestar"
-version = "2.16.0"
+version = "2.19.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -626,11 +638,12 @@ dependencies = [
     { name = "pyyaml" },
     { name = "rich" },
     { name = "rich-click" },
+    { name = "sniffio" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/0d/4e/3376d5737a4c2e26fb2991a046265c38335b134d3e04e93c6d754e962e4e/litestar-2.16.0.tar.gz", hash = "sha256:f65c0d543bfec12b7433dff624322936f30bbdfb54ad3c5b7ef22ab2d092be2d", size = 399637, upload-time = "2025-05-04T11:00:46.654Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/25/1c/2cf555f8c4236a1db2a4f1492143ab1132c4b5e7f2e7c1e41ee931f57d2b/litestar-2.19.0.tar.gz", hash = "sha256:c2663a7f48a7ed273615260c23fc76dbef2ca0d539ece25318772b737470c531", size = 373938, upload-time = "2025-12-14T13:53:28.425Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9a/dc/4d1018577683918cd24a58228c90833f71f792aafcfffb44905c9062f737/litestar-2.16.0-py3-none-any.whl", hash = "sha256:8a48557198556f01d3d70da3859a471aa56595a4a344362d9529ed65804e3ee4", size = 573158, upload-time = "2025-05-04T11:00:44.558Z" },
+    { url = "https://files.pythonhosted.org/packages/12/9a/fdba1ee34c24811592faba859b377d13457e48c37fbe07d88bd74a36d1f0/litestar-2.19.0-py3-none-any.whl", hash = "sha256:849971d097a6118f81235531fc0f342d797bd29d9aef9c23230559f124d16247", size = 565733, upload-time = "2025-12-14T13:53:26.706Z" },
 ]
 
 [package.optional-dependencies]
@@ -639,7 +652,6 @@ standard = [
     { name = "jinja2" },
     { name = "jsbeautifier" },
     { name = "uvicorn", extra = ["standard"] },
-    { name = "uvloop", marker = "sys_platform != 'win32'" },
 ]
 
 [[package]]
@@ -1267,6 +1279,7 @@ name = "shelly-manager-api"
 version = "0.1.0"
 source = { editable = "packages/api" }
 dependencies = [
+    { name = "apscheduler" },
     { name = "litestar", extra = ["standard"] },
     { name = "shelly-manager-core" },
     { name = "uvicorn", extra = ["standard"] },
@@ -1284,15 +1297,16 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "apscheduler", specifier = ">=3.10.4,<4.0" },
     { name = "black", marker = "extra == 'dev'" },
-    { name = "litestar", extras = ["standard"], specifier = "==2.16.0" },
+    { name = "litestar", extras = ["standard"], specifier = "==2.19.0" },
     { name = "mypy", marker = "extra == 'dev'" },
     { name = "pytest", marker = "extra == 'dev'" },
     { name = "pytest-asyncio", marker = "extra == 'dev'" },
     { name = "pytest-cov", marker = "extra == 'dev'" },
     { name = "ruff", marker = "extra == 'dev'" },
     { name = "shelly-manager-core", editable = "packages/core" },
-    { name = "uvicorn", extras = ["standard"], specifier = "==0.35.0" },
+    { name = "uvicorn", extras = ["standard"], specifier = "==0.40.0" },
 ]
 provides-extras = ["dev"]
 
@@ -1321,7 +1335,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "black", marker = "extra == 'dev'" },
-    { name = "click", specifier = "==8.2.1" },
+    { name = "click", specifier = "==8.3.1" },
     { name = "mypy", marker = "extra == 'dev'" },
     { name = "pytest", marker = "extra == 'dev'" },
     { name = "pytest-asyncio", marker = "extra == 'dev'" },
@@ -1366,7 +1380,7 @@ dev = [
 requires-dist = [
     { name = "aiosqlite", specifier = ">=0.19.0" },
     { name = "black", marker = "extra == 'dev'" },
-    { name = "cryptography", specifier = ">=42.0.0" },
+    { name = "cryptography", specifier = ">=46.0.3" },
     { name = "httpx", specifier = "==0.28.1" },
     { name = "mypy", marker = "extra == 'dev'" },
     { name = "pydantic", specifier = "==2.11.7" },
@@ -1549,6 +1563,18 @@ wheels = [
 ]
 
 [[package]]
+name = "tzlocal"
+version = "5.4.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "tzdata", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/48/55/15e2340963d2bfedcc6042da3911438fd336f8ae96b65bdbe3a29766da0c/tzlocal-5.4.3.tar.gz", hash = "sha256:3a8c9bc18cf47e1dcde252ea0e6a72a6cde320a400b6ac6db1f1f8cccd553c00", size = 30873, upload-time = "2026-06-17T04:17:41.764Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/42/28/fc144409c71569e928585f8f3c629d80d1ca3ef40175e9222f01588f98c9/tzlocal-5.4.3-py3-none-any.whl", hash = "sha256:24ce97bb58e2a973f7640ec2553ab4e6f6d5a0d0d1aa9dc43bca21d89e1feb82", size = 18039, upload-time = "2026-06-17T04:17:40.027Z" },
+]
+
+[[package]]
 name = "urllib3"
 version = "2.5.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1559,15 +1585,15 @@ wheels = [
 
 [[package]]
 name = "uvicorn"
-version = "0.35.0"
+version = "0.40.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
     { name = "h11" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/5e/42/e0e305207bb88c6b8d3061399c6a961ffe5fbb7e2aa63c9234df7259e9cd/uvicorn-0.35.0.tar.gz", hash = "sha256:bc662f087f7cf2ce11a1d7fd70b90c9f98ef2e2831556dd078d131b96cc94a01", size = 78473, upload-time = "2025-06-28T16:15:46.058Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/d1/8f3c683c9561a4e6689dd3b1d345c815f10f86acd044ee1fb9a4dcd0b8c5/uvicorn-0.40.0.tar.gz", hash = "sha256:839676675e87e73694518b5574fd0f24c9d97b46bea16df7b8c05ea1a51071ea", size = 81761, upload-time = "2025-12-21T14:16:22.45Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d2/e2/dc81b1bd1dcfe91735810265e9d26bc8ec5da45b4c0f6237e286819194c3/uvicorn-0.35.0-py3-none-any.whl", hash = "sha256:197535216b25ff9b785e29a0b79199f55222193d47f820816e7da751e9bc8d4a", size = 66406, upload-time = "2025-06-28T16:15:44.816Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/d8/2083a1daa7439a66f3a48589a57d576aa117726762618f6bb09fe3798796/uvicorn-0.40.0-py3-none-any.whl", hash = "sha256:c6c8f55bc8bf13eb6fa9ff87ad62308bbbc33d0b67f84293151efe87e0d5f2ee", size = 68502, upload-time = "2025-12-21T14:16:21.041Z" },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
## Purpose

Adds scheduled, automatic device-configuration backups with retention, and paginates the backups list so it scales as snapshots accumulate.

## Context

Backups run in-process via APScheduler, gated by `SHELLY_BACKUP_SCHEDULER_ENABLED`, and retention only prunes `source="scheduled"` snapshots so manually captured backups are never auto-deleted. `GET /api/backups` now returns `{items, total, limit, offset}` instead of a bare array, with a `created_at` index added through `CREATE INDEX IF NOT EXISTS` since the project has no migrations.

## Notes

The in-process scheduler assumes the single-worker app factory; a second worker would double-fire schedules.


Closes  #45