### PR TITLE
Fix bulk action validation and other standalone bugs

### DIFF
--- a/packages/api/src/api/controllers/monitoring.py
+++ b/packages/api/src/api/controllers/monitoring.py
@@ -7,10 +7,6 @@ from typing import Any
 
 from litestar import get
 
-from ..dependencies.container import APIContainer
-
-_container = APIContainer()
-
 
 @get("/health", tags=["Health"], summary="Health Check")
 async def health_check() -> dict[str, Any]:

--- a/packages/core/src/core/gateways/device/shelly_device_gateway.py
+++ b/packages/core/src/core/gateways/device/shelly_device_gateway.py
@@ -422,7 +422,7 @@ class ShellyDeviceGateway(DeviceGateway):
         """
         allowed_bulk_operations = SHELLY_SYSTEM_ACTIONS
 
-        if action not in allowed_bulk_operations and component_key.lower() != "shelly":
+        if action not in allowed_bulk_operations or component_key.lower() != "shelly":
             raise ValueError(
                 f"Bulk operation '{component_key}.{action}' is not supported. "
                 f"Supported operations: shelly.Update, shelly.Reboot, shelly.FactoryReset"

--- a/packages/core/src/core/use_cases/bulk_operations.py
+++ b/packages/core/src/core/use_cases/bulk_operations.py
@@ -1,3 +1,4 @@
+import logging
 from datetime import UTC, datetime
 from typing import Any
 
@@ -5,6 +6,8 @@ from ..domain.entities.device_status import DeviceStatus
 from ..domain.entities.exceptions import BulkOperationError
 from ..domain.value_objects.action_result import ActionResult
 from ..gateways.device import DeviceGateway
+
+logger = logging.getLogger(__name__)
 
 
 class BulkOperationsUseCase:
@@ -98,7 +101,7 @@ class BulkOperationsUseCase:
                 if device:
                     results.append(device)
             except Exception as e:
-                print(f"Error getting status for {ip}: {str(e)}")
+                logger.warning("Error getting status for %s: %s", ip, e)
 
         return results
 

--- a/packages/core/tests/unit/gateways/device/test_shelly_device_gateway.py
+++ b/packages/core/tests/unit/gateways/device/test_shelly_device_gateway.py
@@ -725,6 +725,28 @@ class TestShellyDeviceGateway:
         assert all(result.action_type == "shelly.Reboot" for result in results)
         assert mock_rpc_client.make_rpc_request.call_count == 6
 
+    async def test_it_rejects_bulk_action_with_unsupported_action(
+        self, gateway, mock_rpc_client
+    ):
+        mock_rpc_client.make_rpc_request = AsyncMock()
+
+        with pytest.raises(ValueError, match="not supported"):
+            await gateway.execute_bulk_action(
+                ["192.168.1.100"], "shelly", "AnythingAtAll"
+            )
+
+        mock_rpc_client.make_rpc_request.assert_not_called()
+
+    async def test_it_rejects_bulk_action_with_unsupported_component(
+        self, gateway, mock_rpc_client
+    ):
+        mock_rpc_client.make_rpc_request = AsyncMock()
+
+        with pytest.raises(ValueError, match="not supported"):
+            await gateway.execute_bulk_action(["192.168.1.100"], "switch:0", "Update")
+
+        mock_rpc_client.make_rpc_request.assert_not_called()
+
     async def test_it_handles_device_with_partial_info(self, gateway, mock_rpc_client):
         device_info = {"id": "minimal-device"}
         mock_rpc_client.make_rpc_request = AsyncMock(return_value=(device_info, 0.1))

--- a/packages/core/tests/unit/use_cases/test_bulk_operations.py
+++ b/packages/core/tests/unit/use_cases/test_bulk_operations.py
@@ -202,6 +202,37 @@ class TestBulkOperationsUseCase:
         assert update_result == []
         assert reboot_result == []
 
+    async def test_it_gets_bulk_status_for_multiple_devices(
+        self, use_case, mock_device_gateway
+    ):
+        statuses = [
+            DeviceStatus(device_ip="192.168.1.100"),
+            DeviceStatus(device_ip="192.168.1.101"),
+        ]
+        mock_device_gateway.get_device_status = AsyncMock(side_effect=statuses)
+
+        results = await use_case.get_bulk_status(["192.168.1.100", "192.168.1.101"])
+
+        assert results == statuses
+
+    async def test_it_logs_warning_and_skips_device_on_status_failure(
+        self, use_case, mock_device_gateway, caplog
+    ):
+        status = DeviceStatus(device_ip="192.168.1.101")
+        mock_device_gateway.get_device_status = AsyncMock(
+            side_effect=[Exception("Connection refused"), status]
+        )
+
+        with caplog.at_level("WARNING", logger="core.use_cases.bulk_operations"):
+            results = await use_case.get_bulk_status(["192.168.1.100", "192.168.1.101"])
+
+        assert results == [status]
+        assert any(
+            "192.168.1.100" in record.getMessage()
+            and "Connection refused" in record.getMessage()
+            for record in caplog.records
+        )
+
     @pytest.fixture
     def mock_device_status_with_components(self):
         return DeviceStatus(

--- a/packages/web/src/components/backup-schedules/backups-table-section.tsx
+++ b/packages/web/src/components/backup-schedules/backups-table-section.tsx
@@ -58,8 +58,9 @@ export function BackupsTableSection() {
 
   const deleteMutation = useMutation({
     mutationFn: (id: number) => backupApi.deleteBackup(id),
-    onSuccess: () => {
+    onSuccess: (_data, id) => {
       toast.success("Backup deleted");
+      queryClient.removeQueries({ queryKey: ["backup", id] });
       queryClient.invalidateQueries({ queryKey: ["backups"] });
     },
     onError: (err) => toast.error(handleApiError(err)),

--- a/packages/web/src/hooks/useBackups.ts
+++ b/packages/web/src/hooks/useBackups.ts
@@ -39,8 +39,9 @@ export function useDeleteBackup() {
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: (backupId: number) => backupApi.deleteBackup(backupId),
-    onSuccess: () => {
+    onSuccess: (_data, backupId) => {
       toast.success("Backup deleted");
+      queryClient.removeQueries({ queryKey: ["backup", backupId] });
       queryClient.invalidateQueries({ queryKey: ["backups"] });
     },
     onError: (error) => toast.error(handleApiError(error)),


### PR DESCRIPTION
## Purpose

Standalone bug fixes ahead of the architecture refactor phases.

## Context

`execute_bulk_action` validated with `and` where it needed `or`, so an unsupported action passed as long as the component was `shelly`, and a supported action passed on any component; only requests wrong on both counts were rejected. Also fixes `get_bulk_status` swallowing every status failure through a bare `print()`, removes an unused module-level `APIContainer` in the monitoring controller, and drops the web `["backup", id]` detail query on delete, which sits outside the `["backups"]` invalidation prefix and survived deletion.
