### PR TITLE
Restore Gen1 device configuration from backups

### DIFF
--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -107,11 +107,14 @@ Restore is per-component and **excludes network components (`wifi`/`eth`/`mqtt`/
 by default** to avoid locking the device off-network; pass their keys in `component_keys` to
 include them.
 
-Gen1 devices restore too, by replaying the raw `/settings` captured in the snapshot over the
-legacy HTTP endpoints. Two caveats: secrets are never echoed by Gen1 (`GET /settings` omits the
-WiFi password and `mqtt_pass`), so a `wifi`/`mqtt` restore re-applies everything *except* the
-password; and device auth (`/settings/login`) and Gen1 `actions` are not restored. A backup and
-a target of different generations are refused. See the core README for the full list.
+Gen1 relay/roller/plug/i3 devices restore too, by replaying the raw `/settings` captured in the
+snapshot over the legacy HTTP endpoints, including the device mode (relay/roller), which is
+applied first and **reboots the device** when it differs from the backup. Caveats: secrets are
+never echoed by Gen1 (`GET /settings` omits the WiFi STA password and `mqtt_pass`), so a
+`wifi`/`mqtt` restore re-applies everything *except* the password; device auth
+(`/settings/login`), Gen1 `actions` and light-device (`Dimmer`/`Bulb`/`RGBW2`) configs are not
+restored. A backup and a target of different generations are refused. See the core README for
+the full list.
 
 ### Scheduled Backups
 

--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -105,8 +105,13 @@ DELETE /api/backups/{id}           # Delete a backup
 
 Restore is per-component and **excludes network components (`wifi`/`eth`/`mqtt`/`ws`/`cloud`)
 by default** to avoid locking the device off-network; pass their keys in `component_keys` to
-include them. Restore is supported on Gen2+ devices only (Gen1 devices back up but cannot be
-restored per-component).
+include them.
+
+Gen1 devices restore too, by replaying the raw `/settings` captured in the snapshot over the
+legacy HTTP endpoints. Two caveats: secrets are never echoed by Gen1 (`GET /settings` omits the
+WiFi password and `mqtt_pass`), so a `wifi`/`mqtt` restore re-applies everything *except* the
+password; and device auth (`/settings/login`) and Gen1 `actions` are not restored. A backup and
+a target of different generations are refused. See the core README for the full list.
 
 ### Scheduled Backups
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -230,7 +230,9 @@ shelly-manager backup delete 1
 
 > **Backup/restore vs. `bulk config`:** use backup/restore to recover a single device from its
 > own snapshot. Use `bulk config apply` to push the same settings out to many devices at once.
-> Restore works on Gen2+ devices only.
+> Restore works on Gen1 and Gen2+ devices, but the backup and the target must be the same
+> generation. On Gen1, secrets never leave the device in a backup, so restoring `wifi` or `mqtt`
+> re-applies everything except the password.
 
 ### Scheduled Backups
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -232,7 +232,8 @@ shelly-manager backup delete 1
 > own snapshot. Use `bulk config apply` to push the same settings out to many devices at once.
 > Restore works on Gen1 and Gen2+ devices, but the backup and the target must be the same
 > generation. On Gen1, secrets never leave the device in a backup, so restoring `wifi` or `mqtt`
-> re-applies everything except the password.
+> re-applies everything except the password. A Gen1 backup taken in a different device mode
+> (relay/roller) applies the mode first, which reboots the device mid-restore.
 
 ### Scheduled Backups
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -65,7 +65,9 @@ The core package provides per-device configuration backup and restore:
 - **RestoreDeviceConfig** - Applies a stored snapshot back to a device, per component key. The
   target MAC is validated against the backup; network components (`wifi`/`eth`/`mqtt`/`ws`/
   `cloud`) are excluded by default to avoid lockout; read-only fields are stripped before each
-  `SetConfig`. Restore is supported on Gen2+ devices only.
+  `SetConfig`. Gen1 devices restore through their legacy HTTP settings endpoints instead
+  (`Legacy.SetConfig`), replaying the raw `/settings` captured in the snapshot — see
+  [Gen1 restore](#gen1-restore). A backup and a target of different generations are refused.
 
 Backups are persisted through the `BackupRepository` abstraction
 (`repositories/backup_repository.py`), implemented by `SQLAlchemyBackupRepository`, with the
@@ -79,6 +81,29 @@ Two more use cases drive scheduled backups:
   the retention policy. It takes an injectable clock so the runner is deterministic under test, and
   opens its own repository sessions because it runs outside any HTTP request. Retention is scoped to
   scheduled snapshots, so a manual backup is never pruned by a schedule.
+
+### Gen1 restore
+
+Gen1 devices have no per-component `SetConfig` RPC, so their backups carry the raw `/settings`
+payload alongside the Gen2-shaped component configs. Restore replays that payload over the legacy
+HTTP settings endpoints (`/settings/relay/{i}`, `/settings/roller/{i}`, `/settings`,
+`/settings/sta`, `/settings/cloud`). Only parameters documented as settable in the
+[Gen1 API](https://shelly-api-docs.shelly.cloud/gen1/) are sent — read-only echoes (`ison`,
+`has_timer`, `power`) and unknown per-model fields are dropped rather than replayed.
+
+Known limitations:
+
+- **Secrets are not restored.** `GET /settings` never echoes the WiFi password (`key`) or
+  `mqtt_pass`, so they are absent from every snapshot. Restoring `wifi` re-applies the SSID and
+  static-IP config but not the password; restoring `mqtt` re-applies the broker and username but
+  leaves the password unset. If the device is on a password-protected network, verify it is still
+  connected after a `wifi` restore — network components are excluded by default for this reason.
+- **Device auth is not restored** (`/settings/login`), matching the Gen2 path, which likewise
+  leaves `Shelly.SetAuth` alone.
+- **Gen1 `actions` (webhooks) are not restored.** `/settings/actions` uses its own indexed-array
+  format and is not yet captured.
+- **Inputs have no endpoint of their own.** Gen1 input config lives on the owning relay, so an
+  `input:{i}` key is reported as skipped; its settings restore with `switch:{i}`.
 
 ## Quick Start
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -66,7 +66,7 @@ The core package provides per-device configuration backup and restore:
   target MAC is validated against the backup; network components (`wifi`/`eth`/`mqtt`/`ws`/
   `cloud`) are excluded by default to avoid lockout; read-only fields are stripped before each
   `SetConfig`. Gen1 devices restore through their legacy HTTP settings endpoints instead
-  (`Legacy.SetConfig`), replaying the raw `/settings` captured in the snapshot — see
+  (`Legacy.SetConfig`), replaying the raw `/settings` captured in the snapshot; see
   [Gen1 restore](#gen1-restore). A backup and a target of different generations are refused.
 
 Backups are persisted through the `BackupRepository` abstraction
@@ -86,24 +86,43 @@ Two more use cases drive scheduled backups:
 
 Gen1 devices have no per-component `SetConfig` RPC, so their backups carry the raw `/settings`
 payload alongside the Gen2-shaped component configs. Restore replays that payload over the legacy
-HTTP settings endpoints (`/settings/relay/{i}`, `/settings/roller/{i}`, `/settings`,
-`/settings/sta`, `/settings/cloud`). Only parameters documented as settable in the
-[Gen1 API](https://shelly-api-docs.shelly.cloud/gen1/) are sent — read-only echoes (`ison`,
-`has_timer`, `power`) and unknown per-model fields are dropped rather than replayed.
+HTTP settings endpoints (`/settings/relay/{i}`, `/settings/roller/{i}`, `/settings/input/{i}`,
+`/settings`, `/settings/sta`, `/settings/sta1`, `/settings/ap`, `/settings/cloud`). Only
+parameters documented as settable in the
+[Gen1 API](https://shelly-api-docs.shelly.cloud/gen1/) are sent; read-only echoes (`ison`,
+`has_timer`) and unknown per-model fields are dropped rather than replayed.
+
+If the backup was taken in a different device mode (relay/roller on a Shelly 2/2.5), the mode is
+applied first as a dedicated pre-phase: **a Gen1 mode change reboots the device**, so the restore
+waits for it to come back and re-reads its components before applying anything else. A restore
+whose device never returns fails loudly rather than continuing blind.
 
 Known limitations:
 
-- **Secrets are not restored.** `GET /settings` never echoes the WiFi password (`key`) or
+- **Secrets are not restored.** `GET /settings` never echoes the WiFi STA password (`key`) or
   `mqtt_pass`, so they are absent from every snapshot. Restoring `wifi` re-applies the SSID and
-  static-IP config but not the password; restoring `mqtt` re-applies the broker and username but
-  leaves the password unset. If the device is on a password-protected network, verify it is still
-  connected after a `wifi` restore — network components are excluded by default for this reason.
+  static-IP config for both STA configs but not their passwords (the AP password is echoed and
+  does round-trip); restoring `mqtt` re-applies the broker and username but leaves the password
+  unset. If the device is on a password-protected network, verify it is still connected after a
+  `wifi` restore; network components are excluded by default for this reason.
 - **Device auth is not restored** (`/settings/login`), matching the Gen2 path, which likewise
   leaves `Shelly.SetAuth` alone.
 - **Gen1 `actions` (webhooks) are not restored.** `/settings/actions` uses its own indexed-array
   format and is not yet captured.
-- **Inputs have no endpoint of their own.** Gen1 input config lives on the owning relay, so an
-  `input:{i}` key is reported as skipped; its settings restore with `switch:{i}`.
+- **Cleared-after-backup fields stay cleared… and vice versa.** Fields echoed as `null` are
+  dropped rather than replayed (Gen1 clearing semantics are per-field), so a value set on the
+  device *after* the backup was taken survives a restore instead of being cleared, unlike Gen2,
+  which replays nulls through `SetConfig`.
+- **Light devices are not captured.** Dimmer/Bulb/Duo/Vintage/RGBW2 backups hold only
+  sys/network settings; their `/settings/light|white|color/{i}` config is not yet captured, so
+  there is nothing to restore.
+- **Roller favourite positions** (`/settings/favorites/{i}`, Shelly 2.5) and **external add-on
+  sensor thresholds** (`/settings/ext_temperature|ext_humidity/{i}`) are not replayed; only the
+  `favorites_enabled` flag is.
+- **Inputs restore per model.** On i3/Button1, `input:{i}` restores via its own
+  `/settings/input/{i}` endpoint. On relay-bearing models that endpoint does not exist: input
+  config lives on the owning relay and restores with `switch:{i}`, so the `input:{i}` key is
+  reported as skipped.
 
 ## Quick Start
 

--- a/packages/core/src/core/domain/entities/device_backup.py
+++ b/packages/core/src/core/domain/entities/device_backup.py
@@ -37,7 +37,7 @@ class DeviceBackup:
 class DeviceBackupSummary:
     """Lightweight backup record without the (encrypted) snapshot blob.
 
-    Used for list views so they don't decrypt every snapshot — listing keeps
+    Used for list views so they don't decrypt every snapshot; listing keeps
     working even after the encryption key has rotated.
     """
 

--- a/packages/core/src/core/gateways/device/legacy_device_gateway.py
+++ b/packages/core/src/core/gateways/device/legacy_device_gateway.py
@@ -25,6 +25,19 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+# Gen1 exposes MQTT as ``mqtt_*`` params on the device-level ``/settings``, so it
+# shares an endpoint with ``sys`` rather than having one of its own.
+LEGACY_SETTINGS_ENDPOINTS: dict[str, str] = {
+    "sys": "settings",
+    "mqtt": "settings",
+    "cloud": "settings/cloud",
+    "wifi": "settings/sta",
+}
+LEGACY_INDEXED_SETTINGS_ENDPOINTS: dict[str, str] = {
+    "switch": "settings/relay",
+    "cover": "settings/roller",
+}
+
 
 class LegacyDeviceGateway:
     """Adapter for legacy Gen1 Shelly devices using HTTP API."""
@@ -269,7 +282,8 @@ class LegacyDeviceGateway:
             ip: Device IP address
             component_key: Component key (e.g., 'switch:0', 'input:1')
             action: Action name (must start with 'Legacy.')
-            parameters: Action parameters (unused for legacy actions)
+            parameters: Action parameters. Only ``Legacy.SetConfig`` reads them;
+                the fixed-command actions carry their own params.
 
         Returns:
             ActionResult with execution status
@@ -284,7 +298,9 @@ class LegacyDeviceGateway:
             except ValueError:
                 component_id = None
 
-        command = self._map_legacy_command(component_type, component_id, action)
+        command = self._map_legacy_command(
+            component_type, component_id, action, parameters
+        )
         if command is None:
             return ActionResult(
                 device_ip=ip,
@@ -318,9 +334,23 @@ class LegacyDeviceGateway:
             )
 
     def _map_legacy_command(
-        self, component_type: str, component_id: int | None, action: str
+        self,
+        component_type: str,
+        component_id: int | None,
+        action: str,
+        parameters: dict[str, Any],
     ) -> dict[str, Any] | None:
         """Map legacy action to HTTP endpoint and parameters."""
+        if action == "Legacy.SetConfig":
+            return self._map_set_config(component_type, component_id, parameters)
+
+        if action == "Legacy.Reboot" and component_type == "sys":
+            return {
+                "endpoint": "reboot",
+                "params": {},
+                "message": "Device reboot requested",
+            }
+
         if component_type == "switch" and component_id is not None:
             endpoint = f"relay/{component_id}"
             relay_actions: dict[str, dict[str, Any]] = {
@@ -399,6 +429,44 @@ class LegacyDeviceGateway:
                 return {"endpoint": endpoint, **input_actions[action]}
 
         return None
+
+    def _map_set_config(
+        self,
+        component_type: str,
+        component_id: int | None,
+        parameters: dict[str, Any],
+    ) -> dict[str, Any] | None:
+        endpoint = LEGACY_SETTINGS_ENDPOINTS.get(component_type)
+        if endpoint is None:
+            indexed = LEGACY_INDEXED_SETTINGS_ENDPOINTS.get(component_type)
+            if indexed is None or component_id is None:
+                return None
+            endpoint = f"{indexed}/{component_id}"
+
+        return {
+            "endpoint": endpoint,
+            "params": self._serialize_params(parameters),
+            "message": "Configuration applied",
+        }
+
+    @staticmethod
+    def _serialize_params(parameters: dict[str, Any]) -> dict[str, Any]:
+        """Render params as Gen1 query values.
+
+        An empty list serializes to "", which is how Gen1 clears a list field,
+        whereas ``None`` is dropped so the field is left untouched instead.
+        """
+        params: dict[str, Any] = {}
+        for name, value in parameters.items():
+            if value is None:
+                continue
+            if isinstance(value, bool):
+                params[name] = "true" if value else "false"
+            elif isinstance(value, list | tuple):
+                params[name] = ",".join(str(item) for item in value)
+            else:
+                params[name] = value
+        return params
 
     def _derive_device_name(
         self,

--- a/packages/core/src/core/gateways/device/legacy_device_gateway.py
+++ b/packages/core/src/core/gateways/device/legacy_device_gateway.py
@@ -32,10 +32,15 @@ LEGACY_SETTINGS_ENDPOINTS: dict[str, str] = {
     "mqtt": "settings",
     "cloud": "settings/cloud",
     "wifi": "settings/sta",
+    # Gen1 splits WiFi across three resources behind the single "wifi"
+    # component; these synthetic types exist only for the restore path.
+    "wifi_sta1": "settings/sta1",
+    "wifi_ap": "settings/ap",
 }
 LEGACY_INDEXED_SETTINGS_ENDPOINTS: dict[str, str] = {
     "switch": "settings/relay",
     "cover": "settings/roller",
+    "input": "settings/input",
 }
 
 

--- a/packages/core/src/core/gateways/network/shelly_digest_auth.py
+++ b/packages/core/src/core/gateways/network/shelly_digest_auth.py
@@ -3,7 +3,7 @@ Shelly-specific DigestAuth that correctly handles empty opaque values.
 
 httpx 0.28.1's DigestAuth uses ``if challenge.opaque:`` which treats b""
 as falsy, omitting opaque from the Authorization header. RFC 7616 requires
-clients to return opaque unchanged — even when empty. Shelly Wall Display
+clients to return opaque unchanged, even when empty. Shelly Wall Display
 devices send ``opaque=""`` and reject responses that omit it.
 """
 
@@ -16,7 +16,7 @@ from httpx._utils import to_str
 
 
 class ShellyDigestAuth(httpx.DigestAuth):
-    # Pinned to httpx 0.28.1 — verify on upgrades.
+    # Pinned to httpx 0.28.1; verify on upgrades.
     def _build_auth_header(
         self, request: Request, challenge: _DigestAuthChallenge
     ) -> str:

--- a/packages/core/src/core/repositories/backup_repository.py
+++ b/packages/core/src/core/repositories/backup_repository.py
@@ -35,7 +35,7 @@ class BackupRepository(ABC):
     async def count_summaries(self, device_mac: str | None = None) -> int:
         """Count stored backups, optionally filtered by device MAC.
 
-        Counts every source (manual and scheduled) — this is the total a
+        Counts every source (manual and scheduled); this is the total a
         paginated list view paginates over, not a retention scope.
         """
         pass

--- a/packages/core/src/core/repositories/sqlalchemy_backup_repository.py
+++ b/packages/core/src/core/repositories/sqlalchemy_backup_repository.py
@@ -110,7 +110,7 @@ class SQLAlchemyBackupRepository(BackupRepository):
         self, device_mac: str, n: int, source: str | None = "scheduled"
     ) -> int:
         if n < 1:
-            # Refuse to interpret "keep 0" as "delete everything" — that is almost
+            # Refuse to interpret "keep 0" as "delete everything"; that is almost
             # certainly a misconfiguration, not an intent to wipe all snapshots.
             return 0
         mac = normalize_mac(device_mac)

--- a/packages/core/src/core/use_cases/backup_device_config.py
+++ b/packages/core/src/core/use_cases/backup_device_config.py
@@ -93,7 +93,7 @@ class BackupDeviceConfig:
             )
 
         # Generation comes from the device's explicit `gen` field (Gen2+ RPC) or
-        # the legacy gateway's gen=1 stamp — never inferred from a missing field.
+        # the legacy gateway's gen=1 stamp, never inferred from a missing field.
         if status.gen == 1:
             generation = "gen1"
         elif status.gen is not None and status.gen >= 2:
@@ -132,7 +132,7 @@ class BackupDeviceConfig:
     ) -> list[DeviceBackupSummary]:
         """List every backup summary, newest first, optionally filtered by MAC.
 
-        Unbounded — used by callers that want the full set (the CLI listing).
+        Unbounded; used by callers that want the full set (the CLI listing).
         UI/API list views should use :meth:`list_backups_page` instead.
         """
         async with self._repository_factory() as repository:
@@ -179,7 +179,7 @@ def _has_restorable_payload(entry: dict[str, Any]) -> bool:
     """True if a captured component carries something a restore could apply.
 
     Scripts are only restorable when their code was actually fetched
-    (``GetConfig`` succeeding is not enough — restore re-pushes ``code.data``).
+    (``GetConfig`` succeeding is not enough: restore re-pushes ``code.data``).
     """
     if entry.get("type") == "script":
         code = entry.get("code")

--- a/packages/core/src/core/use_cases/restore_device_config.py
+++ b/packages/core/src/core/use_cases/restore_device_config.py
@@ -26,6 +26,108 @@ NETWORK_TYPES = {"wifi", "eth", "mqtt", "ws", "cloud"}
 # The "schedules" pseudo-component produced by export_bulk_config.
 SCHEDULES_KEY = "schedules"
 
+# The raw Gen1 /settings entry captured alongside the mapped components. It is the
+# data source a Gen1 restore replays, never a restore target itself.
+LEGACY_SETTINGS_KEY = "legacy_settings"
+
+# Section of the raw /settings holding each component's config. "" is the top level.
+GEN1_SECTION_BY_TYPE: dict[str, str] = {
+    "switch": "relays",
+    "cover": "rollers",
+    "sys": "",
+    "mqtt": "mqtt",
+    "cloud": "cloud",
+    "wifi": "wifi_sta",
+}
+
+# Restorable Gen1 settings per component type, as GET /settings names them. Only
+# params documented as settable at https://shelly-api-docs.shelly.cloud/gen1/ are
+# listed, so read-only echoes (ison, has_timer, power, is_valid, safety_switch) are
+# never sent back. Fields a model does not have are absent and skip themselves,
+# which is what lets one table serve every Gen1 model.
+GEN1_RESTORABLE_BY_TYPE: dict[str, tuple[str, ...]] = {
+    "switch": (
+        "name",
+        "appliance_type",
+        "default_state",
+        "btn_type",
+        "btn_reverse",
+        # Shelly 1L exposes two inputs instead of one.
+        "btn1_type",
+        "btn1_reverse",
+        "btn2_type",
+        "btn2_reverse",
+        "swap_inputs",
+        "auto_on",
+        "auto_off",
+        "schedule",
+        "schedule_rules",
+        "max_power",
+    ),
+    "cover": (
+        "default_state",
+        "input_mode",
+        "button_type",
+        "btn_reverse",
+        "swap",
+        "swap_inputs",
+        "maxtime",
+        "maxtime_open",
+        "maxtime_close",
+        "positioning",
+        "obstacle_mode",
+        "obstacle_action",
+        "obstacle_power",
+        "obstacle_delay",
+        "ends_delay",
+        "off_power",
+        "safety_mode",
+        "safety_action",
+        "safety_allowed_on_trigger",
+        "schedule",
+        "schedule_rules",
+    ),
+    "sys": (
+        "name",
+        "timezone",
+        "tzautodetect",
+        "tz_utc_offset",
+        "tz_dst",
+        "tz_dst_auto",
+        "lat",
+        "lng",
+        "discoverable",
+        "led_status_disable",
+        "sntp.server",
+    ),
+    # mqtt_pass is not echoed by GET /settings, so it cannot be restored.
+    "mqtt": (
+        "enable",
+        "server",
+        "user",
+        "id",
+        "clean_session",
+        "retain",
+        "keep_alive",
+        "update_period",
+        "max_qos",
+        "reconnect_timeout_min",
+        "reconnect_timeout_max",
+    ),
+    "cloud": ("enabled",),
+    # The WiFi "key" is not echoed by GET /settings, so it cannot be restored.
+    "wifi": ("enabled", "ssid", "ipv4_method", "ip", "gw", "mask", "dns"),
+}
+
+# GET /settings echoes several fields under a different name than the one their
+# setter accepts; sending the echoed name is silently ignored by the device.
+GEN1_PARAM_RENAMES: dict[str, dict[str, str]] = {
+    "cover": {"button_type": "btn_type"},
+    "sys": {"sntp.server": "sntp_server"},
+    "mqtt": {name: f"mqtt_{name}" for name in GEN1_RESTORABLE_BY_TYPE["mqtt"]},
+    "wifi": {"gw": "gateway", "mask": "netmask"},
+}
+
 # Read-only keys that GetConfig echoes but SetConfig rejects, by component type.
 # Each entry is a (parent, child) path popped from the config dict. Top-level
 # "id" and "cfg_rev" are always stripped. Table-driven so it is easy to extend.
@@ -33,6 +135,15 @@ READ_ONLY_BY_TYPE: dict[str, list[tuple[str, str]]] = {
     "sys": [("device", "mac")],
     "wifi": [("ap", "is_open")],
 }
+
+
+def _dig(section: dict[str, Any], path: str) -> Any:
+    value: Any = section
+    for part in path.split("."):
+        if not isinstance(value, dict):
+            return None
+        value = value.get(part)
+    return value
 
 
 class DeviceMismatchError(Exception):
@@ -116,15 +227,27 @@ class RestoreDeviceConfig:
             if actual != expected_mac:
                 raise DeviceMismatchError(expected_mac, status.mac_address)
 
-        # Restore is unsupported if either the backup or the live target is Gen1
-        # (Gen1 has no per-component SetConfig). Stop before any RPCs. A target
-        # whose generation is unknown (gen is None, e.g. GetDeviceInfo failed) is
-        # already gated by the MAC check above, so it never reaches here.
+        components: dict[str, Any] = backup.snapshot.get("components", {})
+
+        # A target whose generation is unknown (gen is None, e.g. GetDeviceInfo
+        # failed) is already gated by the MAC check above, so it never reaches here.
+        is_gen1 = backup.generation == "gen1" and status.gen == 1
+        gen1_settings: dict[str, Any] | None = None
         if backup.generation == "gen1" or status.gen == 1:
-            return self._gen1_unsupported(backup, device_ip, component_keys)
+            if not is_gen1:
+                return self._generation_mismatch(backup, device_ip, component_keys)
+            # Gen1 restores replay the raw /settings captured at backup time; the
+            # mapped per-component configs are Gen2-shaped and not writable as-is.
+            gen1_settings = self._legacy_settings(backup)
+            if gen1_settings is None:
+                return self._all_skipped(
+                    backup,
+                    device_ip,
+                    component_keys,
+                    "snapshot lacks raw Gen1 settings",
+                )
 
         present_keys = {component.key for component in status.components}
-        components: dict[str, Any] = backup.snapshot.get("components", {})
         selected = self._select(components, component_keys)
 
         results: list[ComponentRestoreResult] = []
@@ -132,7 +255,17 @@ class RestoreDeviceConfig:
         # caller never silently gets a smaller restore set than they asked for.
         if component_keys is not None:
             for key in component_keys:
-                if key not in components:
+                if key == LEGACY_SETTINGS_KEY:
+                    results.append(
+                        ComponentRestoreResult(
+                            key=key,
+                            action="SetConfig",
+                            success=False,
+                            skipped=True,
+                            skipped_reason="not a restorable component",
+                        )
+                    )
+                elif key not in components:
                     results.append(
                         ComponentRestoreResult(
                             key=key,
@@ -144,7 +277,16 @@ class RestoreDeviceConfig:
                     )
         for key in selected:
             entry = components[key]
-            results.append(await self._restore_one(device_ip, key, entry, present_keys))
+            if gen1_settings is not None:
+                results.append(
+                    await self._restore_gen1_one(
+                        device_ip, key, entry, gen1_settings, present_keys
+                    )
+                )
+            else:
+                results.append(
+                    await self._restore_one(device_ip, key, entry, present_keys)
+                )
 
         succeeded = sum(1 for r in results if r.success)
         failed = sum(1 for r in results if not r.success and not r.skipped)
@@ -156,9 +298,14 @@ class RestoreDeviceConfig:
         applied = succeeded > 0 and failed == 0
 
         if reboot and applied:
-            await self._device_gateway.execute_component_action(
-                device_ip, "shelly", "Reboot", {}
-            )
+            if is_gen1:
+                await self._device_gateway.execute_component_action(
+                    device_ip, "sys", "Legacy.Reboot", {}
+                )
+            else:
+                await self._device_gateway.execute_component_action(
+                    device_ip, "shelly", "Reboot", {}
+                )
 
         return RestoreResult(
             success=applied,
@@ -184,17 +331,22 @@ class RestoreDeviceConfig:
         Default (no explicit selection) excludes network types. Network keys are
         always ordered last so connectivity-risk components apply after the rest.
         """
+        candidates = {
+            key: entry
+            for key, entry in components.items()
+            if key != LEGACY_SETTINGS_KEY
+        }
         if component_keys is None:
             keys = [
                 key
-                for key, entry in components.items()
+                for key, entry in candidates.items()
                 if entry.get("type") not in NETWORK_TYPES
             ]
         else:
-            keys = [key for key in component_keys if key in components]
+            keys = [key for key in component_keys if key in candidates]
 
         def is_network(key: str) -> bool:
-            return components[key].get("type") in NETWORK_TYPES
+            return candidates[key].get("type") in NETWORK_TYPES
 
         return sorted(keys, key=is_network)
 
@@ -348,16 +500,130 @@ class RestoreDeviceConfig:
             error="; ".join(errors) if errors else None,
         )
 
-    def _gen1_unsupported(
+    def _legacy_settings(self, backup: DeviceBackup) -> dict[str, Any] | None:
+        components: dict[str, Any] = backup.snapshot.get("components", {})
+        entry = components.get(LEGACY_SETTINGS_KEY)
+        if not isinstance(entry, dict) or not entry.get("success"):
+            return None
+        settings = entry.get("config")
+        return settings if isinstance(settings, dict) else None
+
+    async def _restore_gen1_one(
+        self,
+        device_ip: str,
+        key: str,
+        entry: dict[str, Any],
+        settings: dict[str, Any],
+        present_keys: set[str],
+    ) -> ComponentRestoreResult:
+        ctype = entry.get("type")
+
+        if key not in present_keys:
+            return ComponentRestoreResult(
+                key=key,
+                action="Legacy.SetConfig",
+                success=False,
+                skipped=True,
+                skipped_reason="component not present on target device",
+            )
+
+        params = self._gen1_params(key, ctype, settings)
+        if params is None:
+            return ComponentRestoreResult(
+                key=key,
+                action="Legacy.SetConfig",
+                success=False,
+                skipped=True,
+                skipped_reason="no Gen1 settings endpoint for this component",
+            )
+        if not params:
+            return ComponentRestoreResult(
+                key=key,
+                action="Legacy.SetConfig",
+                success=False,
+                skipped=True,
+                skipped_reason="no restorable settings captured in backup",
+            )
+
+        result = await self._device_gateway.execute_component_action(
+            device_ip, key, "Legacy.SetConfig", params
+        )
+        return ComponentRestoreResult(
+            key=key,
+            action="Legacy.SetConfig",
+            success=result.success,
+            error=result.error if not result.success else None,
+        )
+
+    def _gen1_params(
+        self, key: str, ctype: str | None, settings: dict[str, Any]
+    ) -> dict[str, Any] | None:
+        """``None`` when the type has no Gen1 settings endpoint at all (e.g. inputs,
+        whose config lives on the owning relay); ``{}`` when it has one but the
+        snapshot holds nothing to send.
+        """
+        allowed = GEN1_RESTORABLE_BY_TYPE.get(ctype or "")
+        if allowed is None:
+            return None
+
+        section = self._gen1_section(key, ctype or "", settings)
+        if section is None:
+            return {}
+
+        renames = GEN1_PARAM_RENAMES.get(ctype or "", {})
+        params: dict[str, Any] = {}
+        for attr in allowed:
+            value = _dig(section, attr)
+            if value is not None:
+                params[renames.get(attr, attr)] = value
+        return params
+
+    def _gen1_section(
+        self, key: str, ctype: str, settings: dict[str, Any]
+    ) -> dict[str, Any] | None:
+        section_name = GEN1_SECTION_BY_TYPE[ctype]
+        section: Any = settings if not section_name else settings.get(section_name)
+
+        # relays/rollers are arrays parallel to the component id.
+        if isinstance(section, list):
+            try:
+                index = int(key.split(":")[1])
+            except (IndexError, ValueError):
+                return None
+            section = section[index] if 0 <= index < len(section) else None
+
+        return section if isinstance(section, dict) else None
+
+    def _generation_mismatch(
         self,
         backup: DeviceBackup,
         device_ip: str,
         component_keys: list[str] | None = None,
     ) -> RestoreResult:
+        return self._all_skipped(
+            backup,
+            device_ip,
+            component_keys,
+            "backup generation does not match the target device",
+            message="Backup and device generations differ",
+        )
+
+    def _all_skipped(
+        self,
+        backup: DeviceBackup,
+        device_ip: str,
+        component_keys: list[str] | None,
+        reason: str,
+        message: str | None = None,
+    ) -> RestoreResult:
         components: dict[str, Any] = backup.snapshot.get("components", {})
         # Honour an explicit request subset, and still surface unknown keys
         # rather than reporting every captured component as skipped.
-        keys = list(components) if component_keys is None else component_keys
+        keys = (
+            [key for key in components if key != LEGACY_SETTINGS_KEY]
+            if component_keys is None
+            else component_keys
+        )
         results = [
             ComponentRestoreResult(
                 key=key,
@@ -365,9 +631,7 @@ class RestoreDeviceConfig:
                 success=False,
                 skipped=True,
                 skipped_reason=(
-                    "Gen1 restore not supported (no per-component SetConfig)"
-                    if key in components
-                    else "not present in backup"
+                    reason if key in components else "not present in backup"
                 ),
             )
             for key in keys
@@ -380,6 +644,6 @@ class RestoreDeviceConfig:
             succeeded=0,
             failed=0,
             skipped=len(results),
-            message="Gen1 devices do not support per-component restore",
+            message=message or reason,
             components=results,
         )

--- a/packages/core/src/core/use_cases/restore_device_config.py
+++ b/packages/core/src/core/use_cases/restore_device_config.py
@@ -1,5 +1,6 @@
 """Use case for restoring a stored backup back onto a device."""
 
+import asyncio
 import logging
 from collections.abc import Callable
 from contextlib import AbstractAsyncContextManager
@@ -7,6 +8,7 @@ from copy import deepcopy
 from typing import Any
 
 from core.domain.entities.device_backup import DeviceBackup
+from core.domain.entities.device_status import DeviceStatus
 from core.domain.entities.exceptions import DeviceNotFoundError
 from core.domain.value_objects.restore_result import (
     ComponentRestoreResult,
@@ -31,18 +33,23 @@ SCHEDULES_KEY = "schedules"
 LEGACY_SETTINGS_KEY = "legacy_settings"
 
 # Section of the raw /settings holding each component's config. "" is the top level.
+# wifi_sta1/wifi_ap are synthetic types for the extra Gen1 WiFi resources replayed
+# behind the single "wifi" component (see _restore_gen1_wifi).
 GEN1_SECTION_BY_TYPE: dict[str, str] = {
     "switch": "relays",
     "cover": "rollers",
+    "input": "inputs",
     "sys": "",
     "mqtt": "mqtt",
     "cloud": "cloud",
     "wifi": "wifi_sta",
+    "wifi_sta1": "wifi_sta1",
+    "wifi_ap": "wifi_ap",
 }
 
 # Restorable Gen1 settings per component type, as GET /settings names them. Only
 # params documented as settable at https://shelly-api-docs.shelly.cloud/gen1/ are
-# listed, so read-only echoes (ison, has_timer, power, is_valid, safety_switch) are
+# listed, so read-only echoes (ison, has_timer, is_valid, safety_switch) are
 # never sent back. Fields a model does not have are absent and skip themselves,
 # which is what lets one table serve every Gen1 model.
 GEN1_RESTORABLE_BY_TYPE: dict[str, tuple[str, ...]] = {
@@ -63,6 +70,9 @@ GEN1_RESTORABLE_BY_TYPE: dict[str, tuple[str, ...]] = {
         "schedule",
         "schedule_rules",
         "max_power",
+        # On Shelly 1/1L "power" is the settable user power constant shown in
+        # meters, not a live reading (live power is echoed under "meters").
+        "power",
     ),
     "cover": (
         "default_state",
@@ -87,6 +97,8 @@ GEN1_RESTORABLE_BY_TYPE: dict[str, tuple[str, ...]] = {
         "schedule",
         "schedule_rules",
     ),
+    # "mode" is deliberately absent: Gen1 applies it with a reboot, so it is
+    # replayed alone as a pre-phase (_sync_gen1_mode), never in this batch.
     "sys": (
         "name",
         "timezone",
@@ -98,8 +110,34 @@ GEN1_RESTORABLE_BY_TYPE: dict[str, tuple[str, ...]] = {
         "lng",
         "discoverable",
         "led_status_disable",
+        "led_power_disable",
         "sntp.server",
+        # Device-level overpower threshold (1PM, Plug/PlugS, 2.5 in roller
+        # mode); distinct from the per-relay max_power.
+        "max_power",
+        "longpush_time",
+        "factory_reset_from_switch",
+        "wifirecovery_reboot_enabled",
+        "debug_enable",
+        "allow_cross_origin",
+        "supply_voltage",
+        "power_correction",
+        # 2.5 roller favourite positions live on /settings/favorites/{i} (not
+        # replayed); only their enable flag is a plain /settings param.
+        "favorites_enabled",
+        "coiot.enabled",
+        "coiot.update_period",
+        "coiot.peer",
+        "ap_roaming.enabled",
+        "ap_roaming.threshold",
+        "longpush_duration_ms.min",
+        "longpush_duration_ms.max",
+        "multipush_time_between_pushes_ms.max",
     ),
+    # Only i3/Button1 expose /settings/input/{i}. Relay-bearing models never
+    # echo an "inputs" section in /settings (their input config lives on the
+    # owning relay), so their inputs skip as having nothing captured.
+    "input": ("name", "btn_type", "btn_reverse"),
     # mqtt_pass is not echoed by GET /settings, so it cannot be restored.
     "mqtt": (
         "enable",
@@ -115,18 +153,37 @@ GEN1_RESTORABLE_BY_TYPE: dict[str, tuple[str, ...]] = {
         "reconnect_timeout_max",
     ),
     "cloud": ("enabled",),
-    # The WiFi "key" is not echoed by GET /settings, so it cannot be restored.
+    # The WiFi STA "key" is not echoed by GET /settings, so it cannot be restored.
     "wifi": ("enabled", "ssid", "ipv4_method", "ip", "gw", "mask", "dns"),
+    # The AP SSID is device-fixed and not settable; the AP key, unlike the STA
+    # one, IS echoed by GET /settings and round-trips.
+    "wifi_ap": ("enabled", "key"),
 }
+# /settings/sta1 (fallback STA) is documented as an identical resource to
+# /settings/sta.
+GEN1_RESTORABLE_BY_TYPE["wifi_sta1"] = GEN1_RESTORABLE_BY_TYPE["wifi"]
 
 # GET /settings echoes several fields under a different name than the one their
 # setter accepts; sending the echoed name is silently ignored by the device.
 GEN1_PARAM_RENAMES: dict[str, dict[str, str]] = {
     "cover": {"button_type": "btn_type"},
-    "sys": {"sntp.server": "sntp_server"},
+    "sys": {
+        "sntp.server": "sntp_server",
+        "coiot.enabled": "coiot_enable",
+        "coiot.update_period": "coiot_update_period",
+        "coiot.peer": "coiot_peer",
+        "ap_roaming.enabled": "ap_roaming_enabled",
+        "ap_roaming.threshold": "ap_roaming_threshold",
+        "longpush_duration_ms.min": "longpush_duration_ms_min",
+        "longpush_duration_ms.max": "longpush_duration_ms_max",
+        "multipush_time_between_pushes_ms.max": (
+            "multipush_time_between_pushes_ms_max"
+        ),
+    },
     "mqtt": {name: f"mqtt_{name}" for name in GEN1_RESTORABLE_BY_TYPE["mqtt"]},
     "wifi": {"gw": "gateway", "mask": "netmask"},
 }
+GEN1_PARAM_RENAMES["wifi_sta1"] = GEN1_PARAM_RENAMES["wifi"]
 
 # Read-only keys that GetConfig echoes but SetConfig rejects, by component type.
 # Each entry is a (parent, child) path popped from the config dict. Top-level
@@ -165,9 +222,14 @@ class RestoreDeviceConfig:
         self,
         device_gateway: DeviceGateway,
         repository_factory: Callable[[], AbstractAsyncContextManager[BackupRepository]],
+        *,
+        mode_change_timeout: float = 60.0,
+        mode_change_poll_interval: float = 2.0,
     ):
         self._device_gateway = device_gateway
         self._repository_factory = repository_factory
+        self._mode_change_timeout = mode_change_timeout
+        self._mode_change_poll_interval = mode_change_poll_interval
 
     async def restore(
         self,
@@ -247,15 +309,39 @@ class RestoreDeviceConfig:
                     "snapshot lacks raw Gen1 settings",
                 )
 
+        mode_result: ComponentRestoreResult | None = None
+        if gen1_settings is not None:
+            mode_result, status = await self._sync_gen1_mode(
+                device_ip, gen1_settings, status
+            )
+            if (
+                mode_result is not None
+                and not mode_result.success
+                and not mode_result.skipped
+            ):
+                return RestoreResult(
+                    success=False,
+                    device_ip=device_ip,
+                    backup_id=backup_id,
+                    total=1,
+                    succeeded=0,
+                    failed=1,
+                    skipped=0,
+                    message=mode_result.error,
+                    components=[mode_result],
+                )
+
         present_keys = {component.key for component in status.components}
         selected = self._select(components, component_keys)
 
         results: list[ComponentRestoreResult] = []
+        if mode_result is not None:
+            results.append(mode_result)
         # Surface explicitly-requested keys that aren't in the backup, so the
         # caller never silently gets a smaller restore set than they asked for.
         if component_keys is not None:
             for key in component_keys:
-                if key == LEGACY_SETTINGS_KEY:
+                if key == LEGACY_SETTINGS_KEY and key in components:
                     results.append(
                         ComponentRestoreResult(
                             key=key,
@@ -294,7 +380,7 @@ class RestoreDeviceConfig:
 
         # A restore only "succeeds" if something was actually applied. An
         # all-skipped restore (e.g. unknown keys, or every component absent on
-        # the target) is a no-op, not a success — and must not reboot.
+        # the target) is a no-op, not a success, and must not reboot.
         applied = succeeded > 0 and failed == 0
 
         if reboot and applied:
@@ -471,7 +557,7 @@ class RestoreDeviceConfig:
         # Restore must reproduce the captured schedule set, not merge into the
         # device's existing jobs. Always clear the target first so re-runs are
         # idempotent and stale/duplicate jobs don't accumulate (including when
-        # the captured set is empty). If the clear fails, abort — creating on top
+        # the captured set is empty). If the clear fails, abort: creating on top
         # of un-cleared jobs would merge/duplicate instead of replace.
         delete_result = await self._device_gateway.execute_component_action(
             device_ip, "schedule", "DeleteAll", {}
@@ -527,6 +613,9 @@ class RestoreDeviceConfig:
                 skipped_reason="component not present on target device",
             )
 
+        if ctype == "wifi":
+            return await self._restore_gen1_wifi(device_ip, key, settings)
+
         params = self._gen1_params(key, ctype, settings)
         if params is None:
             return ComponentRestoreResult(
@@ -555,12 +644,126 @@ class RestoreDeviceConfig:
             error=result.error if not result.success else None,
         )
 
+    async def _restore_gen1_wifi(
+        self, device_ip: str, key: str, settings: dict[str, Any]
+    ) -> ComponentRestoreResult:
+        """Replay every captured Gen1 WiFi resource behind the "wifi" component.
+
+        Gen1 splits WiFi across /settings/sta, /settings/sta1 (fallback STA) and
+        /settings/ap. The AP is applied last: enabling one mode disables the
+        other on the device, so the resource enabled in the backup must win.
+        """
+        attempted = False
+        errors: list[str] = []
+        for subtype in ("wifi", "wifi_sta1", "wifi_ap"):
+            params = self._gen1_params(subtype, subtype, settings)
+            if not params:
+                continue
+            attempted = True
+            result = await self._device_gateway.execute_component_action(
+                device_ip, subtype, "Legacy.SetConfig", params
+            )
+            if not result.success:
+                errors.append(f"{subtype}: {result.error or 'failed'}")
+
+        if not attempted:
+            return ComponentRestoreResult(
+                key=key,
+                action="Legacy.SetConfig",
+                success=False,
+                skipped=True,
+                skipped_reason="no restorable settings captured in backup",
+            )
+        return ComponentRestoreResult(
+            key=key,
+            action="Legacy.SetConfig",
+            success=not errors,
+            error="; ".join(errors) if errors else None,
+        )
+
+    async def _sync_gen1_mode(
+        self,
+        device_ip: str,
+        settings: dict[str, Any],
+        status: DeviceStatus,
+    ) -> tuple[ComponentRestoreResult | None, DeviceStatus]:
+        """Align the target's relay/roller mode with the backup before restoring.
+
+        Gen1 applies ``mode`` with a reboot and re-enumerates its components
+        afterwards, so it cannot ride along in the sys param batch: it is sent
+        alone first, and the device status is re-read once the target is back.
+        Returns the pre-phase result (``None`` when nothing needed doing) and
+        the status to restore against.
+        """
+        backup_mode = settings.get("mode")
+        if not isinstance(backup_mode, str) or not backup_mode:
+            return None, status
+
+        target_settings = await self._device_gateway.get_legacy_settings(device_ip)
+        target_mode = (
+            target_settings.get("mode") if isinstance(target_settings, dict) else None
+        )
+        if not isinstance(target_mode, str) or not target_mode:
+            return (
+                ComponentRestoreResult(
+                    key="mode",
+                    action="Legacy.SetConfig",
+                    success=False,
+                    skipped=True,
+                    skipped_reason="could not read the target device mode",
+                ),
+                status,
+            )
+        if target_mode == backup_mode:
+            return None, status
+
+        result = await self._device_gateway.execute_component_action(
+            device_ip, "sys", "Legacy.SetConfig", {"mode": backup_mode}
+        )
+        if not result.success:
+            return (
+                ComponentRestoreResult(
+                    key="mode",
+                    action="Legacy.SetConfig",
+                    success=False,
+                    error=result.error or "mode change failed",
+                ),
+                status,
+            )
+
+        new_status = await self._wait_for_device(device_ip)
+        if new_status is None:
+            return (
+                ComponentRestoreResult(
+                    key="mode",
+                    action="Legacy.SetConfig",
+                    success=False,
+                    error="device did not come back after the mode change",
+                ),
+                status,
+            )
+        return (
+            ComponentRestoreResult(key="mode", action="Legacy.SetConfig", success=True),
+            new_status,
+        )
+
+    async def _wait_for_device(self, device_ip: str) -> DeviceStatus | None:
+        loop = asyncio.get_running_loop()
+        deadline = loop.time() + self._mode_change_timeout
+        while True:
+            status = await self._device_gateway.get_device_status(device_ip)
+            if status is not None:
+                return status
+            if loop.time() >= deadline:
+                return None
+            await asyncio.sleep(self._mode_change_poll_interval)
+
     def _gen1_params(
         self, key: str, ctype: str | None, settings: dict[str, Any]
     ) -> dict[str, Any] | None:
-        """``None`` when the type has no Gen1 settings endpoint at all (e.g. inputs,
-        whose config lives on the owning relay); ``{}`` when it has one but the
-        snapshot holds nothing to send.
+        """``None`` when the type has no Gen1 settings endpoint at all; ``{}``
+        when it has one but the snapshot holds nothing to send (e.g. inputs on
+        relay-bearing models, which never echo an ``inputs`` settings section).
         """
         allowed = GEN1_RESTORABLE_BY_TYPE.get(ctype or "")
         if allowed is None:
@@ -618,11 +821,11 @@ class RestoreDeviceConfig:
     ) -> RestoreResult:
         components: dict[str, Any] = backup.snapshot.get("components", {})
         # Honour an explicit request subset, and still surface unknown keys
-        # rather than reporting every captured component as skipped.
+        # rather than reporting every captured component as skipped. The default
+        # selection mirrors the restore path, so network components a default
+        # restore would never touch are not reported as skipped either.
         keys = (
-            [key for key in components if key != LEGACY_SETTINGS_KEY]
-            if component_keys is None
-            else component_keys
+            self._select(components, None) if component_keys is None else component_keys
         )
         results = [
             ComponentRestoreResult(

--- a/packages/core/tests/unit/gateways/device/test_legacy_device_gateway.py
+++ b/packages/core/tests/unit/gateways/device/test_legacy_device_gateway.py
@@ -169,11 +169,16 @@ class TestLegacyDeviceGateway:
             ("switch:0", "settings/relay/0"),
             ("switch:2", "settings/relay/2"),
             ("cover:1", "settings/roller/1"),
+            # Only i3/Button1 expose this endpoint; the restore path never
+            # targets it for other models.
+            ("input:0", "settings/input/0"),
             ("sys", "settings"),
             # Gen1 exposes MQTT as mqtt_* params on the device-level /settings.
             ("mqtt", "settings"),
             ("cloud", "settings/cloud"),
             ("wifi", "settings/sta"),
+            ("wifi_sta1", "settings/sta1"),
+            ("wifi_ap", "settings/ap"),
         ],
     )
     async def test_it_maps_set_config_to_its_settings_endpoint(
@@ -244,7 +249,7 @@ class TestLegacyDeviceGateway:
             "192.168.1.100", "reboot", {}, auth=None
         )
 
-    @pytest.mark.parametrize("component_key", ["input:0", "schedule", "switch"])
+    @pytest.mark.parametrize("component_key", ["schedule", "switch", "input"])
     async def test_it_refuses_set_config_without_a_settings_endpoint(
         self, gateway, mock_http_client, component_key
     ):

--- a/packages/core/tests/unit/gateways/device/test_legacy_device_gateway.py
+++ b/packages/core/tests/unit/gateways/device/test_legacy_device_gateway.py
@@ -163,6 +163,99 @@ class TestLegacyDeviceGateway:
         assert result.success is False
         assert "Action failed" in result.error
 
+    @pytest.mark.parametrize(
+        "component_key,expected_endpoint",
+        [
+            ("switch:0", "settings/relay/0"),
+            ("switch:2", "settings/relay/2"),
+            ("cover:1", "settings/roller/1"),
+            ("sys", "settings"),
+            # Gen1 exposes MQTT as mqtt_* params on the device-level /settings.
+            ("mqtt", "settings"),
+            ("cloud", "settings/cloud"),
+            ("wifi", "settings/sta"),
+        ],
+    )
+    async def test_it_maps_set_config_to_its_settings_endpoint(
+        self, gateway, mock_http_client, component_key, expected_endpoint
+    ):
+        mock_http_client.get_with_params.return_value = {}
+
+        result = await gateway.execute_action(
+            "192.168.1.100", component_key, "Legacy.SetConfig", {"name": "Kitchen"}
+        )
+
+        assert result.success is True
+        mock_http_client.get_with_params.assert_called_once_with(
+            "192.168.1.100", expected_endpoint, {"name": "Kitchen"}, auth=None
+        )
+
+    async def test_it_serializes_set_config_params_for_gen1(
+        self, gateway, mock_http_client
+    ):
+        mock_http_client.get_with_params.return_value = {}
+
+        await gateway.execute_action(
+            "192.168.1.100",
+            "switch:0",
+            "Legacy.SetConfig",
+            {
+                "schedule": True,
+                "btn_reverse": False,
+                "schedule_rules": ["0700-012345-on", "2200-012345-off"],
+                "auto_off": 30.5,
+                "max_power": 0,
+                "name": None,
+            },
+        )
+
+        params = mock_http_client.get_with_params.call_args.args[2]
+        assert params == {
+            "schedule": "true",
+            "btn_reverse": "false",
+            "schedule_rules": "0700-012345-on,2200-012345-off",
+            "auto_off": 30.5,
+            "max_power": 0,
+        }
+        # None is dropped, not sent as an empty value that would clear the field.
+        assert "name" not in params
+
+    async def test_it_serializes_an_empty_list_as_a_clearing_value(
+        self, gateway, mock_http_client
+    ):
+        mock_http_client.get_with_params.return_value = {}
+
+        await gateway.execute_action(
+            "192.168.1.100", "switch:0", "Legacy.SetConfig", {"schedule_rules": []}
+        )
+
+        params = mock_http_client.get_with_params.call_args.args[2]
+        assert params == {"schedule_rules": ""}
+
+    async def test_it_reboots_a_gen1_device(self, gateway, mock_http_client):
+        mock_http_client.get_with_params.return_value = {}
+
+        result = await gateway.execute_action(
+            "192.168.1.100", "sys", "Legacy.Reboot", {}
+        )
+
+        assert result.success is True
+        mock_http_client.get_with_params.assert_called_once_with(
+            "192.168.1.100", "reboot", {}, auth=None
+        )
+
+    @pytest.mark.parametrize("component_key", ["input:0", "schedule", "switch"])
+    async def test_it_refuses_set_config_without_a_settings_endpoint(
+        self, gateway, mock_http_client, component_key
+    ):
+        result = await gateway.execute_action(
+            "192.168.1.100", component_key, "Legacy.SetConfig", {"name": "x"}
+        )
+
+        assert result.success is False
+        assert result.error == "Unsupported legacy action"
+        mock_http_client.get_with_params.assert_not_called()
+
     async def test_it_derives_device_name_priority(
         self, gateway, mock_http_client, sample_device_info
     ):

--- a/packages/core/tests/unit/use_cases/test_backup_device_config.py
+++ b/packages/core/tests/unit/use_cases/test_backup_device_config.py
@@ -175,7 +175,7 @@ class TestBackupDeviceConfig:
     async def test_it_raises_when_only_scripts_without_code(
         self, use_case, mock_device_gateway, mock_bulk_operations
     ):
-        # GetConfig succeeded for the script but GetCode failed, so no `code` —
+        # GetConfig succeeded for the script but GetCode failed, so no `code`:
         # not actually restorable, even though config is present.
         mock_device_gateway.get_device_status = AsyncMock(return_value=_status())
         mock_bulk_operations.export_bulk_config = AsyncMock(

--- a/packages/core/tests/unit/use_cases/test_restore_device_config.py
+++ b/packages/core/tests/unit/use_cases/test_restore_device_config.py
@@ -50,14 +50,17 @@ def _backup(generation="gen2"):
 def _gen1_settings():
     """A raw Gen1 /settings payload, shaped as the device echoes it.
 
-    Field names follow https://shelly-api-docs.shelly.cloud/gen1/ — note the
-    read-only echoes (ison/has_timer/power) and the fields GET names differently
-    from their setter (wifi gw/mask, roller button_type, nested sntp.server).
+    Field names follow https://shelly-api-docs.shelly.cloud/gen1/; note the
+    read-only echoes (relay ison/has_timer, roller state/power) and the fields
+    GET names differently from their setter (wifi gw/mask, roller button_type,
+    nested sntp.server/coiot/ap_roaming). Deliberately cross-model: relay power
+    (Shelly 1), rollers/favorites (2.5), inputs (i3), led_power_disable (PlugS).
     """
     return {
         "device": {"type": "SHSW-1", "mac": "AABBCCDDEEFF"},
         "fw": "20230913-112003/v1.14.0",
         "name": "Hallway",
+        "mode": "relay",
         "timezone": "Europe/Lisbon",
         "tzautodetect": False,
         "tz_utc_offset": 3600,
@@ -67,8 +70,23 @@ def _gen1_settings():
         "lng": -9.1393,
         "discoverable": True,
         "led_status_disable": False,
+        "led_power_disable": False,
+        "max_power": 3500,
+        "longpush_time": 1000,
+        "factory_reset_from_switch": True,
+        "wifirecovery_reboot_enabled": True,
+        "debug_enable": False,
+        "allow_cross_origin": False,
+        "supply_voltage": 0,
+        "power_correction": 1,
+        "favorites_enabled": True,
+        "coiot": {"enabled": True, "update_period": 15, "peer": "10.0.0.2:5683"},
+        "ap_roaming": {"enabled": True, "threshold": -70},
+        "longpush_duration_ms": {"min": 800, "max": 3000},
+        "multipush_time_between_pushes_ms": {"max": 500},
         "sntp": {"server": "pool.ntp.org", "enabled": True},
         "login": {"enabled": True, "username": "admin"},
+        "inputs": [{"name": "Left button", "btn_type": "momentary", "btn_reverse": 0}],
         "relays": [
             {
                 "name": "Hallway light",
@@ -113,6 +131,16 @@ def _gen1_settings():
             "mask": "255.255.255.0",
             "dns": "8.8.8.8",
         },
+        "wifi_sta1": {
+            "enabled": False,
+            "ssid": "CastleFallback",
+            "ipv4_method": "dhcp",
+            "ip": None,
+            "gw": None,
+            "mask": None,
+            "dns": None,
+        },
+        "wifi_ap": {"enabled": False, "ssid": "shelly1-DDEEFF", "key": "appass"},
         "mqtt": {
             "enable": True,
             "server": "10.0.0.1:1883",
@@ -314,7 +342,18 @@ class TestRestoreDeviceConfig:
 
         assert result.skipped == len(result.components)
         assert result.success is False
+        # Mirrors the default selection: network components are not reported.
+        assert "wifi" not in {c.key for c in result.components}
         mock_device_gateway.execute_component_action.assert_not_called()
+
+    async def test_it_reports_a_missing_legacy_settings_request_as_not_in_backup(
+        self, use_case
+    ):
+        result = await use_case.restore(1, IP, component_keys=["legacy_settings"])
+
+        entry = next(c for c in result.components if c.key == "legacy_settings")
+        assert entry.skipped is True
+        assert entry.skipped_reason == "not present in backup"
 
     async def test_it_raises_when_backup_missing(self, use_case, mock_repository):
         mock_repository.get = AsyncMock(return_value=None)
@@ -480,7 +519,7 @@ class TestRestoreDeviceConfig:
             for call in mock_device_gateway.execute_component_action.call_args_list
             if call.args[1] == "schedule"
         ]
-        # Aborted after the failed clear — no Create attempted.
+        # Aborted after the failed clear; no Create attempted.
         assert actions == ["DeleteAll"]
         assert result.success is False
         sched = next(c for c in result.components if c.key == "schedules")
@@ -518,6 +557,10 @@ class TestRestoreGen1DeviceConfig:
         mock_device_gateway.get_device_status = AsyncMock(
             return_value=_status(keys=GEN1_KEYS, app_name="SHSW-1", gen=1)
         )
+        # Target mode matches the backup, so no mode pre-phase by default.
+        mock_device_gateway.get_legacy_settings = AsyncMock(
+            return_value={"mode": "relay"}
+        )
         mock_device_gateway.execute_component_action = AsyncMock(
             side_effect=lambda ip, key, action, params: _ok(key)
         )
@@ -552,6 +595,9 @@ class TestRestoreGen1DeviceConfig:
             "schedule": True,
             "schedule_rules": ["0700-012345-on", "2200-012345-off"],
             "max_power": 0,
+            # The Shelly 1/1L user power constant: settable, unlike the live
+            # readings under "meters".
+            "power": 12.5,
         }
 
     async def test_it_drops_readonly_relay_fields(self, use_case, mock_device_gateway):
@@ -559,7 +605,7 @@ class TestRestoreGen1DeviceConfig:
 
         sent = self._sent(mock_device_gateway)["switch:0"]
         # Echoed by GET /settings but rejected/meaningless as settings.
-        for read_only in ("ison", "has_timer", "power"):
+        for read_only in ("ison", "has_timer"):
             assert read_only not in sent
 
     async def test_it_renames_wifi_fields_to_their_setter_names(
@@ -577,6 +623,65 @@ class TestRestoreGen1DeviceConfig:
             "netmask": "255.255.255.0",
             "dns": "8.8.8.8",
         }
+
+    async def test_it_restores_the_fallback_sta_and_ap_with_the_primary(
+        self, use_case, mock_device_gateway
+    ):
+        result = await use_case.restore(1, IP, component_keys=["wifi"])
+
+        sent = self._sent(mock_device_gateway)
+        assert sent["wifi_sta1"] == {
+            "enabled": False,
+            "ssid": "CastleFallback",
+            "ipv4_method": "dhcp",
+        }
+        # The AP SSID is device-fixed and never sent; the AP key, unlike the
+        # STA one, is echoed by GET /settings and round-trips.
+        assert sent["wifi_ap"] == {"enabled": False, "key": "appass"}
+        # The AP goes last: enabling one WiFi mode disables the other on the
+        # device, so the resource enabled in the backup must win.
+        assert list(sent) == ["wifi", "wifi_sta1", "wifi_ap"]
+        # One component result for the single "wifi" component.
+        assert [c.key for c in result.components] == ["wifi"]
+        assert result.success is True
+
+    async def test_it_only_replays_captured_wifi_resources(
+        self, use_case, mock_device_gateway, mock_repository
+    ):
+        settings = _gen1_settings()
+        settings.pop("wifi_sta1")
+        settings.pop("wifi_ap")
+        mock_repository.get = AsyncMock(return_value=_gen1_backup(settings=settings))
+
+        result = await use_case.restore(1, IP, component_keys=["wifi"])
+
+        assert set(self._sent(mock_device_gateway)) == {"wifi"}
+        assert result.success is True
+
+    async def test_it_reports_a_failing_wifi_subresource(
+        self, use_case, mock_device_gateway
+    ):
+        def side_effect(ip, key, action, params):
+            if key == "wifi_ap":
+                return ActionResult(
+                    success=False,
+                    action_type="wifi_ap.Legacy.SetConfig",
+                    device_ip=IP,
+                    message="bad",
+                    error="Bad Request",
+                )
+            return _ok(key)
+
+        mock_device_gateway.execute_component_action = AsyncMock(
+            side_effect=side_effect
+        )
+
+        result = await use_case.restore(1, IP, component_keys=["wifi"])
+
+        assert result.success is False
+        entry = next(c for c in result.components if c.key == "wifi")
+        assert entry.success is False
+        assert entry.error == "wifi_ap: Bad Request"
 
     async def test_it_renames_the_roller_button_type_to_its_setter_name(
         self, use_case, mock_device_gateway
@@ -597,7 +702,8 @@ class TestRestoreGen1DeviceConfig:
     ):
         await use_case.restore(1, IP, component_keys=["sys"])
 
-        # /settings echoes sntp.server nested; the setter takes flat sntp_server.
+        # Nested echoes (sntp.server, coiot.*, ap_roaming.*, the i3 timing
+        # blocks) flatten to the names their setters accept.
         assert self._sent(mock_device_gateway)["sys"] == {
             "name": "Hallway",
             "timezone": "Europe/Lisbon",
@@ -609,8 +715,35 @@ class TestRestoreGen1DeviceConfig:
             "lng": -9.1393,
             "discoverable": True,
             "led_status_disable": False,
+            "led_power_disable": False,
+            "max_power": 3500,
+            "longpush_time": 1000,
+            "factory_reset_from_switch": True,
+            "wifirecovery_reboot_enabled": True,
+            "debug_enable": False,
+            "allow_cross_origin": False,
+            "supply_voltage": 0,
+            "power_correction": 1,
+            "favorites_enabled": True,
+            "coiot_enable": True,
+            "coiot_update_period": 15,
+            "coiot_peer": "10.0.0.2:5683",
+            "ap_roaming_enabled": True,
+            "ap_roaming_threshold": -70,
+            "longpush_duration_ms_min": 800,
+            "longpush_duration_ms_max": 3000,
+            "multipush_time_between_pushes_ms_max": 500,
             "sntp_server": "pool.ntp.org",
         }
+
+    async def test_it_never_sends_mode_in_the_sys_batch(
+        self, use_case, mock_device_gateway
+    ):
+        await use_case.restore(1, IP, component_keys=["sys"])
+
+        # A mode change reboots the device, so it only ever travels through the
+        # dedicated pre-phase, never the sys param batch.
+        assert "mode" not in self._sent(mock_device_gateway)["sys"]
 
     async def test_it_prefixes_mqtt_params(self, use_case, mock_device_gateway):
         await use_case.restore(1, IP, component_keys=["mqtt"])
@@ -635,7 +768,12 @@ class TestRestoreGen1DeviceConfig:
     ):
         result = await use_case.restore(1, IP)
 
-        assert set(self._sent(mock_device_gateway)) == {"sys", "switch:0", "cover:0"}
+        assert set(self._sent(mock_device_gateway)) == {
+            "sys",
+            "switch:0",
+            "cover:0",
+            "input:0",
+        }
         assert result.success is True
 
     async def test_it_orders_network_components_last(
@@ -646,7 +784,8 @@ class TestRestoreGen1DeviceConfig:
         )
 
         order = list(self._sent(mock_device_gateway))
-        assert set(order[-3:]) == {"wifi", "mqtt", "cloud"}
+        assert order[:2] == ["switch:0", "sys"]
+        assert set(order[2:]) == {"wifi", "wifi_sta1", "wifi_ap", "mqtt", "cloud"}
 
     async def test_it_skips_everything_when_the_snapshot_lacks_raw_settings(
         self, use_case, mock_device_gateway, mock_repository
@@ -660,6 +799,9 @@ class TestRestoreGen1DeviceConfig:
         assert result.success is False
         assert result.skipped == len(result.components)
         assert result.message == "snapshot lacks raw Gen1 settings"
+        # The default selection never restores network components, so they are
+        # not reported as skipped either.
+        assert {"wifi", "mqtt", "cloud"}.isdisjoint({c.key for c in result.components})
         mock_device_gateway.execute_component_action.assert_not_called()
 
     async def test_it_never_restores_the_legacy_settings_entry(
@@ -673,16 +815,34 @@ class TestRestoreGen1DeviceConfig:
         assert entry.skipped is True
         assert entry.skipped_reason == "not a restorable component"
 
-    async def test_it_skips_components_without_a_gen1_settings_endpoint(
+    async def test_it_restores_input_settings_via_their_own_endpoint(
         self, use_case, mock_device_gateway
     ):
         result = await use_case.restore(1, IP, component_keys=["input:0"])
 
-        # Gen1 input config lives on the owning relay; there is nothing to write.
+        # i3/Button1 expose /settings/input/{i}; the snapshot echoes its params.
+        assert result.success is True
+        assert self._sent(mock_device_gateway)["input:0"] == {
+            "name": "Left button",
+            "btn_type": "momentary",
+            "btn_reverse": 0,
+        }
+
+    async def test_it_skips_inputs_when_the_snapshot_has_no_input_settings(
+        self, use_case, mock_device_gateway, mock_repository
+    ):
+        # Relay-bearing models never echo an "inputs" settings section: their
+        # input config lives on, and restores with, the owning relay.
+        settings = _gen1_settings()
+        settings.pop("inputs")
+        mock_repository.get = AsyncMock(return_value=_gen1_backup(settings=settings))
+
+        result = await use_case.restore(1, IP, component_keys=["input:0"])
+
         assert self._sent(mock_device_gateway) == {}
         entry = next(c for c in result.components if c.key == "input:0")
         assert entry.skipped is True
-        assert entry.skipped_reason == "no Gen1 settings endpoint for this component"
+        assert entry.skipped_reason == "no restorable settings captured in backup"
 
     async def test_it_skips_a_component_missing_from_the_captured_settings(
         self, use_case, mock_device_gateway, mock_repository
@@ -722,8 +882,12 @@ class TestRestoreGen1DeviceConfig:
         assert reboots == [("sys", "Legacy.Reboot")]
 
     async def test_it_does_not_reboot_when_nothing_was_applied(
-        self, use_case, mock_device_gateway
+        self, use_case, mock_device_gateway, mock_repository
     ):
+        settings = _gen1_settings()
+        settings.pop("inputs")
+        mock_repository.get = AsyncMock(return_value=_gen1_backup(settings=settings))
+
         result = await use_case.restore(1, IP, component_keys=["input:0"], reboot=True)
 
         assert result.success is False
@@ -767,3 +931,133 @@ class TestRestoreGen1DeviceConfig:
         assert result.success is False
         assert result.message == "Backup and device generations differ"
         mock_device_gateway.execute_component_action.assert_not_called()
+
+    async def test_it_switches_mode_before_restoring(
+        self, use_case, mock_device_gateway, mock_repository
+    ):
+        # Backup taken in roller mode; the target boots in relay mode and only
+        # enumerates its cover component after the mode change reboots it.
+        settings = _gen1_settings()
+        settings["mode"] = "roller"
+        mock_repository.get = AsyncMock(return_value=_gen1_backup(settings=settings))
+        mock_device_gateway.get_device_status = AsyncMock(
+            side_effect=[
+                _status(keys=("sys", "switch:0", "switch:1"), gen=1),
+                _status(keys=("sys", "cover:0"), gen=1),
+            ]
+        )
+        mock_device_gateway.get_legacy_settings = AsyncMock(
+            return_value={"mode": "relay"}
+        )
+
+        result = await use_case.restore(1, IP, component_keys=["cover:0"])
+
+        calls = [
+            (call.args[1], call.args[3])
+            for call in mock_device_gateway.execute_component_action.call_args_list
+            if call.args[2] == "Legacy.SetConfig"
+        ]
+        assert calls[0] == ("sys", {"mode": "roller"})
+        assert calls[1][0] == "cover:0"
+        mode_entry = next(c for c in result.components if c.key == "mode")
+        assert mode_entry.success is True
+        assert result.success is True
+
+    async def test_it_skips_the_mode_phase_when_modes_match(
+        self, use_case, mock_device_gateway
+    ):
+        result = await use_case.restore(1, IP, component_keys=["sys"])
+
+        assert "mode" not in {c.key for c in result.components}
+        assert mock_device_gateway.get_device_status.await_count == 1
+
+    async def test_it_skips_the_mode_phase_when_the_backup_lacks_a_mode(
+        self, use_case, mock_device_gateway, mock_repository
+    ):
+        settings = _gen1_settings()
+        settings.pop("mode")
+        mock_repository.get = AsyncMock(return_value=_gen1_backup(settings=settings))
+
+        result = await use_case.restore(1, IP, component_keys=["sys"])
+
+        mock_device_gateway.get_legacy_settings.assert_not_called()
+        assert "mode" not in {c.key for c in result.components}
+
+    async def test_it_reports_when_the_target_mode_cannot_be_read(
+        self, use_case, mock_device_gateway
+    ):
+        mock_device_gateway.get_legacy_settings = AsyncMock(return_value=None)
+
+        result = await use_case.restore(1, IP, component_keys=["switch:0"])
+
+        # Surfaced as a skip rather than silently proceeding blind, and the
+        # rest of the restore still runs.
+        entry = next(c for c in result.components if c.key == "mode")
+        assert entry.skipped is True
+        assert entry.skipped_reason == "could not read the target device mode"
+        assert "switch:0" in self._sent(mock_device_gateway)
+        assert result.success is True
+
+    async def test_it_fails_the_restore_when_the_mode_change_fails(
+        self, use_case, mock_device_gateway, mock_repository
+    ):
+        settings = _gen1_settings()
+        settings["mode"] = "roller"
+        mock_repository.get = AsyncMock(return_value=_gen1_backup(settings=settings))
+        mock_device_gateway.get_legacy_settings = AsyncMock(
+            return_value={"mode": "relay"}
+        )
+
+        def side_effect(ip, key, action, params):
+            if params == {"mode": "roller"}:
+                return ActionResult(
+                    success=False,
+                    action_type="sys.Legacy.SetConfig",
+                    device_ip=IP,
+                    message="bad",
+                    error="Bad Request",
+                )
+            return _ok(key)
+
+        mock_device_gateway.execute_component_action = AsyncMock(
+            side_effect=side_effect
+        )
+
+        result = await use_case.restore(1, IP)
+
+        assert result.success is False
+        assert (result.total, result.failed) == (1, 1)
+        assert result.message == "Bad Request"
+        assert len(mock_device_gateway.execute_component_action.call_args_list) == 1
+
+    async def test_it_fails_when_the_device_never_returns_after_the_mode_change(
+        self, mock_device_gateway, mock_repository
+    ):
+        @asynccontextmanager
+        async def repository_factory():
+            yield mock_repository
+
+        settings = _gen1_settings()
+        settings["mode"] = "roller"
+        mock_repository.get = AsyncMock(return_value=_gen1_backup(settings=settings))
+        mock_device_gateway.get_device_status = AsyncMock(
+            side_effect=[_status(keys=GEN1_KEYS, gen=1)] + [None] * 50
+        )
+        mock_device_gateway.get_legacy_settings = AsyncMock(
+            return_value={"mode": "relay"}
+        )
+        mock_device_gateway.execute_component_action = AsyncMock(
+            side_effect=lambda ip, key, action, params: _ok(key)
+        )
+        use_case = RestoreDeviceConfig(
+            device_gateway=mock_device_gateway,
+            repository_factory=repository_factory,
+            mode_change_timeout=0.05,
+            mode_change_poll_interval=0.01,
+        )
+
+        result = await use_case.restore(1, IP)
+
+        assert result.success is False
+        assert result.message == "device did not come back after the mode change"
+        assert (result.total, result.failed) == (1, 1)

--- a/packages/core/tests/unit/use_cases/test_restore_device_config.py
+++ b/packages/core/tests/unit/use_cases/test_restore_device_config.py
@@ -47,6 +47,115 @@ def _backup(generation="gen2"):
     )
 
 
+def _gen1_settings():
+    """A raw Gen1 /settings payload, shaped as the device echoes it.
+
+    Field names follow https://shelly-api-docs.shelly.cloud/gen1/ — note the
+    read-only echoes (ison/has_timer/power) and the fields GET names differently
+    from their setter (wifi gw/mask, roller button_type, nested sntp.server).
+    """
+    return {
+        "device": {"type": "SHSW-1", "mac": "AABBCCDDEEFF"},
+        "fw": "20230913-112003/v1.14.0",
+        "name": "Hallway",
+        "timezone": "Europe/Lisbon",
+        "tzautodetect": False,
+        "tz_utc_offset": 3600,
+        "tz_dst": False,
+        "tz_dst_auto": True,
+        "lat": 38.7223,
+        "lng": -9.1393,
+        "discoverable": True,
+        "led_status_disable": False,
+        "sntp": {"server": "pool.ntp.org", "enabled": True},
+        "login": {"enabled": True, "username": "admin"},
+        "relays": [
+            {
+                "name": "Hallway light",
+                "appliance_type": "General",
+                "ison": True,
+                "has_timer": False,
+                "power": 12.5,
+                "default_state": "last",
+                "btn_type": "momentary",
+                "btn_reverse": 0,
+                "auto_on": 0,
+                "auto_off": 30.5,
+                "schedule": True,
+                "schedule_rules": ["0700-012345-on", "2200-012345-off"],
+                "max_power": 0,
+            }
+        ],
+        "rollers": [
+            {
+                "maxtime": 20,
+                "maxtime_open": 25,
+                "maxtime_close": 24,
+                "default_state": "stop",
+                "swap": False,
+                "input_mode": "openclose",
+                "button_type": "toggle",
+                "btn_reverse": 0,
+                "state": "stop",
+                "power": 0,
+                "is_valid": True,
+                "safety_switch": False,
+                "positioning": True,
+                "schedule_rules": [],
+            }
+        ],
+        "wifi_sta": {
+            "enabled": True,
+            "ssid": "Castle",
+            "ipv4_method": "static",
+            "ip": "192.168.1.100",
+            "gw": "192.168.1.1",
+            "mask": "255.255.255.0",
+            "dns": "8.8.8.8",
+        },
+        "mqtt": {
+            "enable": True,
+            "server": "10.0.0.1:1883",
+            "user": "shelly",
+            "id": "shelly1-DDEEFF",
+            "clean_session": True,
+            "retain": False,
+            "keep_alive": 60,
+            "max_qos": 0,
+            "update_period": 30,
+            "reconnect_timeout_min": 2.0,
+            "reconnect_timeout_max": 60.0,
+        },
+        "cloud": {"enabled": True, "connected": True},
+    }
+
+
+GEN1_KEYS = ("sys", "wifi", "cloud", "mqtt", "switch:0", "cover:0", "input:0")
+
+
+def _gen1_backup(settings=None, with_settings_entry=True):
+    """A Gen1 backup: Gen2-shaped mapped configs plus the raw /settings entry."""
+    components = {
+        key: {"type": key.split(":")[0], "success": True, "config": {"name": "mapped"}}
+        for key in GEN1_KEYS
+    }
+    if with_settings_entry:
+        components["legacy_settings"] = {
+            "type": "legacy_settings",
+            "success": True,
+            "config": _gen1_settings() if settings is None else settings,
+        }
+    return DeviceBackup(
+        device_mac="AABBCCDDEEFF",
+        snapshot={
+            "device_info": {"mac_address": "AABBCCDDEEFF"},
+            "components": components,
+        },
+        generation="gen1",
+        id=1,
+    )
+
+
 def _status(
     mac="AA:BB:CC:DD:EE:FF",
     keys=("switch:0", "sys", "wifi"),
@@ -377,7 +486,7 @@ class TestRestoreDeviceConfig:
         sched = next(c for c in result.components if c.key == "schedules")
         assert sched.success is False
 
-    async def test_it_reports_unknown_keys_on_gen1_path(
+    async def test_it_reports_unknown_keys_on_generation_mismatch(
         self, use_case, mock_device_gateway, mock_repository
     ):
         mock_repository.get = AsyncMock(return_value=_backup(generation="gen1"))
@@ -387,5 +496,274 @@ class TestRestoreDeviceConfig:
         reasons = {c.key: c.skipped_reason for c in result.components}
         assert set(reasons) == {"sys", "bogus:9"}
         assert reasons["bogus:9"] == "not present in backup"
-        assert "Gen1 restore not supported" in reasons["sys"]
+        assert "generation does not match" in reasons["sys"]
+        mock_device_gateway.execute_component_action.assert_not_called()
+
+
+class TestRestoreGen1DeviceConfig:
+    """Gen1 restore replays the raw /settings snapshot over Gen1 HTTP endpoints."""
+
+    @pytest.fixture
+    def mock_repository(self):
+        repo = AsyncMock()
+        repo.get = AsyncMock(return_value=_gen1_backup())
+        return repo
+
+    @pytest.fixture
+    def use_case(self, mock_device_gateway, mock_repository):
+        @asynccontextmanager
+        async def repository_factory():
+            yield mock_repository
+
+        mock_device_gateway.get_device_status = AsyncMock(
+            return_value=_status(keys=GEN1_KEYS, app_name="SHSW-1", gen=1)
+        )
+        mock_device_gateway.execute_component_action = AsyncMock(
+            side_effect=lambda ip, key, action, params: _ok(key)
+        )
+        return RestoreDeviceConfig(
+            device_gateway=mock_device_gateway,
+            repository_factory=repository_factory,
+        )
+
+    def _sent(self, mock_device_gateway):
+        return {
+            call.args[1]: call.args[3]
+            for call in mock_device_gateway.execute_component_action.call_args_list
+            if call.args[2] == "Legacy.SetConfig"
+        }
+
+    async def test_it_restores_relay_settings_from_the_raw_settings(
+        self, use_case, mock_device_gateway
+    ):
+        result = await use_case.restore(1, IP, component_keys=["switch:0"])
+
+        assert result.success is True
+        # Exactly the documented settable params of /settings/relay/{index},
+        # sourced from the raw snapshot rather than the Gen2-shaped mapped config.
+        assert self._sent(mock_device_gateway)["switch:0"] == {
+            "name": "Hallway light",
+            "appliance_type": "General",
+            "default_state": "last",
+            "btn_type": "momentary",
+            "btn_reverse": 0,
+            "auto_on": 0,
+            "auto_off": 30.5,
+            "schedule": True,
+            "schedule_rules": ["0700-012345-on", "2200-012345-off"],
+            "max_power": 0,
+        }
+
+    async def test_it_drops_readonly_relay_fields(self, use_case, mock_device_gateway):
+        await use_case.restore(1, IP, component_keys=["switch:0"])
+
+        sent = self._sent(mock_device_gateway)["switch:0"]
+        # Echoed by GET /settings but rejected/meaningless as settings.
+        for read_only in ("ison", "has_timer", "power"):
+            assert read_only not in sent
+
+    async def test_it_renames_wifi_fields_to_their_setter_names(
+        self, use_case, mock_device_gateway
+    ):
+        await use_case.restore(1, IP, component_keys=["wifi"])
+
+        # GET /settings echoes gw/mask; /settings/sta only accepts gateway/netmask.
+        assert self._sent(mock_device_gateway)["wifi"] == {
+            "enabled": True,
+            "ssid": "Castle",
+            "ipv4_method": "static",
+            "ip": "192.168.1.100",
+            "gateway": "192.168.1.1",
+            "netmask": "255.255.255.0",
+            "dns": "8.8.8.8",
+        }
+
+    async def test_it_renames_the_roller_button_type_to_its_setter_name(
+        self, use_case, mock_device_gateway
+    ):
+        await use_case.restore(1, IP, component_keys=["cover:0"])
+
+        sent = self._sent(mock_device_gateway)["cover:0"]
+        # GET /settings echoes button_type; /settings/roller/{i} accepts btn_type.
+        assert sent["btn_type"] == "toggle"
+        assert "button_type" not in sent
+        assert sent["maxtime_open"] == 25
+        assert sent["schedule_rules"] == []
+        for read_only in ("state", "power", "is_valid", "safety_switch"):
+            assert read_only not in sent
+
+    async def test_it_flattens_the_nested_sntp_server_for_sys(
+        self, use_case, mock_device_gateway
+    ):
+        await use_case.restore(1, IP, component_keys=["sys"])
+
+        # /settings echoes sntp.server nested; the setter takes flat sntp_server.
+        assert self._sent(mock_device_gateway)["sys"] == {
+            "name": "Hallway",
+            "timezone": "Europe/Lisbon",
+            "tzautodetect": False,
+            "tz_utc_offset": 3600,
+            "tz_dst": False,
+            "tz_dst_auto": True,
+            "lat": 38.7223,
+            "lng": -9.1393,
+            "discoverable": True,
+            "led_status_disable": False,
+            "sntp_server": "pool.ntp.org",
+        }
+
+    async def test_it_prefixes_mqtt_params(self, use_case, mock_device_gateway):
+        await use_case.restore(1, IP, component_keys=["mqtt"])
+
+        # Gen1 has no /settings/mqtt: the settings are mqtt_*-prefixed on /settings.
+        assert self._sent(mock_device_gateway)["mqtt"] == {
+            "mqtt_enable": True,
+            "mqtt_server": "10.0.0.1:1883",
+            "mqtt_user": "shelly",
+            "mqtt_id": "shelly1-DDEEFF",
+            "mqtt_clean_session": True,
+            "mqtt_retain": False,
+            "mqtt_keep_alive": 60,
+            "mqtt_max_qos": 0,
+            "mqtt_update_period": 30,
+            "mqtt_reconnect_timeout_min": 2.0,
+            "mqtt_reconnect_timeout_max": 60.0,
+        }
+
+    async def test_it_excludes_network_components_by_default(
+        self, use_case, mock_device_gateway
+    ):
+        result = await use_case.restore(1, IP)
+
+        assert set(self._sent(mock_device_gateway)) == {"sys", "switch:0", "cover:0"}
+        assert result.success is True
+
+    async def test_it_orders_network_components_last(
+        self, use_case, mock_device_gateway
+    ):
+        await use_case.restore(
+            1, IP, component_keys=["wifi", "mqtt", "switch:0", "sys", "cloud"]
+        )
+
+        order = list(self._sent(mock_device_gateway))
+        assert set(order[-3:]) == {"wifi", "mqtt", "cloud"}
+
+    async def test_it_skips_everything_when_the_snapshot_lacks_raw_settings(
+        self, use_case, mock_device_gateway, mock_repository
+    ):
+        mock_repository.get = AsyncMock(
+            return_value=_gen1_backup(with_settings_entry=False)
+        )
+
+        result = await use_case.restore(1, IP)
+
+        assert result.success is False
+        assert result.skipped == len(result.components)
+        assert result.message == "snapshot lacks raw Gen1 settings"
+        mock_device_gateway.execute_component_action.assert_not_called()
+
+    async def test_it_never_restores_the_legacy_settings_entry(
+        self, use_case, mock_device_gateway
+    ):
+        result = await use_case.restore(1, IP, component_keys=["legacy_settings"])
+
+        # It is the data source, not a component that exists on the device.
+        assert self._sent(mock_device_gateway) == {}
+        entry = next(c for c in result.components if c.key == "legacy_settings")
+        assert entry.skipped is True
+        assert entry.skipped_reason == "not a restorable component"
+
+    async def test_it_skips_components_without_a_gen1_settings_endpoint(
+        self, use_case, mock_device_gateway
+    ):
+        result = await use_case.restore(1, IP, component_keys=["input:0"])
+
+        # Gen1 input config lives on the owning relay; there is nothing to write.
+        assert self._sent(mock_device_gateway) == {}
+        entry = next(c for c in result.components if c.key == "input:0")
+        assert entry.skipped is True
+        assert entry.skipped_reason == "no Gen1 settings endpoint for this component"
+
+    async def test_it_skips_a_component_missing_from_the_captured_settings(
+        self, use_case, mock_device_gateway, mock_repository
+    ):
+        settings = _gen1_settings()
+        settings["relays"] = []
+        mock_repository.get = AsyncMock(return_value=_gen1_backup(settings=settings))
+
+        result = await use_case.restore(1, IP, component_keys=["switch:0"])
+
+        assert self._sent(mock_device_gateway) == {}
+        entry = next(c for c in result.components if c.key == "switch:0")
+        assert entry.skipped_reason == "no restorable settings captured in backup"
+
+    async def test_it_skips_components_absent_on_the_target(
+        self, use_case, mock_device_gateway
+    ):
+        mock_device_gateway.get_device_status = AsyncMock(
+            return_value=_status(keys=("sys",), gen=1)
+        )
+
+        result = await use_case.restore(1, IP, component_keys=["switch:0", "sys"])
+
+        entry = next(c for c in result.components if c.key == "switch:0")
+        assert entry.skipped_reason == "component not present on target device"
+
+    async def test_it_reboots_via_the_legacy_endpoint(
+        self, use_case, mock_device_gateway
+    ):
+        await use_case.restore(1, IP, component_keys=["sys"], reboot=True)
+
+        reboots = [
+            call.args[1:3]
+            for call in mock_device_gateway.execute_component_action.call_args_list
+            if call.args[2] == "Legacy.Reboot"
+        ]
+        assert reboots == [("sys", "Legacy.Reboot")]
+
+    async def test_it_does_not_reboot_when_nothing_was_applied(
+        self, use_case, mock_device_gateway
+    ):
+        result = await use_case.restore(1, IP, component_keys=["input:0"], reboot=True)
+
+        assert result.success is False
+        assert mock_device_gateway.execute_component_action.call_args_list == []
+
+    async def test_it_records_per_component_failure(
+        self, use_case, mock_device_gateway
+    ):
+        def side_effect(ip, key, action, params):
+            if key == "switch:0":
+                return ActionResult(
+                    success=False,
+                    action_type="switch:0.Legacy.SetConfig",
+                    device_ip=IP,
+                    message="bad",
+                    error="Bad Request",
+                )
+            return _ok(key)
+
+        mock_device_gateway.execute_component_action = AsyncMock(
+            side_effect=side_effect
+        )
+
+        result = await use_case.restore(1, IP, component_keys=["switch:0", "sys"])
+
+        assert (result.succeeded, result.failed) == (1, 1)
+        assert result.success is False
+        failed = next(c for c in result.components if c.key == "switch:0")
+        assert failed.action == "Legacy.SetConfig"
+        assert failed.error == "Bad Request"
+
+    async def test_it_refuses_a_gen1_backup_on_a_gen2_target(
+        self, use_case, mock_device_gateway
+    ):
+        mock_device_gateway.get_device_status = AsyncMock(
+            return_value=_status(keys=GEN1_KEYS, gen=2)
+        )
+
+        result = await use_case.restore(1, IP)
+
+        assert result.success is False
+        assert result.message == "Backup and device generations differ"
         mock_device_gateway.execute_component_action.assert_not_called()

--- a/packages/web/src/components/backup-schedules/backups-table-section.tsx
+++ b/packages/web/src/components/backup-schedules/backups-table-section.tsx
@@ -48,7 +48,7 @@ export function BackupsTableSection() {
   const items = data?.items ?? [];
   const total = data?.total ?? 0;
 
-  // Step back only on a *successful* empty page — not on a transient error,
+  // Step back only on a *successful* empty page, not on a transient error,
   // which also yields items=[] and would otherwise rewind pagination state.
   useEffect(() => {
     if (isSuccess && items.length === 0 && offset >= PAGE_SIZE) {

--- a/packages/web/src/components/device-detail/backups-section.tsx
+++ b/packages/web/src/components/device-detail/backups-section.tsx
@@ -77,7 +77,7 @@ export function BackupsSection({
     setOffset(0);
   }, [deviceMac]);
 
-  // Step back only on a *successful* empty page — not on a transient error,
+  // Step back only on a *successful* empty page, not on a transient error,
   // which also yields items=[] and would otherwise rewind pagination state.
   useEffect(() => {
     if (isSuccess && items.length === 0 && offset >= PAGE_SIZE) {
@@ -313,7 +313,7 @@ function RestoreDialog({
                   {c.network && (
                     <span className="inline-flex items-center gap-1 text-xs text-amber-600">
                       <AlertTriangle className="h-3 w-3" />
-                      network — may disconnect
+                      network (may disconnect)
                     </span>
                   )}
                 </Label>


### PR DESCRIPTION
## Purpose

Restore Gen1 devices, not just back them up.

## Context

Gen1 has no per-component `SetConfig` RPC, so restore refused these devices outright. It now replays the raw `/settings` captured in the snapshot over the legacy HTTP settings endpoints, sending only the params the [Gen1 docs](https://shelly-api-docs.shelly.cloud/gen1/) list as settable.

Worth knowing while reviewing the allowlist tables: `GET /settings` echoes three fields under names their setters don't accept: wifi `gw`/`mask` vs `gateway`/`netmask`, roller `button_type` vs `btn_type`, and nested `sntp.server` vs flat `sntp_server`. Gen1 ignores unknown query params silently, so a missing re-key means a restore that reports success and writes nothing.

Secrets can't round-trip: Gen1 never echoes the WiFi `key` or `mqtt_pass`, so restoring `wifi`/`mqtt` re-applies everything except the password. 


Fixes #51.

## Notes

Excluded relay `power` deliberately: a settable user power constant on Shelly1, but a live reading on metered models. Happy to revisit.

@lucarui let me know if you can test this, please 🙏 