### PR TITLE
Speed up device scanning

### DIFF
--- a/packages/api/src/api/controllers/devices.py
+++ b/packages/api/src/api/controllers/devices.py
@@ -66,7 +66,6 @@ async def scan_devices(
 
     scan_request = ScanRequest(
         targets=targets or [],
-        use_predefined=use_predefined,
         use_mdns=use_mdns,
         timeout=timeout,
         max_workers=max_workers,

--- a/packages/api/src/api/dependencies/container.py
+++ b/packages/api/src/api/dependencies/container.py
@@ -107,7 +107,8 @@ class APIContainer(BaseContainer):
     def get_rpc_client(self) -> AsyncShellyRPCClient:
         if self._rpc_client is None:
             self._rpc_client = AsyncShellyRPCClient(
-                timeout=int(core_settings.network.timeout),
+                timeout=core_settings.network.timeout,
+                connect_timeout=core_settings.network.connect_timeout,
                 verify=core_settings.network.verify_ssl,
                 authentication_service=self.get_authentication_service(),
                 auth_state_cache=self.get_auth_state_cache(),
@@ -140,6 +141,12 @@ class APIContainer(BaseContainer):
                 await self._mdns_client.close()
             except Exception:
                 pass
+
+        await self._aclose_legacy_http_client()
+
+        self._rpc_client = None
+        self._credentials_use_case = None
+        self._reset_device_caches()
 
 
 def get_dependencies(container: APIContainer) -> dict:

--- a/packages/cli/src/cli/commands/common.py
+++ b/packages/cli/src/cli/commands/common.py
@@ -3,6 +3,7 @@ Common Click utilities, decorators, and options.
 """
 
 import asyncio
+import inspect
 import ipaddress
 from collections.abc import Callable
 from functools import wraps
@@ -45,12 +46,40 @@ def device_targeting_options(func: Callable) -> Callable:
     return wrapper
 
 
+async def _close_container(container: Any) -> None:
+    """Close a CLI container's async resources, skipping mock containers.
+
+    The container's HTTP clients (httpx pools) are created inside the running
+    event loop, so they must be closed from within it. Guarded on a real async
+    ``close`` so unit tests using mock containers are unaffected.
+    """
+    close = getattr(container, "close", None)
+    if inspect.iscoroutinefunction(close):
+        try:
+            await close()
+        except Exception:
+            pass
+
+
+def _container_from_args(args: Any) -> Any:
+    if not args:
+        return None
+    return getattr(getattr(args[0], "obj", None), "container", None)
+
+
+async def _run_then_close(func: Callable, args: Any, kwargs: Any) -> Any:
+    try:
+        return await func(*args, **kwargs)
+    finally:
+        await _close_container(_container_from_args(args))
+
+
 def async_command(func: Callable) -> Callable:
     """Decorator to run async functions in Click commands."""
 
     @wraps(func)
     def wrapper(*args: Any, **kwargs: Any) -> Any:
-        return asyncio.run(func(*args, **kwargs))
+        return asyncio.run(_run_then_close(func, args, kwargs))
 
     return wrapper
 

--- a/packages/cli/src/cli/dependencies/container.py
+++ b/packages/cli/src/cli/dependencies/container.py
@@ -3,7 +3,6 @@
 from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
 
-import httpx
 from core.dependencies.container_base import BaseContainer
 from core.gateways.network.async_shelly_rpc_client import AsyncShellyRPCClient
 from core.repositories.db import async_session_factory
@@ -21,6 +20,7 @@ from core.repositories.sqlalchemy_provisioning_profile_repository import (
 )
 from core.services.authentication_service import AuthenticationService
 from core.services.encryption_service import EncryptionService
+from core.settings import settings as core_settings
 from core.use_cases.scan_devices import ScanDevicesUseCase
 
 
@@ -89,13 +89,33 @@ class CLIContainer(BaseContainer):
 
     def get_rpc_client(self) -> AsyncShellyRPCClient:
         if self._rpc_client is None:
-            # Shared session for connection pooling
-            http_session = httpx.AsyncClient(timeout=3.0)
             self._rpc_client = AsyncShellyRPCClient(
-                session=http_session,
+                timeout=core_settings.network.timeout,
+                connect_timeout=core_settings.network.connect_timeout,
+                verify=core_settings.network.verify_ssl,
                 authentication_service=self.get_authentication_service(),
+                auth_state_cache=self.get_auth_state_cache(),
             )
         return self._rpc_client
+
+    async def close(self) -> None:
+        """Gracefully close async resources (HTTP connection pools)."""
+        if self._rpc_client is not None:
+            try:
+                await self._rpc_client.close()
+            except Exception:
+                pass
+
+        if self._mdns_client is not None:
+            try:
+                await self._mdns_client.close()
+            except Exception:
+                pass
+
+        await self._aclose_legacy_http_client()
+
+        self._rpc_client = None
+        self._reset_device_caches()
 
     # Backwards compatibility helpers (optional convenience wrappers)
     def get_device_scan_interactor(self) -> ScanDevicesUseCase:

--- a/packages/core/src/core/dependencies/container_base.py
+++ b/packages/core/src/core/dependencies/container_base.py
@@ -30,6 +30,7 @@ from core.use_cases.scan_devices import ScanDevicesUseCase
 class BaseContainer:
     def __init__(self) -> None:
         self._device_gateway: ShellyDeviceGateway | None = None
+        self._legacy_http_client: LegacyHttpClient | None = None
         self._mdns_client: MDNSGateway | None = None
         self._scan_interactor: ScanDevicesUseCase | None = None
         self._execute_component_action_interactor: (
@@ -55,7 +56,12 @@ class BaseContainer:
 
     def get_device_gateway(self) -> ShellyDeviceGateway:
         if self._device_gateway is None:
-            legacy_http_client = LegacyHttpClient()
+            from core.settings import settings as core_settings
+
+            legacy_http_client = LegacyHttpClient(
+                connect_timeout=core_settings.network.connect_timeout,
+            )
+            self._legacy_http_client = legacy_http_client
             legacy_component_mapper = LegacyComponentMapper()
             legacy_gateway = LegacyDeviceGateway(
                 http_client=legacy_http_client,
@@ -69,6 +75,36 @@ class BaseContainer:
                 legacy_gateway=legacy_gateway,
             )
         return self._device_gateway
+
+    async def _aclose_legacy_http_client(self) -> None:
+        """Close the legacy HTTP client's connection pool, if one was created."""
+        if self._legacy_http_client is not None:
+            try:
+                await self._legacy_http_client.close()
+            except Exception:
+                pass
+
+    def _reset_device_caches(self) -> None:
+        """Drop cached gateways/interactors that hold now-closed clients.
+
+        Called after close() so that a reused container rebuilds live
+        resources on next access instead of handing back closed ones.
+        """
+        self._device_gateway = None
+        self._legacy_http_client = None
+        self._mdns_client = None
+        self._scan_interactor = None
+        self._execute_component_action_interactor = None
+        self._component_actions_interactor = None
+        self._status_interactor = None
+        self._bulk_operations_interactor = None
+        self._manage_profiles_interactor = None
+        self._provision_device_interactor = None
+        self._ap_device_detector = None
+        self._backup_device_config_interactor = None
+        self._restore_device_config_interactor = None
+        self._manage_backup_schedules_interactor = None
+        self._run_due_backups_interactor = None
 
     def _get_authentication_service_optional(self) -> AuthenticationService | None:
         """Return AuthenticationService if available, None otherwise."""

--- a/packages/core/src/core/domain/entities/exceptions.py
+++ b/packages/core/src/core/domain/entities/exceptions.py
@@ -34,6 +34,15 @@ class DeviceCommunicationError(ShellyManagerError):
         super().__init__(msg, {"ip": ip, "error": error})
 
 
+class DeviceUnreachableError(DeviceCommunicationError):
+    """Raised when a host does not accept a TCP connection.
+
+    Signals that nothing is listening at the address (connect refused/timed
+    out), as opposed to a device that responded but failed at the HTTP/RPC
+    layer. Used to skip the legacy fallback probe for dead IPs during scans.
+    """
+
+
 class ConfigurationError(ShellyManagerError):
 
     def __init__(self, operation: str, message: str | None = None):

--- a/packages/core/src/core/gateways/device/device.py
+++ b/packages/core/src/core/gateways/device/device.py
@@ -14,7 +14,9 @@ class DeviceGateway(ABC):
     timeout: float = 10.0
 
     @abstractmethod
-    async def discover_device(self, ip: str) -> DiscoveredDevice | None:
+    async def discover_device(
+        self, ip: str, timeout: float | None = None
+    ) -> DiscoveredDevice | None:
         pass
 
     @abstractmethod

--- a/packages/core/src/core/gateways/device/legacy_device_gateway.py
+++ b/packages/core/src/core/gateways/device/legacy_device_gateway.py
@@ -4,6 +4,7 @@ Legacy device gateway for Gen1 Shelly devices.
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import time
 from datetime import datetime
@@ -42,13 +43,15 @@ class LegacyDeviceGateway:
         self._ip_to_mac: dict[str, str] = {}
         self._basic_auth_cache: dict[str, tuple[str, str]] = {}
 
-    async def _ensure_mac(self, ip: str) -> str | None:
+    async def _ensure_mac(self, ip: str, timeout: float | None = None) -> str | None:
         """Get MAC address for an IP, fetching from /shelly if not cached."""
         normalized_ip = normalize_mac(ip)
         if normalized_ip in self._ip_to_mac:
             return self._ip_to_mac[normalized_ip]
         try:
-            shelly_data = await self._http_client.fetch_json(ip, "shelly")
+            shelly_data = await self._http_client.fetch_json(
+                ip, "shelly", timeout=timeout
+            )
             mac = shelly_data.get("mac")
             if mac:
                 normalized_mac = normalize_mac(mac)
@@ -58,12 +61,14 @@ class LegacyDeviceGateway:
             pass
         return None
 
-    async def _resolve_auth(self, ip: str) -> tuple[str, str] | None:
+    async def _resolve_auth(
+        self, ip: str, timeout: float | None = None
+    ) -> tuple[str, str] | None:
         """Resolve Basic Auth credentials for a device by IP."""
         if not self._authentication_service:
             return None
 
-        mac = await self._ensure_mac(ip)
+        mac = await self._ensure_mac(ip, timeout)
         if not mac:
             return None
 
@@ -82,18 +87,24 @@ class LegacyDeviceGateway:
         normalized_mac = normalize_mac(mac)
         self._basic_auth_cache.pop(normalized_mac, None)
 
-    async def discover_device(self, ip: str) -> DiscoveredDevice | None:
+    async def discover_device(
+        self, ip: str, timeout: float | None = None
+    ) -> DiscoveredDevice | None:
         """Discover a legacy Gen1 Shelly device.
 
         Args:
             ip: Device IP address
+            timeout: Per-request timeout in seconds; falls back to the HTTP
+                client default when not provided.
 
         Returns:
             DiscoveredDevice or None if discovery fails
         """
         try:
             start_time = time.perf_counter()
-            device_info = await self._http_client.fetch_json(ip, "shelly")
+            device_info = await self._http_client.fetch_json(
+                ip, "shelly", timeout=timeout
+            )
             response_time = time.perf_counter() - start_time
 
             # Detect auth requirement from /shelly response
@@ -105,13 +116,16 @@ class LegacyDeviceGateway:
                 normalized_mac = normalize_mac(mac)
                 self._ip_to_mac[normalize_mac(ip)] = normalized_mac
                 self._auth_state_cache.mark_auth_required(normalized_mac)
-                auth = await self._resolve_auth(ip)
+                auth = await self._resolve_auth(ip, timeout)
 
-            status_data = await self._http_client.fetch_json_optional(
-                ip, "status", auth=auth
-            )
-            settings_data = await self._http_client.fetch_json_optional(
-                ip, "settings", auth=auth
+            # /status and /settings are independent; fetch them concurrently.
+            status_data, settings_data = await asyncio.gather(
+                self._http_client.fetch_json_optional(
+                    ip, "status", auth=auth, timeout=timeout
+                ),
+                self._http_client.fetch_json_optional(
+                    ip, "settings", auth=auth, timeout=timeout
+                ),
             )
 
             device_name = self._derive_device_name(device_info, settings_data)
@@ -154,17 +168,23 @@ class LegacyDeviceGateway:
             )
             return None
 
-    async def get_device_status(self, ip: str) -> DeviceStatus | None:
+    async def get_device_status(
+        self, ip: str, timeout: float | None = None
+    ) -> DeviceStatus | None:
         """Get device status for a legacy Gen1 device.
 
         Args:
             ip: Device IP address
+            timeout: Per-request timeout in seconds; falls back to the HTTP
+                client default when not provided.
 
         Returns:
             DeviceStatus or None if retrieval fails
         """
         try:
-            device_info = await self._http_client.fetch_json(ip, "shelly")
+            device_info = await self._http_client.fetch_json(
+                ip, "shelly", timeout=timeout
+            )
 
             auth: tuple[str, str] | None = None
             if device_info.get("auth", False):
@@ -172,11 +192,13 @@ class LegacyDeviceGateway:
                 if mac:
                     normalized_mac = normalize_mac(mac)
                     self._ip_to_mac[normalize_mac(ip)] = normalized_mac
-                auth = await self._resolve_auth(ip)
+                auth = await self._resolve_auth(ip, timeout)
 
-            status_data = await self._http_client.fetch_json(ip, "status", auth=auth)
+            status_data = await self._http_client.fetch_json(
+                ip, "status", auth=auth, timeout=timeout
+            )
             settings_data = await self._http_client.fetch_json_optional(
-                ip, "settings", auth=auth
+                ip, "settings", auth=auth, timeout=timeout
             )
         except DeviceAuthenticationError:
             raise

--- a/packages/core/src/core/gateways/device/shelly_device_gateway.py
+++ b/packages/core/src/core/gateways/device/shelly_device_gateway.py
@@ -12,6 +12,7 @@ from ...domain.entities.discovered_device import DiscoveredDevice
 from ...domain.entities.exceptions import (
     DeviceAuthenticationError,
     DeviceCommunicationError,
+    DeviceUnreachableError,
 )
 from ...domain.enums.enums import Status
 from ...domain.value_objects.action_result import ActionResult
@@ -43,19 +44,24 @@ class ShellyDeviceGateway(DeviceGateway):
         if self._legacy_gateway:
             self._legacy_gateway.invalidate_credential_cache(mac)
 
-    async def discover_device(self, ip: str) -> DiscoveredDevice | None:
+    async def discover_device(
+        self, ip: str, timeout: float | None = None
+    ) -> DiscoveredDevice | None:
         """
         Discover basic device information (original get_device_status logic).
 
         Args:
             ip: Device IP address
+            timeout: Per-request timeout in seconds; falls back to the gateway
+                default when not provided.
 
         Returns:
             DiscoveredDevice with basic info and update status, or None if unreachable
         """
+        effective_timeout = timeout if timeout is not None else self.timeout
         try:
             device_info, response_time = await self._rpc_client.make_rpc_request(
-                ip, RpcMethods.GET_DEVICE_INFO, timeout=self.timeout
+                ip, RpcMethods.GET_DEVICE_INFO, timeout=effective_timeout
             )
             device_data = device_info.get("result", device_info)
 
@@ -89,7 +95,7 @@ class ShellyDeviceGateway(DeviceGateway):
 
             try:
                 update_info, _ = await self._rpc_client.make_rpc_request(
-                    ip, RpcMethods.CHECK_FOR_UPDATE, timeout=self.timeout
+                    ip, RpcMethods.CHECK_FOR_UPDATE, timeout=effective_timeout
                 )
                 update_data = update_info.get("result", update_info)
 
@@ -107,6 +113,18 @@ class ShellyDeviceGateway(DeviceGateway):
 
             return device
 
+        except DeviceUnreachableError as e:
+            # No TCP connection established: nothing is listening here. A Gen1
+            # device would still accept the connection, so there's no point
+            # paying for a second (legacy) probe on a dead address.
+            logger.debug("Host %s unreachable, skipping legacy probe: %s", ip, e)
+            return DiscoveredDevice(
+                ip=ip,
+                status=Status.UNREACHABLE,
+                error_message=str(e),
+                last_seen=datetime.now(),
+            )
+
         except Exception as e:
             logger.debug(
                 "RPC discovery failed for %s, attempting legacy HTTP fallback: %s",
@@ -114,7 +132,9 @@ class ShellyDeviceGateway(DeviceGateway):
                 e,
             )
             if self._legacy_gateway:
-                legacy_device = await self._legacy_gateway.discover_device(ip)
+                legacy_device = await self._legacy_gateway.discover_device(
+                    ip, timeout=effective_timeout
+                )
                 if legacy_device:
                     return legacy_device
 
@@ -136,17 +156,40 @@ class ShellyDeviceGateway(DeviceGateway):
             DeviceStatus with all component data, or None if unreachable
         """
         try:
+            # The device is already known to exist here, so these independent
+            # reads are issued concurrently rather than one round-trip at a time.
+            device_info_res, components_res, status_res, available_methods = (
+                await asyncio.gather(
+                    self._rpc_client.make_rpc_request(
+                        ip, RpcMethods.GET_DEVICE_INFO, timeout=self.timeout
+                    ),
+                    self._rpc_client.make_rpc_request(
+                        ip,
+                        RpcMethods.GET_COMPONENTS,
+                        params={"offset": 0},
+                        timeout=self.timeout,
+                    ),
+                    self._rpc_client.make_rpc_request(
+                        ip, RpcMethods.GET_STATUS, timeout=self.timeout
+                    ),
+                    self.get_available_methods(ip),
+                    return_exceptions=True,
+                )
+            )
+
+            # Authentication failures from components/status must surface to the
+            # caller (preserving the original sequential behaviour).
+            for res in (components_res, status_res):
+                if isinstance(res, DeviceAuthenticationError):
+                    raise res
+
             rpc_success = False
             device_info_data = None
-            try:
-                device_info_response, _ = await self._rpc_client.make_rpc_request(
-                    ip, RpcMethods.GET_DEVICE_INFO, timeout=self.timeout
-                )
-                device_info_data = device_info_response.get(
-                    "result", device_info_response
-                )
+            if isinstance(device_info_res, BaseException):
+                logger.error(f"Error getting device info: {device_info_res}")
+            else:
+                device_info_data = device_info_res[0].get("result", device_info_res[0])
                 rpc_success = True
-
                 if (
                     device_info_data
                     and device_info_data.get("auth_en", False)
@@ -156,37 +199,23 @@ class ShellyDeviceGateway(DeviceGateway):
                     self._rpc_client.auth_state_cache.mark_auth_required(
                         normalize_mac(ip)
                     )
-            except Exception as e:
-                logger.error(f"Error getting device info: {e}", exc_info=True)
 
-            components_data = {}
-            try:
-                components_response, _ = await self._rpc_client.make_rpc_request(
-                    ip,
-                    RpcMethods.GET_COMPONENTS,
-                    params={"offset": 0},
-                    timeout=self.timeout,
-                )
-                components_data = components_response.get("result", components_response)
+            components_data: Any = {}
+            if isinstance(components_res, BaseException):
+                logger.error(f"Error getting components: {components_res}")
+            else:
+                components_data = components_res[0].get("result", components_res[0])
                 rpc_success = True
-            except DeviceAuthenticationError:
-                raise
-            except Exception as e:
-                logger.error(f"Error getting components: {e}", exc_info=True)
 
             status_response = None
-            try:
-                status_response, _ = await self._rpc_client.make_rpc_request(
-                    ip, RpcMethods.GET_STATUS, timeout=self.timeout
-                )
-                status_response = status_response.get("result", status_response)
+            if isinstance(status_res, BaseException):
+                logger.error(f"Error getting device status: {status_res}")
+            else:
+                status_response = status_res[0].get("result", status_res[0])
                 rpc_success = True
-            except DeviceAuthenticationError:
-                raise
-            except Exception as e:
-                logger.error(f"Error getting device status: {e}", exc_info=True)
 
-            available_methods = await self.get_available_methods(ip)
+            if isinstance(available_methods, BaseException):
+                available_methods = []
 
             if not rpc_success:
                 raise RuntimeError("RPC status retrieval failed; use legacy path")

--- a/packages/core/src/core/gateways/network/async_shelly_rpc_client.py
+++ b/packages/core/src/core/gateways/network/async_shelly_rpc_client.py
@@ -10,6 +10,7 @@ from httpx._types import AuthTypes
 from core.domain.entities.exceptions import (
     DeviceAuthenticationError,
     DeviceCommunicationError,
+    DeviceUnreachableError,
 )
 from core.services.auth_state_cache import AuthStateCache
 from core.services.authentication_service import AuthenticationService
@@ -26,20 +27,43 @@ class AsyncShellyRPCClient(RpcNetworkGateway):
     def __init__(
         self,
         session: httpx.AsyncClient | None = None,
-        timeout: int = 3,
+        timeout: float = 3.0,
+        connect_timeout: float = 2.0,
+        max_connections: int | None = None,
         verify: bool | None = None,
         authentication_service: AuthenticationService | None = None,
         auth_state_cache: AuthStateCache | None = None,
     ):
         self.timeout = timeout
-        self._session = session or httpx.AsyncClient(
-            timeout=timeout, verify=True if verify is None else verify
-        )
+        self._connect_timeout = connect_timeout
+        if session is not None:
+            self._session = session
+        else:
+            # Default pool comfortably exceeds the 200 max_workers ceiling so a
+            # high-concurrency scan isn't throttled by httpx's default of 100.
+            pool = max_connections or 256
+            self._session = httpx.AsyncClient(
+                timeout=self._build_timeout(timeout),
+                limits=httpx.Limits(
+                    max_connections=pool,
+                    max_keepalive_connections=max(1, pool // 2),
+                ),
+                verify=True if verify is None else verify,
+            )
         self.authentication_service = authentication_service
         self.auth_state_cache = auth_state_cache
         self._closed = False
         self._ip_to_mac: dict[str, str] = {}
         self._digest_auth_cache: dict[str, ShellyDigestAuth] = {}
+
+    def _build_timeout(self, timeout: float) -> httpx.Timeout:
+        """Build an httpx timeout with a short, capped connect phase.
+
+        A subnet scan is dominated by dead IPs, which block on the TCP
+        connect. Capping ``connect`` lets those fail fast while present
+        devices still get the full ``timeout`` read window.
+        """
+        return httpx.Timeout(timeout, connect=min(timeout, self._connect_timeout))
 
     async def make_rpc_request(
         self,
@@ -200,7 +224,7 @@ class AsyncShellyRPCClient(RpcNetworkGateway):
                 json=payload,
                 headers=headers,
                 auth=auth_param,
-                timeout=timeout,
+                timeout=self._build_timeout(timeout),
             )
             elapsed = time.time() - start_time
             return response, elapsed
@@ -208,6 +232,12 @@ class AsyncShellyRPCClient(RpcNetworkGateway):
             elapsed = time.time() - start_time
             # Extract IP from URL for error context
             ip = url.replace("http://", "").replace("/rpc", "")
+            # Connect-level failures mean nothing is listening at this address.
+            # Flag them so callers can skip the (expensive) legacy fallback probe.
+            # PoolTimeout is deliberately excluded: it signals local pool
+            # exhaustion, not an unreachable host, so it must not skip fallback.
+            if isinstance(e, httpx.ConnectError | httpx.ConnectTimeout):
+                raise DeviceUnreachableError(ip, str(e)) from e
             raise DeviceCommunicationError(ip, str(e)) from e
 
     def _invalidate_auth_cache(self, ip: str) -> None:
@@ -295,7 +325,7 @@ class AsyncShellyRPCClient(RpcNetworkGateway):
             json=payload,
             headers=headers,
             auth=digest_auth,
-            timeout=timeout,
+            timeout=self._build_timeout(timeout),
         )
 
         if response.status_code == 401:
@@ -323,7 +353,9 @@ class AsyncShellyRPCClient(RpcNetworkGateway):
             url = f"http://{ip}/rpc"
             payload = {"id": str(uuid.uuid4()), "method": "Shelly.GetDeviceInfo"}
             logger.debug("Probing MAC address for %s", ip)
-            response = await self._session.post(url, json=payload, timeout=timeout)
+            response = await self._session.post(
+                url, json=payload, timeout=self._build_timeout(timeout)
+            )
 
             if response.status_code == 200:
                 data = response.json()

--- a/packages/core/src/core/gateways/network/legacy_http_client.py
+++ b/packages/core/src/core/gateways/network/legacy_http_client.py
@@ -1,7 +1,6 @@
-import asyncio
 from typing import Any, cast
 
-import requests
+import httpx
 
 from core.domain.entities.exceptions import DeviceAuthenticationError
 
@@ -10,45 +9,42 @@ class LegacyHttpClient:
     """HTTP client for legacy Gen1 Shelly devices using simple HTTP GET requests."""
 
     def __init__(
-        self, session: requests.Session | None = None, timeout: float = 10.0
+        self,
+        session: httpx.AsyncClient | None = None,
+        timeout: float = 10.0,
+        connect_timeout: float = 2.0,
+        max_connections: int | None = None,
     ) -> None:
         self.timeout = timeout
-        self._session = session or requests.Session()
+        self._connect_timeout = connect_timeout
+        if session is not None:
+            self._session = session
+        else:
+            pool = max_connections or 256
+            self._session = httpx.AsyncClient(
+                timeout=self._build_timeout(timeout),
+                limits=httpx.Limits(
+                    max_connections=pool,
+                    max_keepalive_connections=max(1, pool // 2),
+                ),
+            )
+
+    def _build_timeout(self, timeout: float | None) -> httpx.Timeout:
+        """Build an httpx timeout with a short, capped connect phase."""
+        effective = self.timeout if timeout is None else timeout
+        return httpx.Timeout(effective, connect=min(effective, self._connect_timeout))
 
     async def fetch_json(
-        self, ip: str, endpoint: str, auth: tuple[str, str] | None = None
-    ) -> dict[str, Any]:
-        loop = asyncio.get_event_loop()
-        return await loop.run_in_executor(
-            None, self._sync_fetch_json, ip, endpoint, auth
-        )
-
-    async def fetch_json_optional(
-        self, ip: str, endpoint: str, auth: tuple[str, str] | None = None
-    ) -> dict[str, Any]:
-        try:
-            return await self.fetch_json(ip, endpoint, auth=auth)
-        except Exception:
-            return {}
-
-    async def get_with_params(
         self,
         ip: str,
         endpoint: str,
-        params: dict[str, Any],
         auth: tuple[str, str] | None = None,
-    ) -> dict[str, Any]:
-        loop = asyncio.get_event_loop()
-
-        return await loop.run_in_executor(
-            None, self._sync_get_with_params, ip, endpoint, params, auth
-        )
-
-    def _sync_fetch_json(
-        self, ip: str, endpoint: str, auth: tuple[str, str] | None = None
+        timeout: float | None = None,
     ) -> dict[str, Any]:
         url = f"http://{ip}/{endpoint.lstrip('/')}"
-        response = self._session.get(url, timeout=self.timeout, auth=auth)
+        response = await self._session.get(
+            url, timeout=self._build_timeout(timeout), auth=auth
+        )
         if response.status_code == 401:
             raise DeviceAuthenticationError(ip)
         response.raise_for_status()
@@ -59,16 +55,29 @@ class LegacyHttpClient:
 
         return cast(dict[str, Any], data)
 
-    def _sync_get_with_params(
+    async def fetch_json_optional(
+        self,
+        ip: str,
+        endpoint: str,
+        auth: tuple[str, str] | None = None,
+        timeout: float | None = None,
+    ) -> dict[str, Any]:
+        try:
+            return await self.fetch_json(ip, endpoint, auth=auth, timeout=timeout)
+        except Exception:
+            return {}
+
+    async def get_with_params(
         self,
         ip: str,
         endpoint: str,
         params: dict[str, Any],
         auth: tuple[str, str] | None = None,
+        timeout: float | None = None,
     ) -> dict[str, Any]:
         url = f"http://{ip}/{endpoint.lstrip('/')}"
-        response = self._session.get(
-            url, params=params, timeout=self.timeout, auth=auth
+        response = await self._session.get(
+            url, params=params, timeout=self._build_timeout(timeout), auth=auth
         )
         if response.status_code == 401:
             raise DeviceAuthenticationError(ip)
@@ -86,5 +95,4 @@ class LegacyHttpClient:
             return {"response": response.text}
 
     async def close(self) -> None:
-        loop = asyncio.get_event_loop()
-        await loop.run_in_executor(None, self._session.close)
+        await self._session.aclose()

--- a/packages/core/src/core/settings.py
+++ b/packages/core/src/core/settings.py
@@ -48,7 +48,13 @@ class NetworkSettings(BaseSettings):
     model_config = SettingsConfigDict(env_prefix="NETWORK_")
 
     timeout: float = Field(
-        default=3.0, ge=0.1, le=30.0, description="Default timeout in seconds"
+        default=3.0, ge=0.1, le=30.0, description="Default (read) timeout in seconds"
+    )
+    connect_timeout: float = Field(
+        default=2.0,
+        ge=0.1,
+        le=30.0,
+        description="TCP connect timeout in seconds; fast-fails unreachable hosts",
     )
     max_workers: int = Field(
         default=50, ge=1, le=200, description="Maximum concurrent workers"

--- a/packages/core/src/core/use_cases/scan_devices.py
+++ b/packages/core/src/core/use_cases/scan_devices.py
@@ -100,7 +100,7 @@ class ScanDevicesUseCase:
         self, ip: str, timeout: float = 3.0
     ) -> DiscoveredDevice | None:
         try:
-            device = await self._device_gateway.discover_device(ip)
+            device = await self._device_gateway.discover_device(ip, timeout=timeout)
 
             if device:
                 self._validate_discovered_device(device)

--- a/packages/core/tests/unit/gateways/device/test_shelly_device_gateway.py
+++ b/packages/core/tests/unit/gateways/device/test_shelly_device_gateway.py
@@ -4,7 +4,10 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 from core.domain.entities.device_status import DeviceStatus
 from core.domain.entities.discovered_device import DiscoveredDevice
-from core.domain.entities.exceptions import DeviceAuthenticationError
+from core.domain.entities.exceptions import (
+    DeviceAuthenticationError,
+    DeviceUnreachableError,
+)
 from core.domain.enums.enums import Status
 from core.gateways.device.legacy_device_gateway import LegacyDeviceGateway
 from core.gateways.device.shelly_device_gateway import ShellyDeviceGateway
@@ -122,7 +125,38 @@ class TestShellyDeviceGateway:
         result = await gateway.discover_device("192.168.1.200")
 
         assert result is legacy_device
-        mock_legacy_gateway.discover_device.assert_awaited_once_with("192.168.1.200")
+        mock_legacy_gateway.discover_device.assert_awaited_once_with(
+            "192.168.1.200", timeout=10.0
+        )
+
+    async def test_it_skips_legacy_fallback_when_host_unreachable(
+        self, gateway, mock_rpc_client, mock_legacy_gateway
+    ):
+        mock_rpc_client.make_rpc_request = AsyncMock(
+            side_effect=DeviceUnreachableError("192.168.1.250", "connect timeout")
+        )
+
+        result = await gateway.discover_device("192.168.1.250")
+
+        assert result is not None
+        assert result.status == Status.UNREACHABLE
+        mock_legacy_gateway.discover_device.assert_not_called()
+
+    async def test_it_forwards_timeout_to_rpc_and_legacy(
+        self, gateway, mock_rpc_client, mock_legacy_gateway
+    ):
+        mock_rpc_client.make_rpc_request = AsyncMock(side_effect=Exception("RPC fail"))
+        mock_legacy_gateway.discover_device.return_value = None
+
+        await gateway.discover_device("192.168.1.42", timeout=2.5)
+
+        assert mock_rpc_client.make_rpc_request.call_args_list[0] == (
+            ("192.168.1.42", "Shelly.GetDeviceInfo"),
+            {"timeout": 2.5},
+        )
+        mock_legacy_gateway.discover_device.assert_awaited_once_with(
+            "192.168.1.42", timeout=2.5
+        )
 
     async def test_it_gets_device_status_with_updates(self, gateway, mock_rpc_client):
         components_data = {

--- a/packages/core/tests/unit/gateways/network/test_async_shelly_rpc_client.py
+++ b/packages/core/tests/unit/gateways/network/test_async_shelly_rpc_client.py
@@ -6,6 +6,7 @@ import pytest
 from core.domain.entities.exceptions import (
     DeviceAuthenticationError,
     DeviceCommunicationError,
+    DeviceUnreachableError,
 )
 from core.gateways.network.async_shelly_rpc_client import AsyncShellyRPCClient
 
@@ -208,7 +209,16 @@ class TestAsyncShellyRPCClient:
     async def test_it_handles_pool_timeout(self, client, mock_session):
         mock_session.post.side_effect = httpx.PoolTimeout("Pool timeout")
 
-        with pytest.raises(DeviceCommunicationError, match="Pool timeout"):
+        # Pool exhaustion is a local condition, not an unreachable host: it must
+        # NOT be classified as DeviceUnreachableError (which would skip fallback).
+        with pytest.raises(DeviceCommunicationError, match="Pool timeout") as exc_info:
+            await client.make_rpc_request("192.168.1.100", "Shelly.GetDeviceInfo")
+        assert not isinstance(exc_info.value, DeviceUnreachableError)
+
+    async def test_it_flags_connect_errors_as_unreachable(self, client, mock_session):
+        mock_session.post.side_effect = httpx.ConnectTimeout("Connect timeout")
+
+        with pytest.raises(DeviceUnreachableError):
             await client.make_rpc_request("192.168.1.100", "Shelly.GetDeviceInfo")
 
     async def test_it_creates_timeout_correctly(self, client, mock_session):
@@ -221,7 +231,10 @@ class TestAsyncShellyRPCClient:
 
         call_args = mock_session.post.call_args
         timeout_arg = call_args[1]["timeout"]
-        assert timeout_arg == 10
+        # Per-request read timeout is honored; connect is capped for fast dead-IP reject.
+        assert isinstance(timeout_arg, httpx.Timeout)
+        assert timeout_arg.read == 10
+        assert timeout_arg.connect == 2.0
 
     async def test_it_uses_default_timeout_when_none_provided(
         self, client, mock_session
@@ -235,4 +248,6 @@ class TestAsyncShellyRPCClient:
 
         call_args = mock_session.post.call_args
         timeout_arg = call_args[1]["timeout"]
-        assert timeout_arg == 3.0
+        assert isinstance(timeout_arg, httpx.Timeout)
+        assert timeout_arg.read == 3.0
+        assert timeout_arg.connect == 2.0

--- a/packages/core/tests/unit/gateways/network/test_legacy_http_client.py
+++ b/packages/core/tests/unit/gateways/network/test_legacy_http_client.py
@@ -1,23 +1,29 @@
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock
 
+import httpx
 import pytest
-import requests
 from core.gateways.network.legacy_http_client import LegacyHttpClient
+
+
+def _ok_response(data) -> MagicMock:
+    resp = MagicMock()
+    resp.status_code = 200
+    resp.json.return_value = data
+    return resp
 
 
 class TestLegacyHttpClient:
 
     @pytest.fixture
     def mock_session(self):
-        return MagicMock(spec=requests.Session)
+        session = MagicMock()
+        session.get = AsyncMock()
+        session.aclose = AsyncMock()
+        return session
 
     @pytest.fixture
     def client(self, mock_session):
         return LegacyHttpClient(session=mock_session, timeout=1.0)
-
-    @pytest.fixture
-    def client_with_default_session(self):
-        return LegacyHttpClient()
 
     async def test_it_creates_client_with_custom_session(self, mock_session):
         client = LegacyHttpClient(session=mock_session, timeout=2.0)
@@ -28,82 +34,77 @@ class TestLegacyHttpClient:
     async def test_it_creates_client_with_default_session(self):
         client = LegacyHttpClient(timeout=3.0)
 
-        assert isinstance(client._session, requests.Session)
+        assert isinstance(client._session, httpx.AsyncClient)
         assert client.timeout == 3.0
 
     async def test_it_fetches_json_successfully(self, client, mock_session):
-        mock_response = MagicMock()
-        mock_response.status_code = 200
-        mock_response.json.return_value = {"key": "value"}
-        mock_session.get.return_value = mock_response
+        mock_session.get.return_value = _ok_response({"key": "value"})
 
         result = await client.fetch_json("192.168.1.100", "status")
 
         assert result == {"key": "value"}
-        mock_session.get.assert_called_once()
+        mock_session.get.assert_awaited_once()
         call_args = mock_session.get.call_args
         assert call_args[0][0] == "http://192.168.1.100/status"
+
+    async def test_it_caps_connect_timeout(self, client, mock_session):
+        mock_session.get.return_value = _ok_response({})
+
+        await client.fetch_json("192.168.1.100", "status", timeout=5.0)
+
+        timeout_arg = mock_session.get.call_args[1]["timeout"]
+        assert isinstance(timeout_arg, httpx.Timeout)
+        assert timeout_arg.read == 5.0
+        assert timeout_arg.connect == 2.0
 
     async def test_it_handles_http_error_in_fetch_json(self, client, mock_session):
         mock_response = MagicMock()
         mock_response.status_code = 404
-        mock_response.raise_for_status.side_effect = requests.exceptions.HTTPError(
-            "404 Client Error"
+        mock_response.raise_for_status.side_effect = httpx.HTTPStatusError(
+            "404 Client Error", request=MagicMock(), response=MagicMock()
         )
         mock_session.get.return_value = mock_response
 
-        with pytest.raises(requests.exceptions.HTTPError):
+        with pytest.raises(httpx.HTTPStatusError):
             await client.fetch_json("192.168.1.100", "status")
 
     async def test_it_handles_non_dict_json_response(self, client, mock_session):
-        mock_response = MagicMock()
-        mock_response.status_code = 200
-        mock_response.json.return_value = ["list", "is", "not", "dict"]
-        mock_session.get.return_value = mock_response
+        mock_session.get.return_value = _ok_response(["list", "is", "not", "dict"])
 
         with pytest.raises(ValueError, match="did not return JSON object"):
             await client.fetch_json("192.168.1.100", "status")
 
     async def test_it_fetches_json_optional_success(self, client, mock_session):
-        mock_response = MagicMock()
-        mock_response.status_code = 200
-        mock_response.json.return_value = {"key": "value"}
-        mock_session.get.return_value = mock_response
+        mock_session.get.return_value = _ok_response({"key": "value"})
 
         result = await client.fetch_json_optional("192.168.1.100", "settings")
 
         assert result == {"key": "value"}
 
     async def test_it_fetches_json_optional_failure(self, client, mock_session):
-        mock_session.get.side_effect = requests.exceptions.ConnectionError
+        mock_session.get.side_effect = httpx.ConnectError("boom")
 
         result = await client.fetch_json_optional("192.168.1.100", "settings")
 
         assert result == {}
 
     async def test_it_gets_with_params_successfully(self, client, mock_session):
-        mock_response = MagicMock()
-        mock_response.status_code = 200
-        mock_response.json.return_value = {"success": True}
-        mock_session.get.return_value = mock_response
+        mock_session.get.return_value = _ok_response({"success": True})
 
         params = {"turn": "on"}
         result = await client.get_with_params("192.168.1.100", "relay/0", params)
 
         assert result == {"success": True}
-        mock_session.get.assert_called_once()
+        mock_session.get.assert_awaited_once()
         call_args = mock_session.get.call_args
         assert call_args[1]["params"] == params
 
     async def test_it_handles_value_error_in_get_with_params(
         self, client, mock_session
     ):
-        mock_response = MagicMock()
-        mock_response.status_code = 200
-        # Simulate invalid JSON or non-dict response that raises ValueError in logic
-        mock_response.json.return_value = "not a dict"
-        mock_session.get.return_value = mock_response
+        mock_response = _ok_response("not a dict")
         mock_response.text = "raw response text"
+        mock_session.get.return_value = mock_response
 
         result = await client.get_with_params("192.168.1.100", "relay/0", {})
 
@@ -111,18 +112,4 @@ class TestLegacyHttpClient:
 
     async def test_it_closes_session(self, client, mock_session):
         await client.close()
-        mock_session.close.assert_called_once()
-
-    async def test_it_runs_in_executor(self, client, mock_session):
-        mock_response = MagicMock()
-        mock_response.status_code = 200
-        mock_response.json.return_value = {}
-        mock_session.get.return_value = mock_response
-
-        with patch("asyncio.get_event_loop") as mock_loop:
-            mock_executor = AsyncMock(return_value={})
-            mock_loop.return_value.run_in_executor = mock_executor
-
-            await client.fetch_json("192.168.1.100", "status")
-
-            mock_executor.assert_called_once()
+        mock_session.aclose.assert_awaited_once()

--- a/packages/core/tests/unit/gateways/network/test_legacy_http_client_auth.py
+++ b/packages/core/tests/unit/gateways/network/test_legacy_http_client_auth.py
@@ -1,7 +1,6 @@
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
-import requests
 from core.domain.entities.exceptions import DeviceAuthenticationError
 from core.gateways.network.legacy_http_client import LegacyHttpClient
 
@@ -10,7 +9,10 @@ class TestLegacyHttpClientAuth:
 
     @pytest.fixture
     def mock_session(self):
-        return MagicMock(spec=requests.Session)
+        session = MagicMock()
+        session.get = AsyncMock()
+        session.aclose = AsyncMock()
+        return session
 
     @pytest.fixture
     def client(self, mock_session):

--- a/packages/core/tests/unit/use_cases/test_scan_devices.py
+++ b/packages/core/tests/unit/use_cases/test_scan_devices.py
@@ -120,6 +120,23 @@ class TestScanDevicesUseCase:
 
         assert mock_device_gateway.discover_device.call_count == 100
 
+    async def test_it_forwards_request_timeout_to_gateway(
+        self, use_case, mock_device_gateway
+    ):
+        request = ScanRequest(
+            targets=["192.168.1.5"],
+            use_mdns=False,
+            timeout=1.5,
+            max_workers=10,
+        )
+        mock_device_gateway.discover_device = AsyncMock(return_value=None)
+
+        await use_case.execute(request)
+
+        mock_device_gateway.discover_device.assert_awaited_once_with(
+            "192.168.1.5", timeout=1.5
+        )
+
     @pytest.fixture
     def mock_mdns_client(self):
         return AsyncMock(spec=MDNSGateway)


### PR DESCRIPTION
## Purpose

Make network scans fast: a subnet scan that took minutes now finishes in seconds.

## Context

Scans were dominated by dead IPs: the caller's per-scan `timeout` was silently dropped (every probe used the gateway's 10s default), and each unreachable address paid that timeout twice, once for the RPC probe, again for the legacy HTTP fallback. This threads the timeout through, fails dead IPs fast with a short capped connect timeout, skips the legacy fallback for hosts that never accept a TCP connection (safe: a real Gen1 device still completes the handshake), and moves the legacy client onto httpx with its pools closed on container shutdown.
