### PR TITLE
Share container wiring and fix CLI credential commands

### DIFF
--- a/packages/api/src/api/dependencies/container.py
+++ b/packages/api/src/api/dependencies/container.py
@@ -2,118 +2,15 @@
 Dependency injection container for API layer.
 """
 
-from collections.abc import AsyncGenerator
-from contextlib import asynccontextmanager
-
 from core.dependencies.container_base import BaseContainer
-from core.gateways.network.async_shelly_rpc_client import AsyncShellyRPCClient
-from core.repositories.db import async_session_factory
-from core.repositories.sqlalchemy_backup_repository import (
-    SQLAlchemyBackupRepository,
-)
-from core.repositories.sqlalchemy_backup_schedule_repository import (
-    SQLAlchemyBackupScheduleRepository,
-)
-from core.repositories.sqlalchemy_credentials_repository import (
-    SQLAlchemyCredentialsRepository,
-)
-from core.repositories.sqlalchemy_provisioning_profile_repository import (
-    SQLAlchemyProvisioningProfileRepository,
-)
-from core.services.authentication_service import AuthenticationService
-from core.services.encryption_service import EncryptionService
-from core.settings import settings as core_settings
 from core.use_cases.manage_credentials import ManageCredentialsUseCase
 from litestar.di import Provide
-from sqlalchemy.ext.asyncio import AsyncSession
 
 
 class APIContainer(BaseContainer):
     def __init__(self) -> None:
         super().__init__()
-        self._rpc_client: AsyncShellyRPCClient | None = None
-        self._auth_service: AuthenticationService | None = None
-        self._encryption_service: EncryptionService | None = None
         self._credentials_use_case: ManageCredentialsUseCase | None = None
-
-    def get_encryption_service(self) -> EncryptionService:
-        if self._encryption_service is None:
-            self._encryption_service = EncryptionService()
-        return self._encryption_service
-
-    async def get_db_session(self) -> AsyncGenerator[AsyncSession, None]:
-        async with async_session_factory() as session:
-            try:
-                yield session
-            finally:
-                await session.close()
-
-    def get_credentials_repository(
-        self, session: AsyncSession
-    ) -> SQLAlchemyCredentialsRepository:
-        return SQLAlchemyCredentialsRepository(session, self.get_encryption_service())
-
-    @asynccontextmanager
-    async def create_credentials_repository(
-        self,
-    ) -> AsyncGenerator[SQLAlchemyCredentialsRepository, None]:
-        async with async_session_factory() as session:
-            try:
-                yield SQLAlchemyCredentialsRepository(
-                    session, self.get_encryption_service()
-                )
-            finally:
-                await session.close()
-
-    @asynccontextmanager
-    async def create_provisioning_profile_repository(
-        self,
-    ) -> AsyncGenerator[SQLAlchemyProvisioningProfileRepository, None]:
-        async with async_session_factory() as session:
-            try:
-                yield SQLAlchemyProvisioningProfileRepository(
-                    session, self.get_encryption_service()
-                )
-            finally:
-                await session.close()
-
-    @asynccontextmanager
-    async def create_backup_repository(
-        self,
-    ) -> AsyncGenerator[SQLAlchemyBackupRepository, None]:
-        async with async_session_factory() as session:
-            try:
-                yield SQLAlchemyBackupRepository(session, self.get_encryption_service())
-            finally:
-                await session.close()
-
-    @asynccontextmanager
-    async def create_backup_schedule_repository(
-        self,
-    ) -> AsyncGenerator[SQLAlchemyBackupScheduleRepository, None]:
-        async with async_session_factory() as session:
-            try:
-                yield SQLAlchemyBackupScheduleRepository(session)
-            finally:
-                await session.close()
-
-    def get_authentication_service(self) -> AuthenticationService:
-        if self._auth_service is None:
-            self._auth_service = AuthenticationService(
-                repository_factory=self.create_credentials_repository
-            )
-        return self._auth_service
-
-    def get_rpc_client(self) -> AsyncShellyRPCClient:
-        if self._rpc_client is None:
-            self._rpc_client = AsyncShellyRPCClient(
-                timeout=core_settings.network.timeout,
-                connect_timeout=core_settings.network.connect_timeout,
-                verify=core_settings.network.verify_ssl,
-                authentication_service=self.get_authentication_service(),
-                auth_state_cache=self.get_auth_state_cache(),
-            )
-        return self._rpc_client
 
     def get_credentials_use_case(self) -> ManageCredentialsUseCase:
         if self._credentials_use_case is None:
@@ -129,24 +26,8 @@ class APIContainer(BaseContainer):
         return self._credentials_use_case
 
     async def close(self) -> None:
-        """Gracefully close async resources."""
-        if self._rpc_client is not None:
-            try:
-                await self._rpc_client.close()
-            except Exception:
-                pass
-
-        if self._mdns_client is not None:
-            try:
-                await self._mdns_client.close()
-            except Exception:
-                pass
-
-        await self._aclose_legacy_http_client()
-
-        self._rpc_client = None
+        await super().close()
         self._credentials_use_case = None
-        self._reset_device_caches()
 
 
 def get_dependencies(container: APIContainer) -> dict:
@@ -169,16 +50,8 @@ def get_dependencies(container: APIContainer) -> dict:
             lambda: container.get_bulk_operations_interactor(),
             sync_to_thread=False,
         ),
-        "db_session": Provide(
-            container.get_db_session,
-            sync_to_thread=False,
-        ),
         "credentials_use_case": Provide(
             lambda: container.get_credentials_use_case(),
-            sync_to_thread=False,
-        ),
-        "authentication_service": Provide(
-            lambda: container.get_authentication_service(),
             sync_to_thread=False,
         ),
         "manage_profiles_use_case": Provide(

--- a/packages/cli/src/cli/credential_commands.py
+++ b/packages/cli/src/cli/credential_commands.py
@@ -26,10 +26,11 @@ async def set_credential(
     """Set credentials for a specific device."""
     console = ctx.obj.console
     container = ctx.obj.container
-    repo = container.get_credentials_repository()
 
     try:
-        await repo.set(mac, username, password)
+        await container.initialize_database()
+        async with container.create_credentials_repository() as repo:
+            await repo.set(mac, username, password)
         console.print(f"✅ Credentials set for [bold]{mac.upper()}[/bold]")
     except Exception as e:
         console.print(Messages.error(f"Failed to set credentials: {e}"))
@@ -49,10 +50,11 @@ async def set_global_credential(
     """Set global fallback credentials."""
     console = ctx.obj.console
     container = ctx.obj.container
-    repo = container.get_credentials_repository()
 
     try:
-        await repo.set("*", username, password)
+        await container.initialize_database()
+        async with container.create_credentials_repository() as repo:
+            await repo.set("*", username, password)
         console.print("✅ Global fallback credentials set")
     except Exception as e:
         console.print(Messages.error(f"Failed to set global credentials: {e}"))
@@ -66,10 +68,15 @@ async def list_credentials(ctx: click.Context) -> None:
     """List devices with stored credentials."""
     console = ctx.obj.console
     container = ctx.obj.container
-    repo = container.get_credentials_repository()
 
     try:
-        creds = await repo.list_all()
+        await container.initialize_database()
+        async with container.create_credentials_repository() as repo:
+            creds = [
+                credential
+                for credential in await repo.list_all()
+                if credential is not None
+            ]
         if not creds:
             console.print(Messages.warning("No credentials stored."))
             return
@@ -88,6 +95,7 @@ async def list_credentials(ctx: click.Context) -> None:
         console.print(table)
     except Exception as e:
         console.print(Messages.error(f"Failed to list credentials: {e}"))
+        raise click.Abort() from None
 
 
 @credential_commands.command("delete")
@@ -98,10 +106,11 @@ async def delete_credential(ctx: click.Context, mac: str) -> None:
     """Delete credentials for a device."""
     console = ctx.obj.console
     container = ctx.obj.container
-    repo = container.get_credentials_repository()
 
     try:
-        await repo.delete(mac)
+        await container.initialize_database()
+        async with container.create_credentials_repository() as repo:
+            await repo.delete(mac)
         console.print(f"✅ Credentials deleted for [bold]{mac.upper()}[/bold]")
     except Exception as e:
         console.print(Messages.error(f"Failed to delete credentials: {e}"))

--- a/packages/cli/src/cli/dependencies/container.py
+++ b/packages/cli/src/cli/dependencies/container.py
@@ -1,122 +1,12 @@
 """Dependency injection container for CLI using shared BaseContainer."""
 
-from collections.abc import AsyncGenerator
-from contextlib import asynccontextmanager
-
 from core.dependencies.container_base import BaseContainer
-from core.gateways.network.async_shelly_rpc_client import AsyncShellyRPCClient
-from core.repositories.db import async_session_factory
-from core.repositories.sqlalchemy_backup_repository import (
-    SQLAlchemyBackupRepository,
-)
-from core.repositories.sqlalchemy_backup_schedule_repository import (
-    SQLAlchemyBackupScheduleRepository,
-)
-from core.repositories.sqlalchemy_credentials_repository import (
-    SQLAlchemyCredentialsRepository,
-)
-from core.repositories.sqlalchemy_provisioning_profile_repository import (
-    SQLAlchemyProvisioningProfileRepository,
-)
-from core.services.authentication_service import AuthenticationService
-from core.services.encryption_service import EncryptionService
-from core.settings import settings as core_settings
 from core.use_cases.scan_devices import ScanDevicesUseCase
 
 
 class CLIContainer(BaseContainer):
-    def __init__(self) -> None:
-        super().__init__()
-        self._rpc_client: AsyncShellyRPCClient | None = None
-        self._auth_service: AuthenticationService | None = None
-        self._encryption_service: EncryptionService | None = None
+    """CLI container using the shared wiring."""
 
-    def get_encryption_service(self) -> EncryptionService:
-        if self._encryption_service is None:
-            self._encryption_service = EncryptionService()
-        return self._encryption_service
-
-    @asynccontextmanager
-    async def create_credentials_repository(
-        self,
-    ) -> AsyncGenerator[SQLAlchemyCredentialsRepository, None]:
-        async with async_session_factory() as session:
-            try:
-                yield SQLAlchemyCredentialsRepository(
-                    session, self.get_encryption_service()
-                )
-            finally:
-                await session.close()
-
-    @asynccontextmanager
-    async def create_provisioning_profile_repository(
-        self,
-    ) -> AsyncGenerator[SQLAlchemyProvisioningProfileRepository, None]:
-        async with async_session_factory() as session:
-            try:
-                yield SQLAlchemyProvisioningProfileRepository(
-                    session, self.get_encryption_service()
-                )
-            finally:
-                await session.close()
-
-    @asynccontextmanager
-    async def create_backup_repository(
-        self,
-    ) -> AsyncGenerator[SQLAlchemyBackupRepository, None]:
-        async with async_session_factory() as session:
-            try:
-                yield SQLAlchemyBackupRepository(session, self.get_encryption_service())
-            finally:
-                await session.close()
-
-    @asynccontextmanager
-    async def create_backup_schedule_repository(
-        self,
-    ) -> AsyncGenerator[SQLAlchemyBackupScheduleRepository, None]:
-        async with async_session_factory() as session:
-            try:
-                yield SQLAlchemyBackupScheduleRepository(session)
-            finally:
-                await session.close()
-
-    def get_authentication_service(self) -> AuthenticationService:
-        if self._auth_service is None:
-            self._auth_service = AuthenticationService(
-                repository_factory=self.create_credentials_repository
-            )
-        return self._auth_service
-
-    def get_rpc_client(self) -> AsyncShellyRPCClient:
-        if self._rpc_client is None:
-            self._rpc_client = AsyncShellyRPCClient(
-                timeout=core_settings.network.timeout,
-                connect_timeout=core_settings.network.connect_timeout,
-                verify=core_settings.network.verify_ssl,
-                authentication_service=self.get_authentication_service(),
-                auth_state_cache=self.get_auth_state_cache(),
-            )
-        return self._rpc_client
-
-    async def close(self) -> None:
-        """Gracefully close async resources (HTTP connection pools)."""
-        if self._rpc_client is not None:
-            try:
-                await self._rpc_client.close()
-            except Exception:
-                pass
-
-        if self._mdns_client is not None:
-            try:
-                await self._mdns_client.close()
-            except Exception:
-                pass
-
-        await self._aclose_legacy_http_client()
-
-        self._rpc_client = None
-        self._reset_device_caches()
-
-    # Backwards compatibility helpers (optional convenience wrappers)
     def get_device_scan_interactor(self) -> ScanDevicesUseCase:
+        """Preserve the legacy convenience name."""
         return self.get_scan_interactor()

--- a/packages/cli/src/cli/dependencies/container.py
+++ b/packages/cli/src/cli/dependencies/container.py
@@ -1,11 +1,22 @@
 """Dependency injection container for CLI using shared BaseContainer."""
 
 from core.dependencies.container_base import BaseContainer
+from core.repositories.db import engine
+from core.repositories.models import Base
 from core.use_cases.scan_devices import ScanDevicesUseCase
 
 
 class CLIContainer(BaseContainer):
     """CLI container using the shared wiring."""
+
+    async def initialize_database(self) -> None:
+        """Create the database schema required by standalone CLI commands."""
+        async with engine.begin() as connection:
+            await connection.run_sync(Base.metadata.create_all)
+
+    async def close(self) -> None:
+        await super().close()
+        await engine.dispose()
 
     def get_device_scan_interactor(self) -> ScanDevicesUseCase:
         """Preserve the legacy convenience name."""

--- a/packages/cli/tests/unit/commands/test_credential_commands.py
+++ b/packages/cli/tests/unit/commands/test_credential_commands.py
@@ -1,0 +1,163 @@
+"""Tests for the credentials CLI subgroup."""
+
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from cli.credential_commands import credential_commands
+from click.testing import CliRunner
+from core.domain.credentials import Credential
+
+
+class TestCredentialCommands:
+    @pytest.fixture
+    def runner(self):
+        return CliRunner()
+
+    def _repo(self):
+        repo = MagicMock()
+        repo.set = AsyncMock()
+        repo.delete = AsyncMock()
+        repo.list_all = AsyncMock(return_value=[])
+        return repo
+
+    def _obj(self, repo):
+        obj = MagicMock()
+        obj.console = MagicMock()
+        obj.container.initialize_database = AsyncMock()
+
+        @asynccontextmanager
+        async def create_repo():
+            yield repo
+
+        obj.container.create_credentials_repository = create_repo
+        return obj
+
+    def test_it_sets_credentials_with_default_username(self, runner):
+        repo = self._repo()
+
+        result = runner.invoke(
+            credential_commands,
+            ["set", "AA:BB:CC:DD:EE:FF", "secret"],
+            obj=self._obj(repo),
+        )
+
+        assert result.exit_code == 0
+        repo.set.assert_awaited_once_with("AA:BB:CC:DD:EE:FF", "admin", "secret")
+
+    def test_it_sets_credentials_with_custom_username(self, runner):
+        repo = self._repo()
+
+        result = runner.invoke(
+            credential_commands,
+            ["set", "AA:BB:CC:DD:EE:FF", "secret", "--username", "operator"],
+            obj=self._obj(repo),
+        )
+
+        assert result.exit_code == 0
+        repo.set.assert_awaited_once_with("AA:BB:CC:DD:EE:FF", "operator", "secret")
+
+    def test_it_aborts_when_set_fails(self, runner):
+        repo = self._repo()
+        repo.set.side_effect = Exception("db unavailable")
+
+        result = runner.invoke(
+            credential_commands,
+            ["set", "AA:BB:CC:DD:EE:FF", "secret"],
+            obj=self._obj(repo),
+        )
+
+        assert result.exit_code != 0
+
+    def test_it_sets_global_credentials_under_wildcard_mac(self, runner):
+        repo = self._repo()
+
+        result = runner.invoke(
+            credential_commands,
+            ["set-global", "secret"],
+            obj=self._obj(repo),
+        )
+
+        assert result.exit_code == 0
+        repo.set.assert_awaited_once_with("*", "admin", "secret")
+
+    def test_it_lists_stored_credentials(self, runner):
+        repo = self._repo()
+        repo.list_all.return_value = [
+            Credential(
+                mac="AA:BB:CC:DD:EE:FF",
+                username="admin",
+                password="secret",
+                last_seen_ip="192.168.1.10",
+            )
+        ]
+        obj = self._obj(repo)
+
+        result = runner.invoke(credential_commands, ["list"], obj=obj)
+
+        assert result.exit_code == 0
+        repo.list_all.assert_awaited_once()
+        obj.console.print.assert_called_once()
+
+    def test_it_warns_when_no_credentials_stored(self, runner):
+        repo = self._repo()
+        obj = self._obj(repo)
+
+        result = runner.invoke(credential_commands, ["list"], obj=obj)
+
+        assert result.exit_code == 0
+        printed = str(obj.console.print.call_args_list)
+        assert "No credentials stored" in printed
+
+    def test_it_skips_credentials_that_could_not_be_decrypted(self, runner):
+        repo = self._repo()
+        repo.list_all.return_value = [
+            None,
+            Credential(
+                mac="AA:BB:CC:DD:EE:FF",
+                username="admin",
+                password="secret",
+            ),
+        ]
+        obj = self._obj(repo)
+
+        result = runner.invoke(credential_commands, ["list"], obj=obj)
+
+        assert result.exit_code == 0
+        obj.console.print.assert_called_once()
+
+    def test_it_aborts_when_list_fails(self, runner):
+        repo = self._repo()
+        repo.list_all.side_effect = Exception("db unavailable")
+
+        result = runner.invoke(
+            credential_commands,
+            ["list"],
+            obj=self._obj(repo),
+        )
+
+        assert result.exit_code != 0
+
+    def test_it_deletes_credentials(self, runner):
+        repo = self._repo()
+
+        result = runner.invoke(
+            credential_commands,
+            ["delete", "AA:BB:CC:DD:EE:FF"],
+            obj=self._obj(repo),
+        )
+
+        assert result.exit_code == 0
+        repo.delete.assert_awaited_once_with("AA:BB:CC:DD:EE:FF")
+
+    def test_it_aborts_when_delete_fails(self, runner):
+        repo = self._repo()
+        repo.delete.side_effect = Exception("db unavailable")
+
+        result = runner.invoke(
+            credential_commands,
+            ["delete", "AA:BB:CC:DD:EE:FF"],
+            obj=self._obj(repo),
+        )
+
+        assert result.exit_code != 0

--- a/packages/cli/tests/unit/test_container.py
+++ b/packages/cli/tests/unit/test_container.py
@@ -1,0 +1,43 @@
+"""Tests for CLI-specific container lifecycle and compatibility."""
+
+from unittest.mock import AsyncMock, MagicMock, Mock
+
+import pytest
+from cli.dependencies import container as container_module
+from cli.dependencies.container import CLIContainer
+from core.repositories.models import Base
+
+
+@pytest.mark.asyncio
+async def test_it_initializes_the_database_schema(monkeypatch):
+    connection = MagicMock()
+    connection.run_sync = AsyncMock()
+    transaction = MagicMock()
+    transaction.__aenter__ = AsyncMock(return_value=connection)
+    transaction.__aexit__ = AsyncMock()
+    engine = MagicMock()
+    engine.begin.return_value = transaction
+    monkeypatch.setattr(container_module, "engine", engine)
+
+    await CLIContainer().initialize_database()
+
+    connection.run_sync.assert_awaited_once_with(Base.metadata.create_all)
+
+
+@pytest.mark.asyncio
+async def test_it_disposes_the_database_engine_on_close(monkeypatch):
+    engine = MagicMock()
+    engine.dispose = AsyncMock()
+    monkeypatch.setattr(container_module, "engine", engine)
+
+    await CLIContainer().close()
+
+    engine.dispose.assert_awaited_once()
+
+
+def test_it_preserves_the_legacy_scan_interactor_name():
+    container = CLIContainer()
+    expected = object()
+    container.get_scan_interactor = Mock(return_value=expected)
+
+    assert container.get_device_scan_interactor() is expected

--- a/packages/core/src/core/dependencies/container_base.py
+++ b/packages/core/src/core/dependencies/container_base.py
@@ -1,17 +1,37 @@
-"""Shared container base providing common gateway and interactor factories (no cast)."""
+"""Shared container providing gateway, repository and interactor factories."""
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
-
-if TYPE_CHECKING:
-    from core.services.authentication_service import AuthenticationService
+from collections.abc import AsyncGenerator
+from contextlib import asynccontextmanager
 
 from core.gateways.device import LegacyDeviceGateway
 from core.gateways.device.ap_device_detector import APDeviceDetector
 from core.gateways.device.legacy_component_mapper import LegacyComponentMapper
 from core.gateways.device.shelly_device_gateway import ShellyDeviceGateway
-from core.gateways.network import LegacyHttpClient, MDNSGateway, ZeroconfMDNSClient
+from core.gateways.network import (
+    AsyncShellyRPCClient,
+    LegacyHttpClient,
+    MDNSGateway,
+    ZeroconfMDNSClient,
+)
+from core.repositories.db import async_session_factory
+from core.repositories.sqlalchemy_backup_repository import (
+    SQLAlchemyBackupRepository,
+)
+from core.repositories.sqlalchemy_backup_schedule_repository import (
+    SQLAlchemyBackupScheduleRepository,
+)
+from core.repositories.sqlalchemy_credentials_repository import (
+    SQLAlchemyCredentialsRepository,
+)
+from core.repositories.sqlalchemy_provisioning_profile_repository import (
+    SQLAlchemyProvisioningProfileRepository,
+)
+from core.services.auth_state_cache import AuthStateCache
+from core.services.authentication_service import AuthenticationService
+from core.services.encryption_service import EncryptionService
+from core.settings import settings as core_settings
 from core.use_cases.backup_device_config import BackupDeviceConfig
 from core.use_cases.bulk_operations import BulkOperationsUseCase
 from core.use_cases.check_device_status import CheckDeviceStatusUseCase
@@ -50,14 +70,27 @@ class BaseContainer:
             ManageBackupSchedulesUseCase | None
         ) = None
         self._run_due_backups_interactor: RunDueBackupsUseCase | None = None
+        # Every slot above is a device-scoped cache cleared by
+        # _reset_device_caches(); slots below survive close().
+        self._device_cache_slots: tuple[str, ...] = tuple(vars(self))
+        self._rpc_client: AsyncShellyRPCClient | None = None
+        self._auth_service: AuthenticationService | None = None
+        self._encryption_service: EncryptionService | None = None
+        self._auth_state_cache: AuthStateCache | None = None
 
-    def get_rpc_client(self) -> Any:
-        raise NotImplementedError
+    def get_rpc_client(self) -> AsyncShellyRPCClient:
+        if self._rpc_client is None:
+            self._rpc_client = AsyncShellyRPCClient(
+                timeout=core_settings.network.timeout,
+                connect_timeout=core_settings.network.connect_timeout,
+                verify=core_settings.network.verify_ssl,
+                authentication_service=self.get_authentication_service(),
+                auth_state_cache=self.get_auth_state_cache(),
+            )
+        return self._rpc_client
 
     def get_device_gateway(self) -> ShellyDeviceGateway:
         if self._device_gateway is None:
-            from core.settings import settings as core_settings
-
             legacy_http_client = LegacyHttpClient(
                 connect_timeout=core_settings.network.connect_timeout,
             )
@@ -66,7 +99,7 @@ class BaseContainer:
             legacy_gateway = LegacyDeviceGateway(
                 http_client=legacy_http_client,
                 component_mapper=legacy_component_mapper,
-                authentication_service=self._get_authentication_service_optional(),
+                authentication_service=self.get_authentication_service(),
                 auth_state_cache=self.get_auth_state_cache(),
             )
 
@@ -77,7 +110,6 @@ class BaseContainer:
         return self._device_gateway
 
     async def _aclose_legacy_http_client(self) -> None:
-        """Close the legacy HTTP client's connection pool, if one was created."""
         if self._legacy_http_client is not None:
             try:
                 await self._legacy_http_client.close()
@@ -85,43 +117,28 @@ class BaseContainer:
                 pass
 
     def _reset_device_caches(self) -> None:
-        """Drop cached gateways/interactors that hold now-closed clients.
+        for slot in self._device_cache_slots:
+            setattr(self, slot, None)
 
-        Called after close() so that a reused container rebuilds live
-        resources on next access instead of handing back closed ones.
-        """
-        self._device_gateway = None
-        self._legacy_http_client = None
-        self._mdns_client = None
-        self._scan_interactor = None
-        self._execute_component_action_interactor = None
-        self._component_actions_interactor = None
-        self._status_interactor = None
-        self._bulk_operations_interactor = None
-        self._manage_profiles_interactor = None
-        self._provision_device_interactor = None
-        self._ap_device_detector = None
-        self._backup_device_config_interactor = None
-        self._restore_device_config_interactor = None
-        self._manage_backup_schedules_interactor = None
-        self._run_due_backups_interactor = None
+    def get_encryption_service(self) -> EncryptionService:
+        if self._encryption_service is None:
+            self._encryption_service = EncryptionService()
+        return self._encryption_service
 
-    def _get_authentication_service_optional(self) -> AuthenticationService | None:
-        """Return AuthenticationService if available, None otherwise."""
-        if hasattr(self, "get_authentication_service"):
-            service: AuthenticationService = self.get_authentication_service()
-            return service
-        return None
+    def get_authentication_service(self) -> AuthenticationService:
+        if self._auth_service is None:
+            self._auth_service = AuthenticationService(
+                repository_factory=self.create_credentials_repository
+            )
+        return self._auth_service
 
     def get_mdns_client(self) -> MDNSGateway:
         if self._mdns_client is None:
             self._mdns_client = ZeroconfMDNSClient()
         return self._mdns_client
 
-    def get_auth_state_cache(self) -> Any:
-        from core.services.auth_state_cache import AuthStateCache
-
-        if not hasattr(self, "_auth_state_cache"):
+    def get_auth_state_cache(self) -> AuthStateCache:
+        if self._auth_state_cache is None:
             self._auth_state_cache = AuthStateCache()
         return self._auth_state_cache
 
@@ -219,14 +236,64 @@ class BaseContainer:
             )
         return self._run_due_backups_interactor
 
-    def create_provisioning_profile_repository(self) -> Any:
-        raise NotImplementedError
+    @asynccontextmanager
+    async def create_credentials_repository(
+        self,
+    ) -> AsyncGenerator[SQLAlchemyCredentialsRepository, None]:
+        async with async_session_factory() as session:
+            try:
+                yield SQLAlchemyCredentialsRepository(
+                    session, self.get_encryption_service()
+                )
+            finally:
+                await session.close()
 
-    def create_credentials_repository(self) -> Any:
-        raise NotImplementedError
+    @asynccontextmanager
+    async def create_provisioning_profile_repository(
+        self,
+    ) -> AsyncGenerator[SQLAlchemyProvisioningProfileRepository, None]:
+        async with async_session_factory() as session:
+            try:
+                yield SQLAlchemyProvisioningProfileRepository(
+                    session, self.get_encryption_service()
+                )
+            finally:
+                await session.close()
 
-    def create_backup_repository(self) -> Any:
-        raise NotImplementedError
+    @asynccontextmanager
+    async def create_backup_repository(
+        self,
+    ) -> AsyncGenerator[SQLAlchemyBackupRepository, None]:
+        async with async_session_factory() as session:
+            try:
+                yield SQLAlchemyBackupRepository(session, self.get_encryption_service())
+            finally:
+                await session.close()
 
-    def create_backup_schedule_repository(self) -> Any:
-        raise NotImplementedError
+    @asynccontextmanager
+    async def create_backup_schedule_repository(
+        self,
+    ) -> AsyncGenerator[SQLAlchemyBackupScheduleRepository, None]:
+        async with async_session_factory() as session:
+            try:
+                yield SQLAlchemyBackupScheduleRepository(session)
+            finally:
+                await session.close()
+
+    async def close(self) -> None:
+        if self._rpc_client is not None:
+            try:
+                await self._rpc_client.close()
+            except Exception:
+                pass
+
+        if self._mdns_client is not None:
+            try:
+                await self._mdns_client.close()
+            except Exception:
+                pass
+
+        await self._aclose_legacy_http_client()
+
+        self._rpc_client = None
+        self._reset_device_caches()

--- a/packages/core/tests/unit/dependencies/test_container_base.py
+++ b/packages/core/tests/unit/dependencies/test_container_base.py
@@ -1,0 +1,156 @@
+"""Tests for the shared BaseContainer wiring."""
+
+from unittest.mock import AsyncMock
+
+import pytest
+from core.dependencies.container_base import BaseContainer
+from core.gateways.device.shelly_device_gateway import ShellyDeviceGateway
+from core.gateways.network import AsyncShellyRPCClient
+from core.repositories.sqlalchemy_backup_repository import (
+    SQLAlchemyBackupRepository,
+)
+from core.repositories.sqlalchemy_backup_schedule_repository import (
+    SQLAlchemyBackupScheduleRepository,
+)
+from core.repositories.sqlalchemy_credentials_repository import (
+    SQLAlchemyCredentialsRepository,
+)
+from core.repositories.sqlalchemy_provisioning_profile_repository import (
+    SQLAlchemyProvisioningProfileRepository,
+)
+from core.services.authentication_service import AuthenticationService
+
+PERSISTENT_SLOTS = {
+    "_rpc_client",
+    "_auth_service",
+    "_encryption_service",
+    "_auth_state_cache",
+}
+
+
+@pytest.fixture
+def container():
+    c = BaseContainer()
+    c._rpc_client = AsyncMock(spec=AsyncShellyRPCClient)
+    c._mdns_client = AsyncMock()
+    return c
+
+
+class TestProviderWiring:
+    def test_it_builds_and_caches_the_device_gateway(self, container):
+        gateway = container.get_device_gateway()
+
+        assert isinstance(gateway, ShellyDeviceGateway)
+        assert container.get_device_gateway() is gateway
+
+    async def test_it_builds_the_rpc_client_with_auth_wiring(self):
+        container = BaseContainer()
+
+        client = container.get_rpc_client()
+        try:
+            assert isinstance(client, AsyncShellyRPCClient)
+            assert (
+                client.authentication_service is container.get_authentication_service()
+            )
+            assert client.auth_state_cache is container.get_auth_state_cache()
+            assert container.get_rpc_client() is client
+        finally:
+            await client.close()
+
+    def test_it_wires_the_auth_service_to_the_credentials_factory(self, container):
+        service = container.get_authentication_service()
+
+        assert isinstance(service, AuthenticationService)
+        assert service.repository_factory == container.create_credentials_repository
+
+    @pytest.mark.parametrize(
+        "getter",
+        [
+            "get_scan_interactor",
+            "get_execute_component_action_interactor",
+            "get_component_actions_interactor",
+            "get_status_interactor",
+            "get_bulk_operations_interactor",
+            "get_manage_profiles_interactor",
+            "get_provision_device_interactor",
+            "get_backup_device_config_interactor",
+            "get_restore_device_config_interactor",
+            "get_manage_backup_schedules_interactor",
+            "get_run_due_backups_interactor",
+            "get_ap_device_detector",
+            "get_mdns_client",
+            "get_auth_state_cache",
+            "get_encryption_service",
+            "get_authentication_service",
+        ],
+    )
+    def test_it_caches_each_provider(self, container, getter):
+        first = getattr(container, getter)()
+
+        assert first is not None
+        assert getattr(container, getter)() is first
+
+
+class TestRepositoryFactories:
+    @pytest.mark.parametrize(
+        "factory,expected_type",
+        [
+            ("create_credentials_repository", SQLAlchemyCredentialsRepository),
+            (
+                "create_provisioning_profile_repository",
+                SQLAlchemyProvisioningProfileRepository,
+            ),
+            ("create_backup_repository", SQLAlchemyBackupRepository),
+            (
+                "create_backup_schedule_repository",
+                SQLAlchemyBackupScheduleRepository,
+            ),
+        ],
+    )
+    async def test_it_yields_a_repository_per_session(
+        self, container, factory, expected_type
+    ):
+        async with getattr(container, factory)() as repo:
+            assert isinstance(repo, expected_type)
+
+
+class TestClose:
+    async def test_it_closes_clients_and_rebuilds_device_resources(self):
+        container = BaseContainer()
+        rpc = AsyncMock(spec=AsyncShellyRPCClient)
+        mdns = AsyncMock()
+        container._rpc_client = rpc
+        container._mdns_client = mdns
+        gateway = container.get_device_gateway()
+        auth_service = container.get_authentication_service()
+
+        await container.close()
+
+        rpc.close.assert_awaited_once()
+        mdns.close.assert_awaited_once()
+        assert container._rpc_client is None
+        assert container.get_device_gateway() is not gateway
+        assert container.get_authentication_service() is auth_service
+        await container.close()
+
+    async def test_it_swallows_client_close_errors(self):
+        container = BaseContainer()
+        rpc = AsyncMock(spec=AsyncShellyRPCClient)
+        rpc.close.side_effect = RuntimeError("already closed")
+        container._rpc_client = rpc
+
+        await container.close()
+
+        assert container._rpc_client is None
+
+    def test_it_resets_every_slot_except_declared_persistent_ones(self):
+        container = BaseContainer()
+        sentinel = object()
+        slots = [name for name in vars(container) if name != "_device_cache_slots"]
+        for name in slots:
+            setattr(container, name, sentinel)
+
+        container._reset_device_caches()
+
+        survivors = {name for name in slots if getattr(container, name) is sentinel}
+        assert survivors == PERSISTENT_SLOTS


### PR DESCRIPTION
## Purpose

Collapse the duplicated API and CLI dependency containers into the shared BaseContainer and fix the CLI credentials commands, which crashed on every invocation.

## Context

The two container subclasses were 95% byte-identical, so the shared wiring now lives once in core and each subclass keeps only what is genuinely its own. Routing the credentials commands through the repository factory made them reachable for the first time, which exposed standalone database lifecycle gaps (missing schema creation, undisposed engine, undecryptable rows in list); those are fixed here with the subgroup's first tests. This is Phase 1 of the architecture refactor plan.

## Notes

Importing BaseContainer now validates settings and creates the data directory at import time, same as both apps already did but new for bare core imports; flagging in case core should stay side-effect free. The fresh-database gap still applies to the other DB-using CLI commands (backup, provision, schedules); generalizing schema initialization is left for the CLI cleanup phase.
