### PR TITLE
Capture Gen1 device backups without RPC

### DIFF
--- a/packages/core/src/core/gateways/device/device.py
+++ b/packages/core/src/core/gateways/device/device.py
@@ -29,6 +29,11 @@ class DeviceGateway(ABC):
         """Get available RPC methods for action validation."""
         pass
 
+    async def get_legacy_settings(self, ip: str) -> dict[str, Any] | None:
+        """Raw Gen1 ``/settings`` payload; ``None`` unless the gateway speaks the
+        legacy HTTP path."""
+        return None
+
     @abstractmethod
     async def execute_component_action(
         self,

--- a/packages/core/src/core/gateways/device/legacy_component_mapper.py
+++ b/packages/core/src/core/gateways/device/legacy_component_mapper.py
@@ -241,8 +241,8 @@ class LegacyComponentMapper:
                     },
                     "config": {
                         "name": config.get("name"),
-                        "auto_on": config.get("auto_on", False),
-                        "auto_off": config.get("auto_off", False),
+                        **self._map_auto_timer(config, "auto_on"),
+                        **self._map_auto_timer(config, "auto_off"),
                         "power_limit": config.get(
                             "power_limit", config.get("max_power", 0.0)
                         ),
@@ -258,6 +258,19 @@ class LegacyComponentMapper:
                 }
             )
         return components
+
+    def _map_auto_timer(self, config: dict[str, Any], key: str) -> dict[str, Any]:
+        """Translate a Gen1 auto-timer (``auto_on``/``auto_off`` in seconds, ``0``
+        = off) into the ``bool`` flag + ``<key>_delay`` shape ``SwitchComponent``
+        requires. Passing the raw seconds into the bool field raised a
+        ``ValidationError`` for any real timer value, so it is healed here.
+        """
+        value = config.get(key)
+        if isinstance(value, bool):
+            return {key: value}
+        if isinstance(value, int | float):
+            return {key: value > 0, f"{key}_delay": float(value)}
+        return {key: False}
 
     def _build_cover_components(
         self, status: dict[str, Any], settings: dict[str, Any]

--- a/packages/core/src/core/gateways/device/legacy_device_gateway.py
+++ b/packages/core/src/core/gateways/device/legacy_device_gateway.py
@@ -242,6 +242,20 @@ class LegacyDeviceGateway:
             status_data=None,
         )
 
+    async def fetch_settings(
+        self, ip: str, timeout: float | None = None
+    ) -> dict[str, Any] | None:
+        """Fetch the raw Gen1 ``/settings`` payload for backup capture.
+
+        Returns ``None`` on any failure, including an empty payload, so the
+        export stays non-fatal when a device drops mid-capture.
+        """
+        auth = await self._resolve_auth(ip, timeout)
+        settings = await self._http_client.fetch_json_optional(
+            ip, "settings", auth=auth, timeout=timeout
+        )
+        return settings or None
+
     async def execute_action(
         self,
         ip: str,

--- a/packages/core/src/core/gateways/device/shelly_device_gateway.py
+++ b/packages/core/src/core/gateways/device/shelly_device_gateway.py
@@ -44,6 +44,11 @@ class ShellyDeviceGateway(DeviceGateway):
         if self._legacy_gateway:
             self._legacy_gateway.invalidate_credential_cache(mac)
 
+    async def get_legacy_settings(self, ip: str) -> dict[str, Any] | None:
+        if self._legacy_gateway:
+            return await self._legacy_gateway.fetch_settings(ip)
+        return None
+
     async def discover_device(
         self, ip: str, timeout: float | None = None
     ) -> DiscoveredDevice | None:

--- a/packages/core/src/core/use_cases/bulk_operations.py
+++ b/packages/core/src/core/use_cases/bulk_operations.py
@@ -143,6 +143,15 @@ class BulkOperationsUseCase:
                 "components": {},
             }
 
+            # Gen1 has no /rpc: GetConfig and Schedule.List 404, so capture from
+            # the configs already mapped onto the DeviceStatus instead.
+            if device_status.gen == 1:
+                await self._export_gen1_config(
+                    device_ip, device_status, component_types, device_data
+                )
+                result["devices"][device_ip] = device_data
+                continue
+
             for component in device_status.components:
                 if component.component_type in component_types:
 
@@ -175,6 +184,37 @@ class BulkOperationsUseCase:
             result["devices"][device_ip] = device_data
 
         return result
+
+    async def _export_gen1_config(
+        self,
+        device_ip: str,
+        device_status: DeviceStatus,
+        component_types: list[str],
+        device_data: dict[str, Any],
+    ) -> None:
+        """Capture Gen1 component configs plus the raw ``/settings``.
+
+        The ``legacy_settings`` entry is the source of truth a Gen1 restore
+        replays; it is omitted when the raw fetch fails, and the mapped configs
+        alone still make the backup valid.
+        """
+        for component in device_status.components:
+            if component.component_type in component_types:
+                device_data["components"][component.key] = {
+                    "type": component.component_type,
+                    "success": True,
+                    "config": component.config,
+                    "error": None,
+                }
+
+        legacy_settings = await self._device_gateway.get_legacy_settings(device_ip)
+        if legacy_settings is not None:
+            device_data["components"]["legacy_settings"] = {
+                "type": "legacy_settings",
+                "success": True,
+                "config": legacy_settings,
+                "error": None,
+            }
 
     async def _fetch_script_code(
         self, device_ip: str, component_key: str

--- a/packages/core/tests/unit/gateways/device/test_legacy_component_mapper.py
+++ b/packages/core/tests/unit/gateways/device/test_legacy_component_mapper.py
@@ -1,0 +1,102 @@
+import pytest
+from core.domain.entities.components import SwitchComponent
+from core.gateways.device.legacy_component_mapper import LegacyComponentMapper
+from pydantic import ValidationError
+
+
+@pytest.fixture
+def mapper():
+    return LegacyComponentMapper()
+
+
+def _switch_config(mapper, relay_settings):
+    """Map a single-relay Gen1 device and return its switch:0 config."""
+    components = mapper.map(
+        {"mac": "AABBCCDDEEFF", "type": "SHSW-1"},
+        {"relays": [{"ison": False}]},
+        {"relays": [relay_settings]},
+    )
+    switch = next(c for c in components if c["key"] == "switch:0")
+    return switch["config"]
+
+
+class TestLegacyAutoTimerMapping:
+    @pytest.mark.parametrize(
+        "value, expected_flag, expected_delay",
+        [
+            (0, False, 0.0),
+            (0.5, True, 0.5),
+            (30, True, 30.0),
+            (True, True, None),
+        ],
+    )
+    def test_it_maps_auto_off_seconds_to_flag_and_delay(
+        self, mapper, value, expected_flag, expected_delay
+    ):
+        config = _switch_config(mapper, {"auto_off": value})
+
+        assert config["auto_off"] is expected_flag
+        if expected_delay is None:
+            assert "auto_off_delay" not in config
+        else:
+            assert config["auto_off_delay"] == expected_delay
+
+    @pytest.mark.parametrize(
+        "value, expected_flag, expected_delay",
+        [
+            (0, False, 0.0),
+            (30, True, 30.0),
+            (True, True, None),
+        ],
+    )
+    def test_it_maps_auto_on_seconds_to_flag_and_delay(
+        self, mapper, value, expected_flag, expected_delay
+    ):
+        config = _switch_config(mapper, {"auto_on": value})
+
+        assert config["auto_on"] is expected_flag
+        if expected_delay is None:
+            assert "auto_on_delay" not in config
+        else:
+            assert config["auto_on_delay"] == expected_delay
+
+    def test_it_defaults_missing_auto_timer_to_false_without_delay(self, mapper):
+        config = _switch_config(mapper, {})
+
+        assert config["auto_on"] is False
+        assert config["auto_off"] is False
+        assert "auto_on_delay" not in config
+        assert "auto_off_delay" not in config
+
+    def test_it_treats_garbage_auto_timer_as_disabled(self, mapper):
+        config = _switch_config(mapper, {"auto_on": "nonsense", "auto_off": None})
+
+        assert config["auto_on"] is False
+        assert config["auto_off"] is False
+        assert "auto_on_delay" not in config
+        assert "auto_off_delay" not in config
+
+
+class TestSwitchComponentAcceptsMappedGen1Relay:
+    def test_switch_component_accepts_mapped_relay_with_timer(self, mapper):
+        components = mapper.map(
+            {"mac": "AABBCCDDEEFF", "type": "SHSW-1"},
+            {"relays": [{"ison": True}]},
+            {"relays": [{"auto_off": 0.5, "auto_on": 30}]},
+        )
+        mapped_switch = next(c for c in components if c["key"] == "switch:0")
+
+        component = SwitchComponent.from_raw_data(mapped_switch)
+
+        assert component.auto_off is True
+        assert component.auto_on is True
+        # Delays live on the raw config dict, not as SwitchComponent fields.
+        assert component.config["auto_off_delay"] == 0.5
+        assert component.config["auto_on_delay"] == 30.0
+
+    def test_raw_numeric_seconds_still_raise_at_the_component(self):
+        # The component stays strict on purpose; only the mapper heals raw seconds.
+        with pytest.raises(ValidationError):
+            SwitchComponent.from_raw_data(
+                {"key": "switch:0", "status": {}, "config": {"auto_off": 0.5}}
+            )

--- a/packages/core/tests/unit/use_cases/test_backup_device_config.py
+++ b/packages/core/tests/unit/use_cases/test_backup_device_config.py
@@ -42,6 +42,34 @@ def _export(ip="192.168.1.100"):
     }
 
 
+def _gen1_export(ip="192.168.1.100"):
+    return {
+        "devices": {
+            ip: {
+                "device_info": {"mac_address": "AABBCCDDEEFF"},
+                "components": {
+                    "switch:0": {
+                        "type": "switch",
+                        "success": True,
+                        "config": {
+                            "name": "Relay",
+                            "auto_off": True,
+                            "auto_off_delay": 30.0,
+                        },
+                        "error": None,
+                    },
+                    "legacy_settings": {
+                        "type": "legacy_settings",
+                        "success": True,
+                        "config": {"relays": [{"auto_off": 30}]},
+                        "error": None,
+                    },
+                },
+            }
+        }
+    }
+
+
 class TestBackupDeviceConfig:
     @pytest.fixture
     def mock_repository(self):
@@ -92,6 +120,21 @@ class TestBackupDeviceConfig:
         backup = await use_case.create_backup("192.168.1.100")
 
         assert backup.generation == "gen1"
+
+    async def test_it_creates_gen1_backup_capturing_legacy_settings(
+        self, use_case, mock_device_gateway, mock_bulk_operations, mock_repository
+    ):
+        mock_device_gateway.get_device_status = AsyncMock(return_value=_status(gen=1))
+        mock_bulk_operations.export_bulk_config = AsyncMock(return_value=_gen1_export())
+        mock_repository.create = AsyncMock(side_effect=lambda backup: backup)
+
+        backup = await use_case.create_backup("192.168.1.100")
+
+        assert backup.generation == "gen1"
+        components = backup.snapshot["components"]
+        assert "legacy_settings" in components
+        assert components["legacy_settings"]["config"] == {"relays": [{"auto_off": 30}]}
+        mock_repository.create.assert_awaited_once()
 
     async def test_it_raises_when_generation_unknown(
         self, use_case, mock_device_gateway

--- a/packages/core/tests/unit/use_cases/test_bulk_operations.py
+++ b/packages/core/tests/unit/use_cases/test_bulk_operations.py
@@ -653,6 +653,102 @@ class TestBulkOperationsUseCase:
         assert device_data["components"]["schedules"]["config"]["jobs"] is not None
         assert len(device_data["components"]["schedules"]["config"]["jobs"]) == 1
 
+    @pytest.fixture
+    def gen1_device_status(self):
+        return DeviceStatus(
+            device_ip="192.168.1.100",
+            device_name="Gen1 Relay",
+            device_type="SHSW-1",
+            firmware_version="20230913-112003/v1.14.0",
+            mac_address="AABBCCDDEEFF",
+            app_name="switch",
+            gen=1,
+            components=[
+                SwitchComponent(
+                    key="switch:0",
+                    component_type="switch",
+                    status={"output": False},
+                    config={
+                        "name": "Relay",
+                        "auto_off": True,
+                        "auto_off_delay": 30.0,
+                    },
+                    attrs={},
+                ),
+                SystemComponent(
+                    key="sys",
+                    component_type="sys",
+                    status={},
+                    config={"device": {"name": "Gen1 Relay"}},
+                    attrs={},
+                ),
+            ],
+        )
+
+    async def test_it_exports_gen1_config_from_mapped_components_without_rpc(
+        self, use_case, mock_device_gateway, gen1_device_status
+    ):
+        mock_device_gateway.get_device_status = AsyncMock(
+            return_value=gen1_device_status
+        )
+        mock_device_gateway.execute_component_action = AsyncMock()
+        raw_settings = {"relays": [{"auto_off": 30}], "name": "Gen1 Relay"}
+        mock_device_gateway.get_legacy_settings = AsyncMock(return_value=raw_settings)
+
+        result = await use_case.export_bulk_config(
+            ["192.168.1.100"], ["switch", "sys", "schedules"]
+        )
+
+        mock_device_gateway.execute_component_action.assert_not_called()
+
+        components = result["devices"]["192.168.1.100"]["components"]
+        assert components["switch:0"]["success"] is True
+        assert components["switch:0"]["error"] is None
+        assert components["switch:0"]["config"] == {
+            "name": "Relay",
+            "auto_off": True,
+            "auto_off_delay": 30.0,
+        }
+        assert components["sys"]["success"] is True
+
+        assert components["legacy_settings"]["type"] == "legacy_settings"
+        assert components["legacy_settings"]["success"] is True
+        assert components["legacy_settings"]["config"] == raw_settings
+        mock_device_gateway.get_legacy_settings.assert_awaited_once_with(
+            "192.168.1.100"
+        )
+
+    async def test_it_omits_legacy_settings_when_raw_fetch_fails(
+        self, use_case, mock_device_gateway, gen1_device_status
+    ):
+        mock_device_gateway.get_device_status = AsyncMock(
+            return_value=gen1_device_status
+        )
+        mock_device_gateway.execute_component_action = AsyncMock()
+        mock_device_gateway.get_legacy_settings = AsyncMock(return_value=None)
+
+        result = await use_case.export_bulk_config(["192.168.1.100"], ["switch"])
+
+        components = result["devices"]["192.168.1.100"]["components"]
+        assert "legacy_settings" not in components
+        assert components["switch:0"]["success"] is True
+        mock_device_gateway.execute_component_action.assert_not_called()
+
+    async def test_it_filters_gen1_components_by_requested_type(
+        self, use_case, mock_device_gateway, gen1_device_status
+    ):
+        mock_device_gateway.get_device_status = AsyncMock(
+            return_value=gen1_device_status
+        )
+        mock_device_gateway.execute_component_action = AsyncMock()
+        mock_device_gateway.get_legacy_settings = AsyncMock(return_value=None)
+
+        result = await use_case.export_bulk_config(["192.168.1.100"], ["switch"])
+
+        components = result["devices"]["192.168.1.100"]["components"]
+        assert "switch:0" in components
+        assert "sys" not in components
+
     async def test_it_applies_bulk_config_successfully(
         self, use_case, mock_device_gateway
     ):


### PR DESCRIPTION
## Purpose

Make Gen1 device backups work 

## Context

Gen1 devices are HTTP-only, but the backup export spoke RPC exclusively (`GetConfig`/`Schedule.List`), so every Gen1 capture 404'd and aborted with "No restorable configuration captured". 
Separately, the legacy mapper fed Gen1's numeric `auto_on`/`auto_off` seconds straight into `SwitchComponent`'s bool fields, raising a `ValidationError` that also broke the device page and status API for any Gen1 device with an auto-timer. 

Fixes #51.
