### PR TITLE
Split Gen1 and Gen2 handling into per-generation strategies

### DIFF
--- a/packages/core/src/core/domain/entities/device_backup.py
+++ b/packages/core/src/core/domain/entities/device_backup.py
@@ -5,6 +5,11 @@ from typing import Any
 
 from core.utils.validation import normalize_mac
 
+# The raw Gen1 /settings entry captured alongside the mapped components in a
+# snapshot. It is the data source a Gen1 restore replays, never a restore
+# target itself.
+LEGACY_SETTINGS_KEY = "legacy_settings"
+
 
 @dataclass
 class DeviceBackup:

--- a/packages/core/src/core/domain/entities/device_status.py
+++ b/packages/core/src/core/domain/entities/device_status.py
@@ -72,9 +72,11 @@ class DeviceStatus(BaseModel):
         for component_data in components_data:
             component = ComponentFactory.create_component(component_data)
             component.available_actions = component.get_available_actions(methods)
-            legacy_actions = component.attrs.get("legacy_actions")
-            if isinstance(legacy_actions, list):
-                component.available_actions.extend(legacy_actions)
+            # Gen1 actions cannot be derived from a method list; the legacy
+            # mapper declares them on its payload.
+            declared_actions = component_data.get("available_actions")
+            if isinstance(declared_actions, list):
+                component.available_actions.extend(declared_actions)
             components.append(component)
 
         for key, status in status_dict.items():

--- a/packages/core/src/core/domain/services/__init__.py
+++ b/packages/core/src/core/domain/services/__init__.py
@@ -1,0 +1,1 @@
+"""Pure domain services: no I/O, no gateway or repository dependencies."""

--- a/packages/core/src/core/domain/services/gen1_settings_translation.py
+++ b/packages/core/src/core/domain/services/gen1_settings_translation.py
@@ -1,0 +1,238 @@
+"""Translate a raw Gen1 ``/settings`` snapshot into settable request params.
+
+Gen1 devices have no RPC: a restore replays the raw ``/settings`` payload
+captured at backup time against the per-resource setter endpoints. This module
+owns the wire knowledge that translation needs: which captured params are
+documented as settable (so read-only echoes are never sent back), which section
+of ``/settings`` holds each component type, and the fields whose setter accepts
+a different name than the one GET echoes.
+
+Pure dict-in/dict-out: no I/O, independently testable against the documented
+Gen1 API (https://shelly-api-docs.shelly.cloud/gen1/).
+"""
+
+from typing import Any
+
+# Section of the raw /settings holding each component's config. "" is the top level.
+# wifi_sta1/wifi_ap are synthetic types for the extra Gen1 WiFi resources replayed
+# behind the single "wifi" component (see wifi_subresources).
+GEN1_SECTION_BY_TYPE: dict[str, str] = {
+    "switch": "relays",
+    "cover": "rollers",
+    "input": "inputs",
+    "sys": "",
+    "mqtt": "mqtt",
+    "cloud": "cloud",
+    "wifi": "wifi_sta",
+    "wifi_sta1": "wifi_sta1",
+    "wifi_ap": "wifi_ap",
+}
+
+# Restorable Gen1 settings per component type, as GET /settings names them. Only
+# params documented as settable at https://shelly-api-docs.shelly.cloud/gen1/ are
+# listed, so read-only echoes (ison, has_timer, is_valid, safety_switch) are
+# never sent back. Fields a model does not have are absent and skip themselves,
+# which is what lets one table serve every Gen1 model.
+GEN1_RESTORABLE_BY_TYPE: dict[str, tuple[str, ...]] = {
+    "switch": (
+        "name",
+        "appliance_type",
+        "default_state",
+        "btn_type",
+        "btn_reverse",
+        # Shelly 1L exposes two inputs instead of one.
+        "btn1_type",
+        "btn1_reverse",
+        "btn2_type",
+        "btn2_reverse",
+        "swap_inputs",
+        "auto_on",
+        "auto_off",
+        "schedule",
+        "schedule_rules",
+        "max_power",
+        # On Shelly 1/1L "power" is the settable user power constant shown in
+        # meters, not a live reading (live power is echoed under "meters").
+        "power",
+    ),
+    "cover": (
+        "default_state",
+        "input_mode",
+        "button_type",
+        "btn_reverse",
+        "swap",
+        "swap_inputs",
+        "maxtime",
+        "maxtime_open",
+        "maxtime_close",
+        "positioning",
+        "obstacle_mode",
+        "obstacle_action",
+        "obstacle_power",
+        "obstacle_delay",
+        "ends_delay",
+        "off_power",
+        "safety_mode",
+        "safety_action",
+        "safety_allowed_on_trigger",
+        "schedule",
+        "schedule_rules",
+    ),
+    # "mode" is deliberately absent: Gen1 applies it with a reboot, so it is
+    # replayed alone as a pre-phase (the restore's mode sync), never in this
+    # batch.
+    "sys": (
+        "name",
+        "timezone",
+        "tzautodetect",
+        "tz_utc_offset",
+        "tz_dst",
+        "tz_dst_auto",
+        "lat",
+        "lng",
+        "discoverable",
+        "led_status_disable",
+        "led_power_disable",
+        "sntp.server",
+        # Device-level overpower threshold (1PM, Plug/PlugS, 2.5 in roller
+        # mode); distinct from the per-relay max_power.
+        "max_power",
+        "longpush_time",
+        "factory_reset_from_switch",
+        "wifirecovery_reboot_enabled",
+        "debug_enable",
+        "allow_cross_origin",
+        "supply_voltage",
+        "power_correction",
+        # 2.5 roller favourite positions live on /settings/favorites/{i} (not
+        # replayed); only their enable flag is a plain /settings param.
+        "favorites_enabled",
+        "coiot.enabled",
+        "coiot.update_period",
+        "coiot.peer",
+        "ap_roaming.enabled",
+        "ap_roaming.threshold",
+        "longpush_duration_ms.min",
+        "longpush_duration_ms.max",
+        "multipush_time_between_pushes_ms.max",
+    ),
+    # Only i3/Button1 expose /settings/input/{i}. Relay-bearing models never
+    # echo an "inputs" section in /settings (their input config lives on the
+    # owning relay), so their inputs skip as having nothing captured.
+    "input": ("name", "btn_type", "btn_reverse"),
+    # mqtt_pass is not echoed by GET /settings, so it cannot be restored.
+    "mqtt": (
+        "enable",
+        "server",
+        "user",
+        "id",
+        "clean_session",
+        "retain",
+        "keep_alive",
+        "update_period",
+        "max_qos",
+        "reconnect_timeout_min",
+        "reconnect_timeout_max",
+    ),
+    "cloud": ("enabled",),
+    # The WiFi STA "key" is not echoed by GET /settings, so it cannot be restored.
+    "wifi": ("enabled", "ssid", "ipv4_method", "ip", "gw", "mask", "dns"),
+    # The AP SSID is device-fixed and not settable; the AP key, unlike the STA
+    # one, IS echoed by GET /settings and round-trips.
+    "wifi_ap": ("enabled", "key"),
+}
+# /settings/sta1 (fallback STA) is documented as an identical resource to
+# /settings/sta.
+GEN1_RESTORABLE_BY_TYPE["wifi_sta1"] = GEN1_RESTORABLE_BY_TYPE["wifi"]
+
+# GET /settings echoes several fields under a different name than the one their
+# setter accepts; sending the echoed name is silently ignored by the device.
+GEN1_PARAM_RENAMES: dict[str, dict[str, str]] = {
+    "cover": {"button_type": "btn_type"},
+    "sys": {
+        "sntp.server": "sntp_server",
+        "coiot.enabled": "coiot_enable",
+        "coiot.update_period": "coiot_update_period",
+        "coiot.peer": "coiot_peer",
+        "ap_roaming.enabled": "ap_roaming_enabled",
+        "ap_roaming.threshold": "ap_roaming_threshold",
+        "longpush_duration_ms.min": "longpush_duration_ms_min",
+        "longpush_duration_ms.max": "longpush_duration_ms_max",
+        "multipush_time_between_pushes_ms.max": (
+            "multipush_time_between_pushes_ms_max"
+        ),
+    },
+    "mqtt": {name: f"mqtt_{name}" for name in GEN1_RESTORABLE_BY_TYPE["mqtt"]},
+    "wifi": {"gw": "gateway", "mask": "netmask"},
+}
+GEN1_PARAM_RENAMES["wifi_sta1"] = GEN1_PARAM_RENAMES["wifi"]
+
+# Gen1 splits WiFi across /settings/sta, /settings/sta1 (fallback STA) and
+# /settings/ap; all three replay behind the single "wifi" component. The AP is
+# last: enabling one mode disables the other on the device, so the resource
+# enabled in the backup must win.
+WIFI_SUBTYPES: tuple[str, ...] = ("wifi", "wifi_sta1", "wifi_ap")
+
+
+def restorable_params(
+    key: str, ctype: str | None, settings: dict[str, Any]
+) -> dict[str, Any] | None:
+    """The settable params captured for one component, under their setter names.
+
+    ``None`` when the type has no Gen1 settings endpoint at all; ``{}`` when it
+    has one but the snapshot holds nothing to send (e.g. inputs on relay-bearing
+    models, which never echo an ``inputs`` settings section).
+    """
+    allowed = GEN1_RESTORABLE_BY_TYPE.get(ctype or "")
+    if allowed is None:
+        return None
+
+    section = _section(key, ctype or "", settings)
+    if section is None:
+        return {}
+
+    renames = GEN1_PARAM_RENAMES.get(ctype or "", {})
+    params: dict[str, Any] = {}
+    for attr in allowed:
+        value = _dig(section, attr)
+        if value is not None:
+            params[renames.get(attr, attr)] = value
+    return params
+
+
+def wifi_subresources(settings: dict[str, Any]) -> list[tuple[str, dict[str, Any]]]:
+    """The captured WiFi resources to replay, in apply order (AP last).
+
+    Each item is ``(subtype, params)``; resources the snapshot holds nothing
+    for are omitted.
+    """
+    subresources: list[tuple[str, dict[str, Any]]] = []
+    for subtype in WIFI_SUBTYPES:
+        params = restorable_params(subtype, subtype, settings)
+        if params:
+            subresources.append((subtype, params))
+    return subresources
+
+
+def _section(key: str, ctype: str, settings: dict[str, Any]) -> dict[str, Any] | None:
+    section_name = GEN1_SECTION_BY_TYPE[ctype]
+    section: Any = settings if not section_name else settings.get(section_name)
+
+    # relays/rollers are arrays parallel to the component id.
+    if isinstance(section, list):
+        try:
+            index = int(key.split(":")[1])
+        except (IndexError, ValueError):
+            return None
+        section = section[index] if 0 <= index < len(section) else None
+
+    return section if isinstance(section, dict) else None
+
+
+def _dig(section: dict[str, Any], path: str) -> Any:
+    value: Any = section
+    for part in path.split("."):
+        if not isinstance(value, dict):
+            return None
+        value = value.get(part)
+    return value

--- a/packages/core/src/core/domain/value_objects/__init__.py
+++ b/packages/core/src/core/domain/value_objects/__init__.py
@@ -9,6 +9,7 @@ from .bulk_reboot_request import BulkRebootRequest
 from .bulk_status_request import BulkStatusRequest
 from .check_device_status_request import CheckDeviceStatusRequest
 from .component_action_request import ComponentActionRequest
+from .generation import Generation
 from .get_component_actions_request import GetComponentActionsRequest
 from .scan_request import ScanRequest
 
@@ -20,6 +21,7 @@ __all__ = [
     "BaseBulkDeviceRequest",
     "CheckDeviceStatusRequest",
     "ComponentActionRequest",
+    "Generation",
     "GetComponentActionsRequest",
     "BulkDeviceRequest",
     "BulkRebootRequest",

--- a/packages/core/src/core/domain/value_objects/generation.py
+++ b/packages/core/src/core/domain/value_objects/generation.py
@@ -1,0 +1,51 @@
+"""Device generation as one domain value.
+
+Shelly generations reach the code in three raw shapes: the integer ``gen``
+devices report (1 legacy, 2/3/4 RPC), the ``gen1``/``gen2`` labels stored on
+backups, and a ``/shelly`` identification response whose ``gen`` field Gen1
+firmware omits entirely. This value object is the single place those shapes
+are reconciled; nothing else should compare raw ``gen`` ints or labels.
+
+``GEN2`` covers the whole RPC family: Gen2+ devices share one RPC surface, so
+gen 3 and 4 devices are ``GEN2`` here. Code that needs the literal device
+generation (provisioning reports gen 2 vs 3) keeps the raw int.
+"""
+
+from enum import Enum
+from typing import Any
+
+
+class Generation(str, Enum):
+    """The two protocol families a device can speak."""
+
+    GEN1 = "gen1"
+    GEN2 = "gen2"
+
+    @classmethod
+    def from_device_gen(cls, gen: int | None) -> "Generation | None":
+        """From the ``gen`` a device status reports (Gen2+ RPC field or the
+        legacy gateway's gen=1 stamp). ``None`` when the generation could not
+        be determined; callers decide whether that is an error."""
+        if gen == 1:
+            return cls.GEN1
+        if gen is not None and gen >= 2:
+            return cls.GEN2
+        return None
+
+    @classmethod
+    def from_label(cls, label: str) -> "Generation | None":
+        """From a stored backup label; ``None`` for an unknown label."""
+        try:
+            return cls(label)
+        except ValueError:
+            return None
+
+    @classmethod
+    def from_shelly_payload(cls, payload: dict[str, Any]) -> "Generation":
+        """From a raw ``/shelly`` identification response.
+
+        Gen1 firmware has no ``gen`` field there (it identifies via ``type``),
+        so a missing field means Gen1, unlike a device status where a missing
+        generation means undetermined.
+        """
+        return cls.GEN1 if payload.get("gen") is None else cls.GEN2

--- a/packages/core/src/core/gateways/device/ap_device_detector.py
+++ b/packages/core/src/core/gateways/device/ap_device_detector.py
@@ -9,6 +9,7 @@ from core.domain.entities.exceptions import (
     DeviceCommunicationError,
     DeviceNotFoundError,
 )
+from core.domain.value_objects.generation import Generation
 from core.domain.value_objects.provision_request import APDeviceInfo
 
 logger = logging.getLogger(__name__)
@@ -74,10 +75,7 @@ class APDeviceDetector:
         Gen2+ devices have a 'gen' field (2 or 3).
         Gen1 devices have a 'type' field but no 'gen' field.
         """
-        generation = data.get("gen")
-
-        if generation is None:
-            # This is a Gen1 device
+        if Generation.from_shelly_payload(data) is Generation.GEN1:
             device_type = data.get("type", "")
             if not device_type:
                 raise DeviceNotFoundError(
@@ -89,7 +87,7 @@ class APDeviceDetector:
                 "Only Gen2/Gen3 devices are supported for provisioning.",
             )
 
-        # Gen2/Gen3 device
+        generation = data["gen"]
         device_id = data.get("id", "")
         mac = data.get("mac", "")
         model = data.get("model", "")

--- a/packages/core/src/core/gateways/device/legacy_component_mapper.py
+++ b/packages/core/src/core/gateways/device/legacy_component_mapper.py
@@ -191,10 +191,10 @@ class LegacyComponentMapper:
                         "enable": config.get("enable", True),
                         "invert": config.get("invert", False),
                     },
+                    "available_actions": LEGACY_INPUT_ACTIONS.copy(),
                     "attrs": {
                         "legacy_component": "input",
                         "legacy_id": idx,
-                        "legacy_actions": LEGACY_INPUT_ACTIONS.copy(),
                     },
                 }
             )
@@ -250,10 +250,10 @@ class LegacyComponentMapper:
                             "current_limit", config.get("max_current", 0.0)
                         ),
                     },
+                    "available_actions": LEGACY_SWITCH_ACTIONS.copy(),
                     "attrs": {
                         "legacy_component": "relay",
                         "legacy_id": idx,
-                        "legacy_actions": LEGACY_SWITCH_ACTIONS.copy(),
                     },
                 }
             )
@@ -306,10 +306,10 @@ class LegacyComponentMapper:
                         "maxtime_close": config.get("maxtime_close", 0),
                         "power_limit": config.get("power_limit", 0),
                     },
+                    "available_actions": LEGACY_COVER_ACTIONS.copy(),
                     "attrs": {
                         "legacy_component": "roller",
                         "legacy_id": idx,
-                        "legacy_actions": LEGACY_COVER_ACTIONS.copy(),
                     },
                 }
             )

--- a/packages/core/src/core/use_cases/backup_device_config.py
+++ b/packages/core/src/core/use_cases/backup_device_config.py
@@ -11,6 +11,7 @@ from core.domain.entities.device_backup import (
     DeviceBackupSummary,
 )
 from core.domain.entities.exceptions import DeviceNotFoundError
+from core.domain.value_objects.generation import Generation
 from core.gateways.device import DeviceGateway
 from core.repositories.backup_repository import BackupRepository
 from core.use_cases.bulk_operations import BulkOperationsUseCase
@@ -94,11 +95,8 @@ class BackupDeviceConfig:
 
         # Generation comes from the device's explicit `gen` field (Gen2+ RPC) or
         # the legacy gateway's gen=1 stamp, never inferred from a missing field.
-        if status.gen == 1:
-            generation = "gen1"
-        elif status.gen is not None and status.gen >= 2:
-            generation = "gen2"
-        else:
+        generation = Generation.from_device_gen(status.gen)
+        if generation is None:
             raise BackupError(
                 f"Could not determine device generation for {device_ip}; "
                 "backup aborted"
@@ -111,7 +109,7 @@ class BackupDeviceConfig:
             device_name=status.device_name,
             device_type=status.device_type,
             firmware_version=status.firmware_version,
-            generation=generation,
+            generation=generation.value,
             name=name,
             source=source,
         )

--- a/packages/core/src/core/use_cases/bulk_operations.py
+++ b/packages/core/src/core/use_cases/bulk_operations.py
@@ -7,6 +7,9 @@ from ..domain.entities.exceptions import BulkOperationError
 from ..domain.value_objects.action_result import ActionResult
 from ..domain.value_objects.generation import Generation
 from ..gateways.device import DeviceGateway
+from .capture_strategies import ComponentCaptureStrategy
+from .capture_strategies.gen1 import Gen1CaptureStrategy
+from .capture_strategies.gen2 import Gen2CaptureStrategy
 
 logger = logging.getLogger(__name__)
 
@@ -18,6 +21,8 @@ class BulkOperationsUseCase:
         device_gateway: DeviceGateway,
     ):
         self._device_gateway = device_gateway
+        self._gen1_capture = Gen1CaptureStrategy(device_gateway)
+        self._gen2_capture = Gen2CaptureStrategy(device_gateway)
 
     async def execute_bulk_update(
         self, device_ips: list[str], channel: str = "stable"
@@ -136,6 +141,7 @@ class BulkOperationsUseCase:
             if not device_status:
                 continue
 
+            strategy = self._capture_strategy(device_status)
             device_data: dict[str, Any] = {
                 "device_info": {
                     "device_name": device_status.device_name,
@@ -144,120 +150,19 @@ class BulkOperationsUseCase:
                     "mac_address": device_status.mac_address,
                     "app_name": device_status.app_name,
                 },
-                "components": {},
+                "components": await strategy.capture_components(
+                    device_ip, device_status, component_types
+                ),
             }
-
-            # Gen1 has no /rpc: GetConfig and Schedule.List 404, so capture from
-            # the configs already mapped onto the DeviceStatus instead.
-            if Generation.from_device_gen(device_status.gen) is Generation.GEN1:
-                await self._export_gen1_config(
-                    device_ip, device_status, component_types, device_data
-                )
-                result["devices"][device_ip] = device_data
-                continue
-
-            for component in device_status.components:
-                if component.component_type in component_types:
-
-                    config_result = await self._device_gateway.execute_component_action(
-                        device_ip, component.key, "GetConfig", {}
-                    )
-
-                    component_export = {
-                        "type": component.component_type,
-                        "success": config_result.success,
-                        "config": config_result.data if config_result.success else None,
-                        "error": (
-                            config_result.error if not config_result.success else None
-                        ),
-                    }
-
-                    if component.component_type == "script" and config_result.success:
-                        code_data = await self._fetch_script_code(
-                            device_ip, component.key
-                        )
-                        if code_data is not None:
-                            component_export["code"] = code_data
-
-                    device_data["components"][component.key] = component_export
-
-            if "schedules" in component_types:
-                schedules = await self._fetch_schedules(device_ip)
-                device_data["components"].update(schedules)
 
             result["devices"][device_ip] = device_data
 
         return result
 
-    async def _export_gen1_config(
-        self,
-        device_ip: str,
-        device_status: DeviceStatus,
-        component_types: list[str],
-        device_data: dict[str, Any],
-    ) -> None:
-        """Capture Gen1 component configs plus the raw ``/settings``.
-
-        The ``legacy_settings`` entry is the source of truth a Gen1 restore
-        replays; it is omitted when the raw fetch fails, and the mapped configs
-        alone still make the backup valid.
-        """
-        for component in device_status.components:
-            if component.component_type in component_types:
-                device_data["components"][component.key] = {
-                    "type": component.component_type,
-                    "success": True,
-                    "config": component.config,
-                    "error": None,
-                }
-
-        legacy_settings = await self._device_gateway.get_legacy_settings(device_ip)
-        if legacy_settings is not None:
-            device_data["components"]["legacy_settings"] = {
-                "type": "legacy_settings",
-                "success": True,
-                "config": legacy_settings,
-                "error": None,
-            }
-
-    async def _fetch_script_code(
-        self, device_ip: str, component_key: str
-    ) -> dict[str, Any] | None:
-        try:
-            script_id = int(component_key.split(":")[1])
-            code_result = await self._device_gateway.execute_component_action(
-                device_ip, component_key, "GetCode", {"id": script_id}
-            )
-            if code_result.success and code_result.data:
-                return code_result.data
-        except (ValueError, IndexError, AttributeError):
-            pass
-
-        return None
-
-    async def _fetch_schedules(self, device_ip: str) -> dict[str, Any]:
-        schedule_export = {}
-
-        list_result = await self._device_gateway.execute_component_action(
-            device_ip, "schedule", "List", {}
-        )
-        schedule_data = list_result.data
-        if list_result.success and schedule_data:
-            schedule_export["schedules"] = {
-                "type": "schedule",
-                "success": True,
-                "config": schedule_data,
-                "error": None,
-            }
-        elif not list_result.success:
-            schedule_export["schedules"] = {
-                "type": "schedule",
-                "success": False,
-                "config": None,
-                "error": list_result.error,
-            }
-
-        return schedule_export
+    def _capture_strategy(self, status: DeviceStatus) -> ComponentCaptureStrategy:
+        if Generation.from_device_gen(status.gen) is Generation.GEN1:
+            return self._gen1_capture
+        return self._gen2_capture
 
     async def apply_bulk_config(
         self,

--- a/packages/core/src/core/use_cases/bulk_operations.py
+++ b/packages/core/src/core/use_cases/bulk_operations.py
@@ -5,6 +5,7 @@ from typing import Any
 from ..domain.entities.device_status import DeviceStatus
 from ..domain.entities.exceptions import BulkOperationError
 from ..domain.value_objects.action_result import ActionResult
+from ..domain.value_objects.generation import Generation
 from ..gateways.device import DeviceGateway
 
 logger = logging.getLogger(__name__)
@@ -148,7 +149,7 @@ class BulkOperationsUseCase:
 
             # Gen1 has no /rpc: GetConfig and Schedule.List 404, so capture from
             # the configs already mapped onto the DeviceStatus instead.
-            if device_status.gen == 1:
+            if Generation.from_device_gen(device_status.gen) is Generation.GEN1:
                 await self._export_gen1_config(
                     device_ip, device_status, component_types, device_data
                 )

--- a/packages/core/src/core/use_cases/capture_strategies/__init__.py
+++ b/packages/core/src/core/use_cases/capture_strategies/__init__.py
@@ -1,0 +1,23 @@
+"""Per-generation capture strategies.
+
+The capture mirror of :mod:`core.use_cases.restore_strategies`:
+``BulkOperationsUseCase.export_bulk_config`` owns the export envelope and the
+per-device loop; how one generation's component configs are captured lives
+behind ``ComponentCaptureStrategy``.
+"""
+
+from typing import Any, Protocol
+
+from core.domain.entities.device_status import DeviceStatus
+
+
+class ComponentCaptureStrategy(Protocol):
+    """One device generation's side of a config capture."""
+
+    async def capture_components(
+        self, device_ip: str, status: DeviceStatus, component_types: list[str]
+    ) -> dict[str, Any]:
+        """Captured component entries keyed by component key, in the snapshot
+        shape (``{"type", "success", "config", "error"}`` plus per-type
+        extras)."""
+        ...

--- a/packages/core/src/core/use_cases/capture_strategies/gen1.py
+++ b/packages/core/src/core/use_cases/capture_strategies/gen1.py
@@ -1,0 +1,46 @@
+"""Capture strategy for Gen1 (legacy HTTP) devices."""
+
+from typing import Any
+
+from core.domain.entities.device_backup import LEGACY_SETTINGS_KEY
+from core.domain.entities.device_status import DeviceStatus
+from core.gateways.device import DeviceGateway
+
+
+class Gen1CaptureStrategy:
+    """Capture Gen1 component configs plus the raw ``/settings``.
+
+    Gen1 has no /rpc: GetConfig and Schedule.List 404, so the mapped configs
+    already on the ``DeviceStatus`` are captured instead. The
+    ``legacy_settings`` entry is the source of truth a Gen1 restore replays;
+    it is omitted when the raw fetch fails, and the mapped configs alone still
+    make the backup valid.
+    """
+
+    def __init__(self, device_gateway: DeviceGateway):
+        self._device_gateway = device_gateway
+
+    async def capture_components(
+        self, device_ip: str, status: DeviceStatus, component_types: list[str]
+    ) -> dict[str, Any]:
+        components: dict[str, Any] = {}
+
+        for component in status.components:
+            if component.component_type in component_types:
+                components[component.key] = {
+                    "type": component.component_type,
+                    "success": True,
+                    "config": component.config,
+                    "error": None,
+                }
+
+        legacy_settings = await self._device_gateway.get_legacy_settings(device_ip)
+        if legacy_settings is not None:
+            components[LEGACY_SETTINGS_KEY] = {
+                "type": LEGACY_SETTINGS_KEY,
+                "success": True,
+                "config": legacy_settings,
+                "error": None,
+            }
+
+        return components

--- a/packages/core/src/core/use_cases/capture_strategies/gen2.py
+++ b/packages/core/src/core/use_cases/capture_strategies/gen2.py
@@ -1,0 +1,86 @@
+"""Capture strategy for Gen2+ (RPC) devices."""
+
+from typing import Any
+
+from core.domain.entities.device_status import DeviceStatus
+from core.gateways.device import DeviceGateway
+
+
+class Gen2CaptureStrategy:
+    """Capture component configs over the Gen2+ RPC surface."""
+
+    def __init__(self, device_gateway: DeviceGateway):
+        self._device_gateway = device_gateway
+
+    async def capture_components(
+        self, device_ip: str, status: DeviceStatus, component_types: list[str]
+    ) -> dict[str, Any]:
+        components: dict[str, Any] = {}
+
+        for component in status.components:
+            if component.component_type in component_types:
+
+                config_result = await self._device_gateway.execute_component_action(
+                    device_ip, component.key, "GetConfig", {}
+                )
+
+                component_export = {
+                    "type": component.component_type,
+                    "success": config_result.success,
+                    "config": config_result.data if config_result.success else None,
+                    "error": (
+                        config_result.error if not config_result.success else None
+                    ),
+                }
+
+                if component.component_type == "script" and config_result.success:
+                    code_data = await self._fetch_script_code(device_ip, component.key)
+                    if code_data is not None:
+                        component_export["code"] = code_data
+
+                components[component.key] = component_export
+
+        if "schedules" in component_types:
+            schedules = await self._fetch_schedules(device_ip)
+            components.update(schedules)
+
+        return components
+
+    async def _fetch_script_code(
+        self, device_ip: str, component_key: str
+    ) -> dict[str, Any] | None:
+        try:
+            script_id = int(component_key.split(":")[1])
+            code_result = await self._device_gateway.execute_component_action(
+                device_ip, component_key, "GetCode", {"id": script_id}
+            )
+            if code_result.success and code_result.data:
+                return code_result.data
+        except (ValueError, IndexError, AttributeError):
+            pass
+
+        return None
+
+    async def _fetch_schedules(self, device_ip: str) -> dict[str, Any]:
+        schedule_export = {}
+
+        list_result = await self._device_gateway.execute_component_action(
+            device_ip, "schedule", "List", {}
+        )
+        schedule_data = list_result.data
+        if list_result.success and schedule_data:
+            schedule_export["schedules"] = {
+                "type": "schedule",
+                "success": True,
+                "config": schedule_data,
+                "error": None,
+            }
+        elif not list_result.success:
+            schedule_export["schedules"] = {
+                "type": "schedule",
+                "success": False,
+                "config": None,
+                "error": list_result.error,
+            }
+
+        return schedule_export

--- a/packages/core/src/core/use_cases/restore_device_config.py
+++ b/packages/core/src/core/use_cases/restore_device_config.py
@@ -5,7 +5,7 @@ from collections.abc import Callable
 from contextlib import AbstractAsyncContextManager
 from typing import Any
 
-from core.domain.entities.device_backup import DeviceBackup
+from core.domain.entities.device_backup import LEGACY_SETTINGS_KEY, DeviceBackup
 from core.domain.entities.exceptions import DeviceNotFoundError
 from core.domain.value_objects.generation import Generation
 from core.domain.value_objects.restore_result import (
@@ -15,10 +15,7 @@ from core.domain.value_objects.restore_result import (
 from core.gateways.device import DeviceGateway
 from core.repositories.backup_repository import BackupRepository
 from core.use_cases.backup_device_config import BackupNotFoundError
-from core.use_cases.restore_strategies import (
-    LEGACY_SETTINGS_KEY,
-    ComponentRestoreStrategy,
-)
+from core.use_cases.restore_strategies import ComponentRestoreStrategy
 from core.use_cases.restore_strategies.gen1 import Gen1RestoreStrategy
 from core.use_cases.restore_strategies.gen2 import Gen2RestoreStrategy
 from core.utils.validation import normalize_mac

--- a/packages/core/src/core/use_cases/restore_device_config.py
+++ b/packages/core/src/core/use_cases/restore_device_config.py
@@ -7,6 +7,7 @@ from typing import Any
 
 from core.domain.entities.device_backup import DeviceBackup
 from core.domain.entities.exceptions import DeviceNotFoundError
+from core.domain.value_objects.generation import Generation
 from core.domain.value_objects.restore_result import (
     ComponentRestoreResult,
     RestoreResult,
@@ -124,11 +125,18 @@ class RestoreDeviceConfig:
 
         # A target whose generation is unknown (gen is None, e.g. GetDeviceInfo
         # failed) is already gated by the MAC check above, so it never reaches here.
-        is_gen1 = backup.generation == "gen1" and status.gen == 1
-        if (backup.generation == "gen1" or status.gen == 1) and not is_gen1:
+        backup_generation = Generation.from_label(backup.generation)
+        device_generation = Generation.from_device_gen(status.gen)
+        is_gen1 = (
+            backup_generation is Generation.GEN1
+            and device_generation is Generation.GEN1
+        )
+        if (
+            backup_generation is Generation.GEN1 or device_generation is Generation.GEN1
+        ) and not is_gen1:
             return self._generation_mismatch(backup, device_ip, component_keys)
 
-        strategy = self._build_strategy(is_gen1)
+        strategy = self._build_strategy(Generation.GEN1 if is_gen1 else Generation.GEN2)
         outcome = await strategy.prepare(device_ip, backup, status)
         if outcome.abort_reason is not None:
             return self._all_skipped(
@@ -216,10 +224,10 @@ class RestoreDeviceConfig:
             components=results,
         )
 
-    def _build_strategy(self, is_gen1: bool) -> ComponentRestoreStrategy:
+    def _build_strategy(self, generation: Generation) -> ComponentRestoreStrategy:
         # Strategies are stateful per run (Gen1 holds the loaded settings), so
         # each restore constructs its own.
-        if is_gen1:
+        if generation is Generation.GEN1:
             return Gen1RestoreStrategy(
                 self._device_gateway,
                 mode_change_timeout=self._mode_change_timeout,

--- a/packages/core/src/core/use_cases/restore_device_config.py
+++ b/packages/core/src/core/use_cases/restore_device_config.py
@@ -1,19 +1,12 @@
 """Use case for restoring a stored backup back onto a device."""
 
-import asyncio
 import logging
 from collections.abc import Callable
 from contextlib import AbstractAsyncContextManager
-from copy import deepcopy
 from typing import Any
 
 from core.domain.entities.device_backup import DeviceBackup
-from core.domain.entities.device_status import DeviceStatus
 from core.domain.entities.exceptions import DeviceNotFoundError
-from core.domain.services.gen1_settings_translation import (
-    restorable_params,
-    wifi_subresources,
-)
 from core.domain.value_objects.restore_result import (
     ComponentRestoreResult,
     RestoreResult,
@@ -21,6 +14,12 @@ from core.domain.value_objects.restore_result import (
 from core.gateways.device import DeviceGateway
 from core.repositories.backup_repository import BackupRepository
 from core.use_cases.backup_device_config import BackupNotFoundError
+from core.use_cases.restore_strategies import (
+    LEGACY_SETTINGS_KEY,
+    ComponentRestoreStrategy,
+)
+from core.use_cases.restore_strategies.gen1 import Gen1RestoreStrategy
+from core.use_cases.restore_strategies.gen2 import Gen2RestoreStrategy
 from core.utils.validation import normalize_mac
 
 logger = logging.getLogger(__name__)
@@ -28,21 +27,6 @@ logger = logging.getLogger(__name__)
 # Component types that can drop the device off the network if restored.
 # Excluded from the default selection; applied LAST when explicitly included.
 NETWORK_TYPES = {"wifi", "eth", "mqtt", "ws", "cloud"}
-
-# The "schedules" pseudo-component produced by export_bulk_config.
-SCHEDULES_KEY = "schedules"
-
-# The raw Gen1 /settings entry captured alongside the mapped components. It is the
-# data source a Gen1 restore replays, never a restore target itself.
-LEGACY_SETTINGS_KEY = "legacy_settings"
-
-# Read-only keys that GetConfig echoes but SetConfig rejects, by component type.
-# Each entry is a (parent, child) path popped from the config dict. Top-level
-# "id" and "cfg_rev" are always stripped. Table-driven so it is easy to extend.
-READ_ONLY_BY_TYPE: dict[str, list[tuple[str, str]]] = {
-    "sys": [("device", "mac")],
-    "wifi": [("ap", "is_open")],
-}
 
 
 class DeviceMismatchError(Exception):
@@ -58,7 +42,12 @@ class DeviceMismatchError(Exception):
 
 
 class RestoreDeviceConfig:
-    """Apply a stored backup back to a device, per component key."""
+    """Apply a stored backup back to a device, per component key.
+
+    Orchestration only: backup lookup, identity and generation checks,
+    selection and ordering, result aggregation. The per-generation wire work
+    lives in the restore strategies.
+    """
 
     def __init__(
         self,
@@ -136,49 +125,38 @@ class RestoreDeviceConfig:
         # A target whose generation is unknown (gen is None, e.g. GetDeviceInfo
         # failed) is already gated by the MAC check above, so it never reaches here.
         is_gen1 = backup.generation == "gen1" and status.gen == 1
-        gen1_settings: dict[str, Any] | None = None
-        if backup.generation == "gen1" or status.gen == 1:
-            if not is_gen1:
-                return self._generation_mismatch(backup, device_ip, component_keys)
-            # Gen1 restores replay the raw /settings captured at backup time; the
-            # mapped per-component configs are Gen2-shaped and not writable as-is.
-            gen1_settings = self._legacy_settings(backup)
-            if gen1_settings is None:
-                return self._all_skipped(
-                    backup,
-                    device_ip,
-                    component_keys,
-                    "snapshot lacks raw Gen1 settings",
-                )
+        if (backup.generation == "gen1" or status.gen == 1) and not is_gen1:
+            return self._generation_mismatch(backup, device_ip, component_keys)
 
-        mode_result: ComponentRestoreResult | None = None
-        if gen1_settings is not None:
-            mode_result, status = await self._sync_gen1_mode(
-                device_ip, gen1_settings, status
+        strategy = self._build_strategy(is_gen1)
+        outcome = await strategy.prepare(device_ip, backup, status)
+        if outcome.abort_reason is not None:
+            return self._all_skipped(
+                backup, device_ip, component_keys, outcome.abort_reason
             )
-            if (
-                mode_result is not None
-                and not mode_result.success
-                and not mode_result.skipped
-            ):
-                return RestoreResult(
-                    success=False,
-                    device_ip=device_ip,
-                    backup_id=backup_id,
-                    total=1,
-                    succeeded=0,
-                    failed=1,
-                    skipped=0,
-                    message=mode_result.error,
-                    components=[mode_result],
-                )
+        failure = next(
+            (r for r in outcome.preliminary if not r.success and not r.skipped), None
+        )
+        if failure is not None:
+            return RestoreResult(
+                success=False,
+                device_ip=device_ip,
+                backup_id=backup_id,
+                total=len(outcome.preliminary),
+                succeeded=sum(1 for r in outcome.preliminary if r.success),
+                failed=sum(
+                    1 for r in outcome.preliminary if not r.success and not r.skipped
+                ),
+                skipped=sum(1 for r in outcome.preliminary if r.skipped),
+                message=failure.error,
+                components=outcome.preliminary,
+            )
 
+        status = outcome.status
         present_keys = {component.key for component in status.components}
         selected = self._select(components, component_keys)
 
-        results: list[ComponentRestoreResult] = []
-        if mode_result is not None:
-            results.append(mode_result)
+        results: list[ComponentRestoreResult] = list(outcome.preliminary)
         # Surface explicitly-requested keys that aren't in the backup, so the
         # caller never silently gets a smaller restore set than they asked for.
         if component_keys is not None:
@@ -204,17 +182,11 @@ class RestoreDeviceConfig:
                         )
                     )
         for key in selected:
-            entry = components[key]
-            if gen1_settings is not None:
-                results.append(
-                    await self._restore_gen1_one(
-                        device_ip, key, entry, gen1_settings, present_keys
-                    )
+            results.append(
+                await strategy.restore_component(
+                    device_ip, key, components[key], present_keys
                 )
-            else:
-                results.append(
-                    await self._restore_one(device_ip, key, entry, present_keys)
-                )
+            )
 
         succeeded = sum(1 for r in results if r.success)
         failed = sum(1 for r in results if not r.success and not r.skipped)
@@ -226,14 +198,7 @@ class RestoreDeviceConfig:
         applied = succeeded > 0 and failed == 0
 
         if reboot and applied:
-            if is_gen1:
-                await self._device_gateway.execute_component_action(
-                    device_ip, "sys", "Legacy.Reboot", {}
-                )
-            else:
-                await self._device_gateway.execute_component_action(
-                    device_ip, "shelly", "Reboot", {}
-                )
+            await strategy.reboot(device_ip)
 
         return RestoreResult(
             success=applied,
@@ -250,6 +215,17 @@ class RestoreDeviceConfig:
             ),
             components=results,
         )
+
+    def _build_strategy(self, is_gen1: bool) -> ComponentRestoreStrategy:
+        # Strategies are stateful per run (Gen1 holds the loaded settings), so
+        # each restore constructs its own.
+        if is_gen1:
+            return Gen1RestoreStrategy(
+                self._device_gateway,
+                mode_change_timeout=self._mode_change_timeout,
+                mode_change_poll_interval=self._mode_change_poll_interval,
+            )
+        return Gen2RestoreStrategy(self._device_gateway)
 
     def _select(
         self, components: dict[str, Any], component_keys: list[str] | None
@@ -277,319 +253,6 @@ class RestoreDeviceConfig:
             return candidates[key].get("type") in NETWORK_TYPES
 
         return sorted(keys, key=is_network)
-
-    async def _restore_one(
-        self,
-        device_ip: str,
-        key: str,
-        entry: dict[str, Any],
-        present_keys: set[str],
-    ) -> ComponentRestoreResult:
-        ctype = entry.get("type")
-
-        if key == SCHEDULES_KEY:
-            return await self._restore_schedules(device_ip, key, entry)
-        if ctype == "script":
-            return await self._restore_script(device_ip, key, entry, present_keys)
-
-        if not entry.get("success") or entry.get("config") is None:
-            return ComponentRestoreResult(
-                key=key,
-                action="SetConfig",
-                success=False,
-                skipped=True,
-                skipped_reason="no config captured in backup",
-            )
-        if key not in present_keys:
-            return ComponentRestoreResult(
-                key=key,
-                action="SetConfig",
-                success=False,
-                skipped=True,
-                skipped_reason="component not present on target device",
-            )
-
-        config = self._strip_readonly(ctype, deepcopy(entry["config"]))
-        result = await self._device_gateway.execute_component_action(
-            device_ip, key, "SetConfig", {"config": config}
-        )
-        return ComponentRestoreResult(
-            key=key,
-            action="SetConfig",
-            success=result.success,
-            error=result.error if not result.success else None,
-        )
-
-    def _strip_readonly(
-        self, ctype: str | None, config: dict[str, Any]
-    ) -> dict[str, Any]:
-        config.pop("id", None)
-        config.pop("cfg_rev", None)
-        for parent, child in READ_ONLY_BY_TYPE.get(ctype or "", []):
-            section = config.get(parent)
-            if isinstance(section, dict):
-                section.pop(child, None)
-        return config
-
-    async def _restore_script(
-        self,
-        device_ip: str,
-        key: str,
-        entry: dict[str, Any],
-        present_keys: set[str],
-    ) -> ComponentRestoreResult:
-        code_block = entry.get("code") or {}
-        code = code_block.get("data") if isinstance(code_block, dict) else None
-        # Presence + type, not truthiness: an empty script body ("") is valid.
-        if not isinstance(code, str):
-            return ComponentRestoreResult(
-                key=key,
-                action="PutCode",
-                success=False,
-                skipped=True,
-                skipped_reason="no script code captured in backup",
-            )
-        if key not in present_keys:
-            return ComponentRestoreResult(
-                key=key,
-                action="PutCode",
-                success=False,
-                skipped=True,
-                skipped_reason="script not present on target device",
-            )
-        try:
-            script_id = int(key.split(":")[1])
-        except (ValueError, IndexError):
-            return ComponentRestoreResult(
-                key=key,
-                action="PutCode",
-                success=False,
-                skipped=True,
-                skipped_reason="could not resolve script id",
-            )
-
-        result = await self._device_gateway.execute_component_action(
-            device_ip, key, "PutCode", {"id": script_id, "code": code, "append": False}
-        )
-        return ComponentRestoreResult(
-            key=key,
-            action="PutCode",
-            success=result.success,
-            error=result.error if not result.success else None,
-        )
-
-    async def _restore_schedules(
-        self, device_ip: str, key: str, entry: dict[str, Any]
-    ) -> ComponentRestoreResult:
-        # Gate on whether the schedules component was *captured*, not on job
-        # count: a device with zero schedules is captured as {"jobs": []}, and
-        # restoring it must still clear the target's schedules.
-        if not entry.get("success") or entry.get("config") is None:
-            return ComponentRestoreResult(
-                key=key,
-                action="Schedule.Replace",
-                success=False,
-                skipped=True,
-                skipped_reason="no schedules captured in backup",
-            )
-
-        config = entry["config"]
-        jobs = config.get("jobs", []) if isinstance(config, dict) else []
-
-        # Restore must reproduce the captured schedule set, not merge into the
-        # device's existing jobs. Always clear the target first so re-runs are
-        # idempotent and stale/duplicate jobs don't accumulate (including when
-        # the captured set is empty). If the clear fails, abort: creating on top
-        # of un-cleared jobs would merge/duplicate instead of replace.
-        delete_result = await self._device_gateway.execute_component_action(
-            device_ip, "schedule", "DeleteAll", {}
-        )
-        if not delete_result.success:
-            return ComponentRestoreResult(
-                key=key,
-                action="Schedule.Replace",
-                success=False,
-                error=f"DeleteAll failed: {delete_result.error or 'unknown error'}",
-            )
-
-        errors: list[str] = []
-        for job in jobs:
-            params = {k: v for k, v in job.items() if k != "id"}
-            result = await self._device_gateway.execute_component_action(
-                device_ip, "schedule", "Create", params
-            )
-            if not result.success:
-                errors.append(result.error or "Schedule.Create failed")
-
-        return ComponentRestoreResult(
-            key=key,
-            action="Schedule.Replace",
-            success=not errors,
-            error="; ".join(errors) if errors else None,
-        )
-
-    def _legacy_settings(self, backup: DeviceBackup) -> dict[str, Any] | None:
-        components: dict[str, Any] = backup.snapshot.get("components", {})
-        entry = components.get(LEGACY_SETTINGS_KEY)
-        if not isinstance(entry, dict) or not entry.get("success"):
-            return None
-        settings = entry.get("config")
-        return settings if isinstance(settings, dict) else None
-
-    async def _restore_gen1_one(
-        self,
-        device_ip: str,
-        key: str,
-        entry: dict[str, Any],
-        settings: dict[str, Any],
-        present_keys: set[str],
-    ) -> ComponentRestoreResult:
-        ctype = entry.get("type")
-
-        if key not in present_keys:
-            return ComponentRestoreResult(
-                key=key,
-                action="Legacy.SetConfig",
-                success=False,
-                skipped=True,
-                skipped_reason="component not present on target device",
-            )
-
-        if ctype == "wifi":
-            return await self._restore_gen1_wifi(device_ip, key, settings)
-
-        params = restorable_params(key, ctype, settings)
-        if params is None:
-            return ComponentRestoreResult(
-                key=key,
-                action="Legacy.SetConfig",
-                success=False,
-                skipped=True,
-                skipped_reason="no Gen1 settings endpoint for this component",
-            )
-        if not params:
-            return ComponentRestoreResult(
-                key=key,
-                action="Legacy.SetConfig",
-                success=False,
-                skipped=True,
-                skipped_reason="no restorable settings captured in backup",
-            )
-
-        result = await self._device_gateway.execute_component_action(
-            device_ip, key, "Legacy.SetConfig", params
-        )
-        return ComponentRestoreResult(
-            key=key,
-            action="Legacy.SetConfig",
-            success=result.success,
-            error=result.error if not result.success else None,
-        )
-
-    async def _restore_gen1_wifi(
-        self, device_ip: str, key: str, settings: dict[str, Any]
-    ) -> ComponentRestoreResult:
-        """Replay every captured Gen1 WiFi resource behind the "wifi" component."""
-        subresources = wifi_subresources(settings)
-        errors: list[str] = []
-        for subtype, params in subresources:
-            result = await self._device_gateway.execute_component_action(
-                device_ip, subtype, "Legacy.SetConfig", params
-            )
-            if not result.success:
-                errors.append(f"{subtype}: {result.error or 'failed'}")
-
-        if not subresources:
-            return ComponentRestoreResult(
-                key=key,
-                action="Legacy.SetConfig",
-                success=False,
-                skipped=True,
-                skipped_reason="no restorable settings captured in backup",
-            )
-        return ComponentRestoreResult(
-            key=key,
-            action="Legacy.SetConfig",
-            success=not errors,
-            error="; ".join(errors) if errors else None,
-        )
-
-    async def _sync_gen1_mode(
-        self,
-        device_ip: str,
-        settings: dict[str, Any],
-        status: DeviceStatus,
-    ) -> tuple[ComponentRestoreResult | None, DeviceStatus]:
-        """Align the target's relay/roller mode with the backup before restoring.
-
-        Gen1 applies ``mode`` with a reboot and re-enumerates its components
-        afterwards, so it cannot ride along in the sys param batch: it is sent
-        alone first, and the device status is re-read once the target is back.
-        Returns the pre-phase result (``None`` when nothing needed doing) and
-        the status to restore against.
-        """
-        backup_mode = settings.get("mode")
-        if not isinstance(backup_mode, str) or not backup_mode:
-            return None, status
-
-        target_settings = await self._device_gateway.get_legacy_settings(device_ip)
-        target_mode = (
-            target_settings.get("mode") if isinstance(target_settings, dict) else None
-        )
-        if not isinstance(target_mode, str) or not target_mode:
-            return (
-                ComponentRestoreResult(
-                    key="mode",
-                    action="Legacy.SetConfig",
-                    success=False,
-                    skipped=True,
-                    skipped_reason="could not read the target device mode",
-                ),
-                status,
-            )
-        if target_mode == backup_mode:
-            return None, status
-
-        result = await self._device_gateway.execute_component_action(
-            device_ip, "sys", "Legacy.SetConfig", {"mode": backup_mode}
-        )
-        if not result.success:
-            return (
-                ComponentRestoreResult(
-                    key="mode",
-                    action="Legacy.SetConfig",
-                    success=False,
-                    error=result.error or "mode change failed",
-                ),
-                status,
-            )
-
-        new_status = await self._wait_for_device(device_ip)
-        if new_status is None:
-            return (
-                ComponentRestoreResult(
-                    key="mode",
-                    action="Legacy.SetConfig",
-                    success=False,
-                    error="device did not come back after the mode change",
-                ),
-                status,
-            )
-        return (
-            ComponentRestoreResult(key="mode", action="Legacy.SetConfig", success=True),
-            new_status,
-        )
-
-    async def _wait_for_device(self, device_ip: str) -> DeviceStatus | None:
-        loop = asyncio.get_running_loop()
-        deadline = loop.time() + self._mode_change_timeout
-        while True:
-            status = await self._device_gateway.get_device_status(device_ip)
-            if status is not None:
-                return status
-            if loop.time() >= deadline:
-                return None
-            await asyncio.sleep(self._mode_change_poll_interval)
 
     def _generation_mismatch(
         self,

--- a/packages/core/src/core/use_cases/restore_device_config.py
+++ b/packages/core/src/core/use_cases/restore_device_config.py
@@ -10,6 +10,10 @@ from typing import Any
 from core.domain.entities.device_backup import DeviceBackup
 from core.domain.entities.device_status import DeviceStatus
 from core.domain.entities.exceptions import DeviceNotFoundError
+from core.domain.services.gen1_settings_translation import (
+    restorable_params,
+    wifi_subresources,
+)
 from core.domain.value_objects.restore_result import (
     ComponentRestoreResult,
     RestoreResult,
@@ -32,159 +36,6 @@ SCHEDULES_KEY = "schedules"
 # data source a Gen1 restore replays, never a restore target itself.
 LEGACY_SETTINGS_KEY = "legacy_settings"
 
-# Section of the raw /settings holding each component's config. "" is the top level.
-# wifi_sta1/wifi_ap are synthetic types for the extra Gen1 WiFi resources replayed
-# behind the single "wifi" component (see _restore_gen1_wifi).
-GEN1_SECTION_BY_TYPE: dict[str, str] = {
-    "switch": "relays",
-    "cover": "rollers",
-    "input": "inputs",
-    "sys": "",
-    "mqtt": "mqtt",
-    "cloud": "cloud",
-    "wifi": "wifi_sta",
-    "wifi_sta1": "wifi_sta1",
-    "wifi_ap": "wifi_ap",
-}
-
-# Restorable Gen1 settings per component type, as GET /settings names them. Only
-# params documented as settable at https://shelly-api-docs.shelly.cloud/gen1/ are
-# listed, so read-only echoes (ison, has_timer, is_valid, safety_switch) are
-# never sent back. Fields a model does not have are absent and skip themselves,
-# which is what lets one table serve every Gen1 model.
-GEN1_RESTORABLE_BY_TYPE: dict[str, tuple[str, ...]] = {
-    "switch": (
-        "name",
-        "appliance_type",
-        "default_state",
-        "btn_type",
-        "btn_reverse",
-        # Shelly 1L exposes two inputs instead of one.
-        "btn1_type",
-        "btn1_reverse",
-        "btn2_type",
-        "btn2_reverse",
-        "swap_inputs",
-        "auto_on",
-        "auto_off",
-        "schedule",
-        "schedule_rules",
-        "max_power",
-        # On Shelly 1/1L "power" is the settable user power constant shown in
-        # meters, not a live reading (live power is echoed under "meters").
-        "power",
-    ),
-    "cover": (
-        "default_state",
-        "input_mode",
-        "button_type",
-        "btn_reverse",
-        "swap",
-        "swap_inputs",
-        "maxtime",
-        "maxtime_open",
-        "maxtime_close",
-        "positioning",
-        "obstacle_mode",
-        "obstacle_action",
-        "obstacle_power",
-        "obstacle_delay",
-        "ends_delay",
-        "off_power",
-        "safety_mode",
-        "safety_action",
-        "safety_allowed_on_trigger",
-        "schedule",
-        "schedule_rules",
-    ),
-    # "mode" is deliberately absent: Gen1 applies it with a reboot, so it is
-    # replayed alone as a pre-phase (_sync_gen1_mode), never in this batch.
-    "sys": (
-        "name",
-        "timezone",
-        "tzautodetect",
-        "tz_utc_offset",
-        "tz_dst",
-        "tz_dst_auto",
-        "lat",
-        "lng",
-        "discoverable",
-        "led_status_disable",
-        "led_power_disable",
-        "sntp.server",
-        # Device-level overpower threshold (1PM, Plug/PlugS, 2.5 in roller
-        # mode); distinct from the per-relay max_power.
-        "max_power",
-        "longpush_time",
-        "factory_reset_from_switch",
-        "wifirecovery_reboot_enabled",
-        "debug_enable",
-        "allow_cross_origin",
-        "supply_voltage",
-        "power_correction",
-        # 2.5 roller favourite positions live on /settings/favorites/{i} (not
-        # replayed); only their enable flag is a plain /settings param.
-        "favorites_enabled",
-        "coiot.enabled",
-        "coiot.update_period",
-        "coiot.peer",
-        "ap_roaming.enabled",
-        "ap_roaming.threshold",
-        "longpush_duration_ms.min",
-        "longpush_duration_ms.max",
-        "multipush_time_between_pushes_ms.max",
-    ),
-    # Only i3/Button1 expose /settings/input/{i}. Relay-bearing models never
-    # echo an "inputs" section in /settings (their input config lives on the
-    # owning relay), so their inputs skip as having nothing captured.
-    "input": ("name", "btn_type", "btn_reverse"),
-    # mqtt_pass is not echoed by GET /settings, so it cannot be restored.
-    "mqtt": (
-        "enable",
-        "server",
-        "user",
-        "id",
-        "clean_session",
-        "retain",
-        "keep_alive",
-        "update_period",
-        "max_qos",
-        "reconnect_timeout_min",
-        "reconnect_timeout_max",
-    ),
-    "cloud": ("enabled",),
-    # The WiFi STA "key" is not echoed by GET /settings, so it cannot be restored.
-    "wifi": ("enabled", "ssid", "ipv4_method", "ip", "gw", "mask", "dns"),
-    # The AP SSID is device-fixed and not settable; the AP key, unlike the STA
-    # one, IS echoed by GET /settings and round-trips.
-    "wifi_ap": ("enabled", "key"),
-}
-# /settings/sta1 (fallback STA) is documented as an identical resource to
-# /settings/sta.
-GEN1_RESTORABLE_BY_TYPE["wifi_sta1"] = GEN1_RESTORABLE_BY_TYPE["wifi"]
-
-# GET /settings echoes several fields under a different name than the one their
-# setter accepts; sending the echoed name is silently ignored by the device.
-GEN1_PARAM_RENAMES: dict[str, dict[str, str]] = {
-    "cover": {"button_type": "btn_type"},
-    "sys": {
-        "sntp.server": "sntp_server",
-        "coiot.enabled": "coiot_enable",
-        "coiot.update_period": "coiot_update_period",
-        "coiot.peer": "coiot_peer",
-        "ap_roaming.enabled": "ap_roaming_enabled",
-        "ap_roaming.threshold": "ap_roaming_threshold",
-        "longpush_duration_ms.min": "longpush_duration_ms_min",
-        "longpush_duration_ms.max": "longpush_duration_ms_max",
-        "multipush_time_between_pushes_ms.max": (
-            "multipush_time_between_pushes_ms_max"
-        ),
-    },
-    "mqtt": {name: f"mqtt_{name}" for name in GEN1_RESTORABLE_BY_TYPE["mqtt"]},
-    "wifi": {"gw": "gateway", "mask": "netmask"},
-}
-GEN1_PARAM_RENAMES["wifi_sta1"] = GEN1_PARAM_RENAMES["wifi"]
-
 # Read-only keys that GetConfig echoes but SetConfig rejects, by component type.
 # Each entry is a (parent, child) path popped from the config dict. Top-level
 # "id" and "cfg_rev" are always stripped. Table-driven so it is easy to extend.
@@ -192,15 +43,6 @@ READ_ONLY_BY_TYPE: dict[str, list[tuple[str, str]]] = {
     "sys": [("device", "mac")],
     "wifi": [("ap", "is_open")],
 }
-
-
-def _dig(section: dict[str, Any], path: str) -> Any:
-    value: Any = section
-    for part in path.split("."):
-        if not isinstance(value, dict):
-            return None
-        value = value.get(part)
-    return value
 
 
 class DeviceMismatchError(Exception):
@@ -616,7 +458,7 @@ class RestoreDeviceConfig:
         if ctype == "wifi":
             return await self._restore_gen1_wifi(device_ip, key, settings)
 
-        params = self._gen1_params(key, ctype, settings)
+        params = restorable_params(key, ctype, settings)
         if params is None:
             return ComponentRestoreResult(
                 key=key,
@@ -647,26 +489,17 @@ class RestoreDeviceConfig:
     async def _restore_gen1_wifi(
         self, device_ip: str, key: str, settings: dict[str, Any]
     ) -> ComponentRestoreResult:
-        """Replay every captured Gen1 WiFi resource behind the "wifi" component.
-
-        Gen1 splits WiFi across /settings/sta, /settings/sta1 (fallback STA) and
-        /settings/ap. The AP is applied last: enabling one mode disables the
-        other on the device, so the resource enabled in the backup must win.
-        """
-        attempted = False
+        """Replay every captured Gen1 WiFi resource behind the "wifi" component."""
+        subresources = wifi_subresources(settings)
         errors: list[str] = []
-        for subtype in ("wifi", "wifi_sta1", "wifi_ap"):
-            params = self._gen1_params(subtype, subtype, settings)
-            if not params:
-                continue
-            attempted = True
+        for subtype, params in subresources:
             result = await self._device_gateway.execute_component_action(
                 device_ip, subtype, "Legacy.SetConfig", params
             )
             if not result.success:
                 errors.append(f"{subtype}: {result.error or 'failed'}")
 
-        if not attempted:
+        if not subresources:
             return ComponentRestoreResult(
                 key=key,
                 action="Legacy.SetConfig",
@@ -757,45 +590,6 @@ class RestoreDeviceConfig:
             if loop.time() >= deadline:
                 return None
             await asyncio.sleep(self._mode_change_poll_interval)
-
-    def _gen1_params(
-        self, key: str, ctype: str | None, settings: dict[str, Any]
-    ) -> dict[str, Any] | None:
-        """``None`` when the type has no Gen1 settings endpoint at all; ``{}``
-        when it has one but the snapshot holds nothing to send (e.g. inputs on
-        relay-bearing models, which never echo an ``inputs`` settings section).
-        """
-        allowed = GEN1_RESTORABLE_BY_TYPE.get(ctype or "")
-        if allowed is None:
-            return None
-
-        section = self._gen1_section(key, ctype or "", settings)
-        if section is None:
-            return {}
-
-        renames = GEN1_PARAM_RENAMES.get(ctype or "", {})
-        params: dict[str, Any] = {}
-        for attr in allowed:
-            value = _dig(section, attr)
-            if value is not None:
-                params[renames.get(attr, attr)] = value
-        return params
-
-    def _gen1_section(
-        self, key: str, ctype: str, settings: dict[str, Any]
-    ) -> dict[str, Any] | None:
-        section_name = GEN1_SECTION_BY_TYPE[ctype]
-        section: Any = settings if not section_name else settings.get(section_name)
-
-        # relays/rollers are arrays parallel to the component id.
-        if isinstance(section, list):
-            try:
-                index = int(key.split(":")[1])
-            except (IndexError, ValueError):
-                return None
-            section = section[index] if 0 <= index < len(section) else None
-
-        return section if isinstance(section, dict) else None
 
     def _generation_mismatch(
         self,

--- a/packages/core/src/core/use_cases/restore_strategies/__init__.py
+++ b/packages/core/src/core/use_cases/restore_strategies/__init__.py
@@ -12,10 +12,6 @@ from core.domain.entities.device_backup import DeviceBackup
 from core.domain.entities.device_status import DeviceStatus
 from core.domain.value_objects.restore_result import ComponentRestoreResult
 
-# The raw Gen1 /settings entry captured alongside the mapped components. It is the
-# data source a Gen1 restore replays, never a restore target itself.
-LEGACY_SETTINGS_KEY = "legacy_settings"
-
 
 @dataclass
 class PrepareOutcome:

--- a/packages/core/src/core/use_cases/restore_strategies/__init__.py
+++ b/packages/core/src/core/use_cases/restore_strategies/__init__.py
@@ -1,0 +1,53 @@
+"""Per-generation restore strategies.
+
+``RestoreDeviceConfig`` owns orchestration (selection, ordering, identity,
+aggregation); everything a generation does differently on the wire lives behind
+``ComponentRestoreStrategy``.
+"""
+
+from dataclasses import dataclass, field
+from typing import Any, Protocol
+
+from core.domain.entities.device_backup import DeviceBackup
+from core.domain.entities.device_status import DeviceStatus
+from core.domain.value_objects.restore_result import ComponentRestoreResult
+
+# The raw Gen1 /settings entry captured alongside the mapped components. It is the
+# data source a Gen1 restore replays, never a restore target itself.
+LEGACY_SETTINGS_KEY = "legacy_settings"
+
+
+@dataclass
+class PrepareOutcome:
+    """Result of a strategy's pre-restore phase.
+
+    ``status`` is the device status to restore against (Gen1 re-reads it after
+    a mode change). ``preliminary`` carries component results produced before
+    the component loop (the Gen1 mode entry); a failed, non-skipped preliminary
+    result aborts the restore with exactly those results. ``abort_reason`` is
+    set when the snapshot cannot be restored at all (e.g. it lacks raw Gen1
+    settings): the restore reports every selected component as skipped for that
+    reason.
+    """
+
+    status: DeviceStatus
+    preliminary: list[ComponentRestoreResult] = field(default_factory=list)
+    abort_reason: str | None = None
+
+
+class ComponentRestoreStrategy(Protocol):
+    """One device generation's side of a restore."""
+
+    async def prepare(
+        self, device_ip: str, backup: DeviceBackup, status: DeviceStatus
+    ) -> PrepareOutcome: ...
+
+    async def restore_component(
+        self,
+        device_ip: str,
+        key: str,
+        entry: dict[str, Any],
+        present_keys: set[str],
+    ) -> ComponentRestoreResult: ...
+
+    async def reboot(self, device_ip: str) -> None: ...

--- a/packages/core/src/core/use_cases/restore_strategies/gen1.py
+++ b/packages/core/src/core/use_cases/restore_strategies/gen1.py
@@ -1,0 +1,219 @@
+"""Restore strategy for Gen1 (legacy HTTP) devices.
+
+Gen1 restores replay the raw ``/settings`` captured at backup time; the mapped
+per-component configs are Gen2-shaped and not writable as-is.
+"""
+
+import asyncio
+from typing import Any
+
+from core.domain.entities.device_backup import DeviceBackup
+from core.domain.entities.device_status import DeviceStatus
+from core.domain.services.gen1_settings_translation import (
+    restorable_params,
+    wifi_subresources,
+)
+from core.domain.value_objects.restore_result import ComponentRestoreResult
+from core.gateways.device import DeviceGateway
+from core.use_cases.restore_strategies import LEGACY_SETTINGS_KEY, PrepareOutcome
+
+
+class Gen1RestoreStrategy:
+    """Replay a raw Gen1 /settings snapshot over the legacy HTTP endpoints.
+
+    Stateful per restore run: ``prepare`` loads the raw settings the component
+    loop replays, so one instance serves exactly one restore.
+    """
+
+    def __init__(
+        self,
+        device_gateway: DeviceGateway,
+        *,
+        mode_change_timeout: float = 60.0,
+        mode_change_poll_interval: float = 2.0,
+    ):
+        self._device_gateway = device_gateway
+        self._mode_change_timeout = mode_change_timeout
+        self._mode_change_poll_interval = mode_change_poll_interval
+        self._settings: dict[str, Any] = {}
+
+    async def prepare(
+        self, device_ip: str, backup: DeviceBackup, status: DeviceStatus
+    ) -> PrepareOutcome:
+        settings = self._legacy_settings(backup)
+        if settings is None:
+            return PrepareOutcome(
+                status=status, abort_reason="snapshot lacks raw Gen1 settings"
+            )
+        self._settings = settings
+
+        mode_result, status = await self._sync_mode(device_ip, settings, status)
+        return PrepareOutcome(
+            status=status,
+            preliminary=[mode_result] if mode_result is not None else [],
+        )
+
+    async def restore_component(
+        self,
+        device_ip: str,
+        key: str,
+        entry: dict[str, Any],
+        present_keys: set[str],
+    ) -> ComponentRestoreResult:
+        ctype = entry.get("type")
+
+        if key not in present_keys:
+            return ComponentRestoreResult(
+                key=key,
+                action="Legacy.SetConfig",
+                success=False,
+                skipped=True,
+                skipped_reason="component not present on target device",
+            )
+
+        if ctype == "wifi":
+            return await self._restore_wifi(device_ip, key)
+
+        params = restorable_params(key, ctype, self._settings)
+        if params is None:
+            return ComponentRestoreResult(
+                key=key,
+                action="Legacy.SetConfig",
+                success=False,
+                skipped=True,
+                skipped_reason="no Gen1 settings endpoint for this component",
+            )
+        if not params:
+            return ComponentRestoreResult(
+                key=key,
+                action="Legacy.SetConfig",
+                success=False,
+                skipped=True,
+                skipped_reason="no restorable settings captured in backup",
+            )
+
+        result = await self._device_gateway.execute_component_action(
+            device_ip, key, "Legacy.SetConfig", params
+        )
+        return ComponentRestoreResult(
+            key=key,
+            action="Legacy.SetConfig",
+            success=result.success,
+            error=result.error if not result.success else None,
+        )
+
+    async def reboot(self, device_ip: str) -> None:
+        await self._device_gateway.execute_component_action(
+            device_ip, "sys", "Legacy.Reboot", {}
+        )
+
+    def _legacy_settings(self, backup: DeviceBackup) -> dict[str, Any] | None:
+        components: dict[str, Any] = backup.snapshot.get("components", {})
+        entry = components.get(LEGACY_SETTINGS_KEY)
+        if not isinstance(entry, dict) or not entry.get("success"):
+            return None
+        settings = entry.get("config")
+        return settings if isinstance(settings, dict) else None
+
+    async def _restore_wifi(self, device_ip: str, key: str) -> ComponentRestoreResult:
+        """Replay every captured Gen1 WiFi resource behind the "wifi" component."""
+        subresources = wifi_subresources(self._settings)
+        errors: list[str] = []
+        for subtype, params in subresources:
+            result = await self._device_gateway.execute_component_action(
+                device_ip, subtype, "Legacy.SetConfig", params
+            )
+            if not result.success:
+                errors.append(f"{subtype}: {result.error or 'failed'}")
+
+        if not subresources:
+            return ComponentRestoreResult(
+                key=key,
+                action="Legacy.SetConfig",
+                success=False,
+                skipped=True,
+                skipped_reason="no restorable settings captured in backup",
+            )
+        return ComponentRestoreResult(
+            key=key,
+            action="Legacy.SetConfig",
+            success=not errors,
+            error="; ".join(errors) if errors else None,
+        )
+
+    async def _sync_mode(
+        self,
+        device_ip: str,
+        settings: dict[str, Any],
+        status: DeviceStatus,
+    ) -> tuple[ComponentRestoreResult | None, DeviceStatus]:
+        """Align the target's relay/roller mode with the backup before restoring.
+
+        Gen1 applies ``mode`` with a reboot and re-enumerates its components
+        afterwards, so it cannot ride along in the sys param batch: it is sent
+        alone first, and the device status is re-read once the target is back.
+        Returns the pre-phase result (``None`` when nothing needed doing) and
+        the status to restore against.
+        """
+        backup_mode = settings.get("mode")
+        if not isinstance(backup_mode, str) or not backup_mode:
+            return None, status
+
+        target_settings = await self._device_gateway.get_legacy_settings(device_ip)
+        target_mode = (
+            target_settings.get("mode") if isinstance(target_settings, dict) else None
+        )
+        if not isinstance(target_mode, str) or not target_mode:
+            return (
+                ComponentRestoreResult(
+                    key="mode",
+                    action="Legacy.SetConfig",
+                    success=False,
+                    skipped=True,
+                    skipped_reason="could not read the target device mode",
+                ),
+                status,
+            )
+        if target_mode == backup_mode:
+            return None, status
+
+        result = await self._device_gateway.execute_component_action(
+            device_ip, "sys", "Legacy.SetConfig", {"mode": backup_mode}
+        )
+        if not result.success:
+            return (
+                ComponentRestoreResult(
+                    key="mode",
+                    action="Legacy.SetConfig",
+                    success=False,
+                    error=result.error or "mode change failed",
+                ),
+                status,
+            )
+
+        new_status = await self._wait_for_device(device_ip)
+        if new_status is None:
+            return (
+                ComponentRestoreResult(
+                    key="mode",
+                    action="Legacy.SetConfig",
+                    success=False,
+                    error="device did not come back after the mode change",
+                ),
+                status,
+            )
+        return (
+            ComponentRestoreResult(key="mode", action="Legacy.SetConfig", success=True),
+            new_status,
+        )
+
+    async def _wait_for_device(self, device_ip: str) -> DeviceStatus | None:
+        loop = asyncio.get_running_loop()
+        deadline = loop.time() + self._mode_change_timeout
+        while True:
+            status = await self._device_gateway.get_device_status(device_ip)
+            if status is not None:
+                return status
+            if loop.time() >= deadline:
+                return None
+            await asyncio.sleep(self._mode_change_poll_interval)

--- a/packages/core/src/core/use_cases/restore_strategies/gen1.py
+++ b/packages/core/src/core/use_cases/restore_strategies/gen1.py
@@ -7,7 +7,7 @@ per-component configs are Gen2-shaped and not writable as-is.
 import asyncio
 from typing import Any
 
-from core.domain.entities.device_backup import DeviceBackup
+from core.domain.entities.device_backup import LEGACY_SETTINGS_KEY, DeviceBackup
 from core.domain.entities.device_status import DeviceStatus
 from core.domain.services.gen1_settings_translation import (
     restorable_params,
@@ -15,7 +15,7 @@ from core.domain.services.gen1_settings_translation import (
 )
 from core.domain.value_objects.restore_result import ComponentRestoreResult
 from core.gateways.device import DeviceGateway
-from core.use_cases.restore_strategies import LEGACY_SETTINGS_KEY, PrepareOutcome
+from core.use_cases.restore_strategies import PrepareOutcome
 
 
 class Gen1RestoreStrategy:

--- a/packages/core/src/core/use_cases/restore_strategies/gen2.py
+++ b/packages/core/src/core/use_cases/restore_strategies/gen2.py
@@ -1,0 +1,188 @@
+"""Restore strategy for Gen2+ (RPC) devices."""
+
+from copy import deepcopy
+from typing import Any
+
+from core.domain.entities.device_backup import DeviceBackup
+from core.domain.entities.device_status import DeviceStatus
+from core.domain.value_objects.restore_result import ComponentRestoreResult
+from core.gateways.device import DeviceGateway
+from core.use_cases.restore_strategies import PrepareOutcome
+
+# The "schedules" pseudo-component produced by export_bulk_config.
+SCHEDULES_KEY = "schedules"
+
+# Read-only keys that GetConfig echoes but SetConfig rejects, by component type.
+# Each entry is a (parent, child) path popped from the config dict. Top-level
+# "id" and "cfg_rev" are always stripped. Table-driven so it is easy to extend.
+READ_ONLY_BY_TYPE: dict[str, list[tuple[str, str]]] = {
+    "sys": [("device", "mac")],
+    "wifi": [("ap", "is_open")],
+}
+
+
+class Gen2RestoreStrategy:
+    """Apply captured component configs over the Gen2+ RPC surface."""
+
+    def __init__(self, device_gateway: DeviceGateway):
+        self._device_gateway = device_gateway
+
+    async def prepare(
+        self, device_ip: str, backup: DeviceBackup, status: DeviceStatus
+    ) -> PrepareOutcome:
+        return PrepareOutcome(status=status)
+
+    async def restore_component(
+        self,
+        device_ip: str,
+        key: str,
+        entry: dict[str, Any],
+        present_keys: set[str],
+    ) -> ComponentRestoreResult:
+        ctype = entry.get("type")
+
+        if key == SCHEDULES_KEY:
+            return await self._restore_schedules(device_ip, key, entry)
+        if ctype == "script":
+            return await self._restore_script(device_ip, key, entry, present_keys)
+
+        if not entry.get("success") or entry.get("config") is None:
+            return ComponentRestoreResult(
+                key=key,
+                action="SetConfig",
+                success=False,
+                skipped=True,
+                skipped_reason="no config captured in backup",
+            )
+        if key not in present_keys:
+            return ComponentRestoreResult(
+                key=key,
+                action="SetConfig",
+                success=False,
+                skipped=True,
+                skipped_reason="component not present on target device",
+            )
+
+        config = self._strip_readonly(ctype, deepcopy(entry["config"]))
+        result = await self._device_gateway.execute_component_action(
+            device_ip, key, "SetConfig", {"config": config}
+        )
+        return ComponentRestoreResult(
+            key=key,
+            action="SetConfig",
+            success=result.success,
+            error=result.error if not result.success else None,
+        )
+
+    async def reboot(self, device_ip: str) -> None:
+        await self._device_gateway.execute_component_action(
+            device_ip, "shelly", "Reboot", {}
+        )
+
+    def _strip_readonly(
+        self, ctype: str | None, config: dict[str, Any]
+    ) -> dict[str, Any]:
+        config.pop("id", None)
+        config.pop("cfg_rev", None)
+        for parent, child in READ_ONLY_BY_TYPE.get(ctype or "", []):
+            section = config.get(parent)
+            if isinstance(section, dict):
+                section.pop(child, None)
+        return config
+
+    async def _restore_script(
+        self,
+        device_ip: str,
+        key: str,
+        entry: dict[str, Any],
+        present_keys: set[str],
+    ) -> ComponentRestoreResult:
+        code_block = entry.get("code") or {}
+        code = code_block.get("data") if isinstance(code_block, dict) else None
+        # Presence + type, not truthiness: an empty script body ("") is valid.
+        if not isinstance(code, str):
+            return ComponentRestoreResult(
+                key=key,
+                action="PutCode",
+                success=False,
+                skipped=True,
+                skipped_reason="no script code captured in backup",
+            )
+        if key not in present_keys:
+            return ComponentRestoreResult(
+                key=key,
+                action="PutCode",
+                success=False,
+                skipped=True,
+                skipped_reason="script not present on target device",
+            )
+        try:
+            script_id = int(key.split(":")[1])
+        except (ValueError, IndexError):
+            return ComponentRestoreResult(
+                key=key,
+                action="PutCode",
+                success=False,
+                skipped=True,
+                skipped_reason="could not resolve script id",
+            )
+
+        result = await self._device_gateway.execute_component_action(
+            device_ip, key, "PutCode", {"id": script_id, "code": code, "append": False}
+        )
+        return ComponentRestoreResult(
+            key=key,
+            action="PutCode",
+            success=result.success,
+            error=result.error if not result.success else None,
+        )
+
+    async def _restore_schedules(
+        self, device_ip: str, key: str, entry: dict[str, Any]
+    ) -> ComponentRestoreResult:
+        # Gate on whether the schedules component was *captured*, not on job
+        # count: a device with zero schedules is captured as {"jobs": []}, and
+        # restoring it must still clear the target's schedules.
+        if not entry.get("success") or entry.get("config") is None:
+            return ComponentRestoreResult(
+                key=key,
+                action="Schedule.Replace",
+                success=False,
+                skipped=True,
+                skipped_reason="no schedules captured in backup",
+            )
+
+        config = entry["config"]
+        jobs = config.get("jobs", []) if isinstance(config, dict) else []
+
+        # Restore must reproduce the captured schedule set, not merge into the
+        # device's existing jobs. Always clear the target first so re-runs are
+        # idempotent and stale/duplicate jobs don't accumulate (including when
+        # the captured set is empty). If the clear fails, abort: creating on top
+        # of un-cleared jobs would merge/duplicate instead of replace.
+        delete_result = await self._device_gateway.execute_component_action(
+            device_ip, "schedule", "DeleteAll", {}
+        )
+        if not delete_result.success:
+            return ComponentRestoreResult(
+                key=key,
+                action="Schedule.Replace",
+                success=False,
+                error=f"DeleteAll failed: {delete_result.error or 'unknown error'}",
+            )
+
+        errors: list[str] = []
+        for job in jobs:
+            params = {k: v for k, v in job.items() if k != "id"}
+            result = await self._device_gateway.execute_component_action(
+                device_ip, "schedule", "Create", params
+            )
+            if not result.success:
+                errors.append(result.error or "Schedule.Create failed")
+
+        return ComponentRestoreResult(
+            key=key,
+            action="Schedule.Replace",
+            success=not errors,
+            error="; ".join(errors) if errors else None,
+        )

--- a/packages/core/tests/unit/domain/entities/test_device_status.py
+++ b/packages/core/tests/unit/domain/entities/test_device_status.py
@@ -77,6 +77,31 @@ class TestDeviceStatusComponents:
         zigbee_comp = device_status.get_component_by_key("zigbee")
         assert zigbee_comp is None
 
+    def test_it_extends_derived_actions_with_the_ones_a_gateway_declares(self):
+        response_data = {
+            "components": [
+                {
+                    "key": "switch:0",
+                    "status": {"output": True},
+                    "config": {"name": "Test Switch"},
+                    "available_actions": ["Legacy.Toggle", "Legacy.TurnOn"],
+                    "attrs": {},
+                }
+            ],
+        }
+
+        device_status = DeviceStatus.from_raw_response(
+            "192.168.1.100", response_data, available_methods=["Switch.Toggle"]
+        )
+
+        switch_comp = device_status.get_component_by_key("switch:0")
+        assert switch_comp is not None
+        assert switch_comp.available_actions == [
+            "Switch.Toggle",
+            "Legacy.Toggle",
+            "Legacy.TurnOn",
+        ]
+
     def test_it_gets_zigbee_info_method(self):
         zigbee_comp = ZigbeeComponent(
             key="zigbee", component_type="zigbee", network_state="joined", enabled=True

--- a/packages/core/tests/unit/domain/services/test_gen1_settings_translation.py
+++ b/packages/core/tests/unit/domain/services/test_gen1_settings_translation.py
@@ -1,0 +1,291 @@
+"""Wire-param pins for the Gen1 /settings translation.
+
+These tests pin the literal params a Gen1 restore sends per component, so any
+change to the settable-param tables, renames, or section layout shows up as a
+failing pin rather than a silent wire change.
+"""
+
+from core.domain.services.gen1_settings_translation import (
+    restorable_params,
+    wifi_subresources,
+)
+
+
+def _gen1_settings():
+    """A raw Gen1 /settings payload, shaped as the device echoes it.
+
+    Field names follow https://shelly-api-docs.shelly.cloud/gen1/; note the
+    read-only echoes (relay ison/has_timer, roller state/power) and the fields
+    GET names differently from their setter (wifi gw/mask, roller button_type,
+    nested sntp.server/coiot/ap_roaming). Deliberately cross-model: relay power
+    (Shelly 1), rollers/favorites (2.5), inputs (i3), led_power_disable (PlugS).
+    """
+    return {
+        "device": {"type": "SHSW-1", "mac": "AABBCCDDEEFF"},
+        "fw": "20230913-112003/v1.14.0",
+        "name": "Hallway",
+        "mode": "relay",
+        "timezone": "Europe/Lisbon",
+        "tzautodetect": False,
+        "tz_utc_offset": 3600,
+        "tz_dst": False,
+        "tz_dst_auto": True,
+        "lat": 38.7223,
+        "lng": -9.1393,
+        "discoverable": True,
+        "led_status_disable": False,
+        "led_power_disable": False,
+        "max_power": 3500,
+        "longpush_time": 1000,
+        "factory_reset_from_switch": True,
+        "wifirecovery_reboot_enabled": True,
+        "debug_enable": False,
+        "allow_cross_origin": False,
+        "supply_voltage": 0,
+        "power_correction": 1,
+        "favorites_enabled": True,
+        "coiot": {"enabled": True, "update_period": 15, "peer": "10.0.0.2:5683"},
+        "ap_roaming": {"enabled": True, "threshold": -70},
+        "longpush_duration_ms": {"min": 800, "max": 3000},
+        "multipush_time_between_pushes_ms": {"max": 500},
+        "sntp": {"server": "pool.ntp.org", "enabled": True},
+        "login": {"enabled": True, "username": "admin"},
+        "inputs": [{"name": "Left button", "btn_type": "momentary", "btn_reverse": 0}],
+        "relays": [
+            {
+                "name": "Hallway light",
+                "appliance_type": "General",
+                "ison": True,
+                "has_timer": False,
+                "power": 12.5,
+                "default_state": "last",
+                "btn_type": "momentary",
+                "btn_reverse": 0,
+                "auto_on": 0,
+                "auto_off": 30.5,
+                "schedule": True,
+                "schedule_rules": ["0700-012345-on", "2200-012345-off"],
+                "max_power": 0,
+            }
+        ],
+        "rollers": [
+            {
+                "maxtime": 20,
+                "maxtime_open": 25,
+                "maxtime_close": 24,
+                "default_state": "stop",
+                "swap": False,
+                "input_mode": "openclose",
+                "button_type": "toggle",
+                "btn_reverse": 0,
+                "state": "stop",
+                "power": 0,
+                "is_valid": True,
+                "safety_switch": False,
+                "positioning": True,
+                "schedule_rules": [],
+            }
+        ],
+        "wifi_sta": {
+            "enabled": True,
+            "ssid": "Castle",
+            "ipv4_method": "static",
+            "ip": "192.168.1.100",
+            "gw": "192.168.1.1",
+            "mask": "255.255.255.0",
+            "dns": "8.8.8.8",
+        },
+        "wifi_sta1": {
+            "enabled": False,
+            "ssid": "CastleFallback",
+            "ipv4_method": "dhcp",
+            "ip": None,
+            "gw": None,
+            "mask": None,
+            "dns": None,
+        },
+        "wifi_ap": {"enabled": False, "ssid": "shelly1-DDEEFF", "key": "appass"},
+        "mqtt": {
+            "enable": True,
+            "server": "10.0.0.1:1883",
+            "user": "shelly",
+            "id": "shelly1-DDEEFF",
+            "clean_session": True,
+            "retain": False,
+            "keep_alive": 60,
+            "max_qos": 0,
+            "update_period": 30,
+            "reconnect_timeout_min": 2.0,
+            "reconnect_timeout_max": 60.0,
+        },
+        "cloud": {"enabled": True, "connected": True},
+    }
+
+
+class TestRestorableParams:
+    def test_it_extracts_the_documented_relay_settings(self):
+        # Exactly the documented settable params of /settings/relay/{index}.
+        assert restorable_params("switch:0", "switch", _gen1_settings()) == {
+            "name": "Hallway light",
+            "appliance_type": "General",
+            "default_state": "last",
+            "btn_type": "momentary",
+            "btn_reverse": 0,
+            "auto_on": 0,
+            "auto_off": 30.5,
+            "schedule": True,
+            "schedule_rules": ["0700-012345-on", "2200-012345-off"],
+            "max_power": 0,
+            # The Shelly 1/1L user power constant: settable, unlike the live
+            # readings under "meters".
+            "power": 12.5,
+        }
+
+    def test_it_drops_readonly_relay_fields(self):
+        params = restorable_params("switch:0", "switch", _gen1_settings())
+
+        # Echoed by GET /settings but rejected/meaningless as settings.
+        for read_only in ("ison", "has_timer"):
+            assert read_only not in params
+
+    def test_it_renames_wifi_fields_to_their_setter_names(self):
+        # GET /settings echoes gw/mask; /settings/sta only accepts gateway/netmask.
+        assert restorable_params("wifi", "wifi", _gen1_settings()) == {
+            "enabled": True,
+            "ssid": "Castle",
+            "ipv4_method": "static",
+            "ip": "192.168.1.100",
+            "gateway": "192.168.1.1",
+            "netmask": "255.255.255.0",
+            "dns": "8.8.8.8",
+        }
+
+    def test_it_renames_the_roller_button_type_to_its_setter_name(self):
+        params = restorable_params("cover:0", "cover", _gen1_settings())
+
+        # GET /settings echoes button_type; /settings/roller/{i} accepts btn_type.
+        assert params["btn_type"] == "toggle"
+        assert "button_type" not in params
+        assert params["maxtime_open"] == 25
+        assert params["schedule_rules"] == []
+        for read_only in ("state", "power", "is_valid", "safety_switch"):
+            assert read_only not in params
+
+    def test_it_flattens_the_nested_sntp_server_for_sys(self):
+        # Nested echoes (sntp.server, coiot.*, ap_roaming.*, the i3 timing
+        # blocks) flatten to the names their setters accept.
+        assert restorable_params("sys", "sys", _gen1_settings()) == {
+            "name": "Hallway",
+            "timezone": "Europe/Lisbon",
+            "tzautodetect": False,
+            "tz_utc_offset": 3600,
+            "tz_dst": False,
+            "tz_dst_auto": True,
+            "lat": 38.7223,
+            "lng": -9.1393,
+            "discoverable": True,
+            "led_status_disable": False,
+            "led_power_disable": False,
+            "max_power": 3500,
+            "longpush_time": 1000,
+            "factory_reset_from_switch": True,
+            "wifirecovery_reboot_enabled": True,
+            "debug_enable": False,
+            "allow_cross_origin": False,
+            "supply_voltage": 0,
+            "power_correction": 1,
+            "favorites_enabled": True,
+            "coiot_enable": True,
+            "coiot_update_period": 15,
+            "coiot_peer": "10.0.0.2:5683",
+            "ap_roaming_enabled": True,
+            "ap_roaming_threshold": -70,
+            "longpush_duration_ms_min": 800,
+            "longpush_duration_ms_max": 3000,
+            "multipush_time_between_pushes_ms_max": 500,
+            "sntp_server": "pool.ntp.org",
+        }
+
+    def test_it_never_includes_mode_in_the_sys_params(self):
+        # A mode change reboots the device, so it only ever travels through the
+        # restore's dedicated pre-phase, never the sys param batch.
+        assert "mode" not in restorable_params("sys", "sys", _gen1_settings())
+
+    def test_it_prefixes_mqtt_params(self):
+        # Gen1 has no /settings/mqtt: the settings are mqtt_*-prefixed on /settings.
+        assert restorable_params("mqtt", "mqtt", _gen1_settings()) == {
+            "mqtt_enable": True,
+            "mqtt_server": "10.0.0.1:1883",
+            "mqtt_user": "shelly",
+            "mqtt_id": "shelly1-DDEEFF",
+            "mqtt_clean_session": True,
+            "mqtt_retain": False,
+            "mqtt_keep_alive": 60,
+            "mqtt_max_qos": 0,
+            "mqtt_update_period": 30,
+            "mqtt_reconnect_timeout_min": 2.0,
+            "mqtt_reconnect_timeout_max": 60.0,
+        }
+
+    def test_it_extracts_input_settings(self):
+        # i3/Button1 expose /settings/input/{i}; the snapshot echoes its params.
+        assert restorable_params("input:0", "input", _gen1_settings()) == {
+            "name": "Left button",
+            "btn_type": "momentary",
+            "btn_reverse": 0,
+        }
+
+    def test_it_returns_none_for_a_type_without_a_settings_endpoint(self):
+        assert restorable_params("script:0", "script", _gen1_settings()) is None
+
+    def test_it_returns_empty_when_the_snapshot_lacks_the_section(self):
+        # Relay-bearing models never echo an "inputs" settings section: their
+        # input config lives on, and restores with, the owning relay.
+        settings = _gen1_settings()
+        settings.pop("inputs")
+
+        assert restorable_params("input:0", "input", settings) == {}
+
+    def test_it_returns_empty_when_the_component_index_is_not_captured(self):
+        settings = _gen1_settings()
+        settings["relays"] = []
+
+        assert restorable_params("switch:0", "switch", settings) == {}
+
+
+class TestWifiSubresources:
+    def test_it_replays_every_captured_wifi_resource_with_the_ap_last(self):
+        # The AP goes last: enabling one WiFi mode disables the other on the
+        # device, so the resource enabled in the backup must win.
+        assert wifi_subresources(_gen1_settings()) == [
+            (
+                "wifi",
+                {
+                    "enabled": True,
+                    "ssid": "Castle",
+                    "ipv4_method": "static",
+                    "ip": "192.168.1.100",
+                    "gateway": "192.168.1.1",
+                    "netmask": "255.255.255.0",
+                    "dns": "8.8.8.8",
+                },
+            ),
+            (
+                "wifi_sta1",
+                {
+                    "enabled": False,
+                    "ssid": "CastleFallback",
+                    "ipv4_method": "dhcp",
+                },
+            ),
+            # The AP SSID is device-fixed and never sent; the AP key, unlike
+            # the STA one, is echoed by GET /settings and round-trips.
+            ("wifi_ap", {"enabled": False, "key": "appass"}),
+        ]
+
+    def test_it_omits_resources_the_snapshot_lacks(self):
+        settings = _gen1_settings()
+        settings.pop("wifi_sta1")
+        settings.pop("wifi_ap")
+
+        assert [subtype for subtype, _ in wifi_subresources(settings)] == ["wifi"]

--- a/packages/core/tests/unit/domain/value_objects/test_generation.py
+++ b/packages/core/tests/unit/domain/value_objects/test_generation.py
@@ -1,0 +1,34 @@
+from core.domain.value_objects.generation import Generation
+
+
+class TestFromDeviceGen:
+    def test_it_maps_gen_1_to_gen1(self):
+        assert Generation.from_device_gen(1) is Generation.GEN1
+
+    def test_it_maps_the_rpc_family_to_gen2(self):
+        assert Generation.from_device_gen(2) is Generation.GEN2
+        assert Generation.from_device_gen(3) is Generation.GEN2
+        assert Generation.from_device_gen(4) is Generation.GEN2
+
+    def test_it_returns_none_when_the_generation_is_unknown(self):
+        # A device status without a gen means undetermined, never Gen1.
+        assert Generation.from_device_gen(None) is None
+
+
+class TestFromLabel:
+    def test_it_parses_the_stored_backup_labels(self):
+        assert Generation.from_label("gen1") is Generation.GEN1
+        assert Generation.from_label("gen2") is Generation.GEN2
+
+    def test_it_returns_none_for_an_unknown_label(self):
+        assert Generation.from_label("gen3") is None
+
+
+class TestFromShellyPayload:
+    def test_it_treats_a_missing_gen_field_as_gen1(self):
+        # Gen1 firmware omits gen from /shelly and identifies via type.
+        assert Generation.from_shelly_payload({"type": "SHSW-1"}) is Generation.GEN1
+
+    def test_it_maps_a_present_gen_field_to_gen2(self):
+        assert Generation.from_shelly_payload({"gen": 2}) is Generation.GEN2
+        assert Generation.from_shelly_payload({"gen": 3}) is Generation.GEN2

--- a/packages/core/tests/unit/gateways/device/test_legacy_component_mapper.py
+++ b/packages/core/tests/unit/gateways/device/test_legacy_component_mapper.py
@@ -20,6 +20,22 @@ def _switch_config(mapper, relay_settings):
     return switch["config"]
 
 
+class TestLegacyActionDeclaration:
+    def test_it_declares_the_relay_actions_on_the_component_payload(self, mapper):
+        components = mapper.map(
+            {"mac": "AABBCCDDEEFF", "type": "SHSW-1"},
+            {"relays": [{"ison": False}]},
+            {"relays": [{}]},
+        )
+
+        switch = next(c for c in components if c["key"] == "switch:0")
+        assert switch["available_actions"] == [
+            "Legacy.Toggle",
+            "Legacy.TurnOn",
+            "Legacy.TurnOff",
+        ]
+
+
 class TestLegacyAutoTimerMapping:
     @pytest.mark.parametrize(
         "value, expected_flag, expected_delay",

--- a/packages/core/tests/unit/use_cases/test_restore_device_config.py
+++ b/packages/core/tests/unit/use_cases/test_restore_device_config.py
@@ -576,72 +576,13 @@ class TestRestoreGen1DeviceConfig:
             if call.args[2] == "Legacy.SetConfig"
         }
 
-    async def test_it_restores_relay_settings_from_the_raw_settings(
-        self, use_case, mock_device_gateway
-    ):
-        result = await use_case.restore(1, IP, component_keys=["switch:0"])
-
-        assert result.success is True
-        # Exactly the documented settable params of /settings/relay/{index},
-        # sourced from the raw snapshot rather than the Gen2-shaped mapped config.
-        assert self._sent(mock_device_gateway)["switch:0"] == {
-            "name": "Hallway light",
-            "appliance_type": "General",
-            "default_state": "last",
-            "btn_type": "momentary",
-            "btn_reverse": 0,
-            "auto_on": 0,
-            "auto_off": 30.5,
-            "schedule": True,
-            "schedule_rules": ["0700-012345-on", "2200-012345-off"],
-            "max_power": 0,
-            # The Shelly 1/1L user power constant: settable, unlike the live
-            # readings under "meters".
-            "power": 12.5,
-        }
-
-    async def test_it_drops_readonly_relay_fields(self, use_case, mock_device_gateway):
-        await use_case.restore(1, IP, component_keys=["switch:0"])
-
-        sent = self._sent(mock_device_gateway)["switch:0"]
-        # Echoed by GET /settings but rejected/meaningless as settings.
-        for read_only in ("ison", "has_timer"):
-            assert read_only not in sent
-
-    async def test_it_renames_wifi_fields_to_their_setter_names(
-        self, use_case, mock_device_gateway
-    ):
-        await use_case.restore(1, IP, component_keys=["wifi"])
-
-        # GET /settings echoes gw/mask; /settings/sta only accepts gateway/netmask.
-        assert self._sent(mock_device_gateway)["wifi"] == {
-            "enabled": True,
-            "ssid": "Castle",
-            "ipv4_method": "static",
-            "ip": "192.168.1.100",
-            "gateway": "192.168.1.1",
-            "netmask": "255.255.255.0",
-            "dns": "8.8.8.8",
-        }
-
     async def test_it_restores_the_fallback_sta_and_ap_with_the_primary(
         self, use_case, mock_device_gateway
     ):
         result = await use_case.restore(1, IP, component_keys=["wifi"])
 
         sent = self._sent(mock_device_gateway)
-        assert sent["wifi_sta1"] == {
-            "enabled": False,
-            "ssid": "CastleFallback",
-            "ipv4_method": "dhcp",
-        }
-        # The AP SSID is device-fixed and never sent; the AP key, unlike the
-        # STA one, is echoed by GET /settings and round-trips.
-        assert sent["wifi_ap"] == {"enabled": False, "key": "appass"}
-        # The AP goes last: enabling one WiFi mode disables the other on the
-        # device, so the resource enabled in the backup must win.
         assert list(sent) == ["wifi", "wifi_sta1", "wifi_ap"]
-        # One component result for the single "wifi" component.
         assert [c.key for c in result.components] == ["wifi"]
         assert result.success is True
 
@@ -682,86 +623,6 @@ class TestRestoreGen1DeviceConfig:
         entry = next(c for c in result.components if c.key == "wifi")
         assert entry.success is False
         assert entry.error == "wifi_ap: Bad Request"
-
-    async def test_it_renames_the_roller_button_type_to_its_setter_name(
-        self, use_case, mock_device_gateway
-    ):
-        await use_case.restore(1, IP, component_keys=["cover:0"])
-
-        sent = self._sent(mock_device_gateway)["cover:0"]
-        # GET /settings echoes button_type; /settings/roller/{i} accepts btn_type.
-        assert sent["btn_type"] == "toggle"
-        assert "button_type" not in sent
-        assert sent["maxtime_open"] == 25
-        assert sent["schedule_rules"] == []
-        for read_only in ("state", "power", "is_valid", "safety_switch"):
-            assert read_only not in sent
-
-    async def test_it_flattens_the_nested_sntp_server_for_sys(
-        self, use_case, mock_device_gateway
-    ):
-        await use_case.restore(1, IP, component_keys=["sys"])
-
-        # Nested echoes (sntp.server, coiot.*, ap_roaming.*, the i3 timing
-        # blocks) flatten to the names their setters accept.
-        assert self._sent(mock_device_gateway)["sys"] == {
-            "name": "Hallway",
-            "timezone": "Europe/Lisbon",
-            "tzautodetect": False,
-            "tz_utc_offset": 3600,
-            "tz_dst": False,
-            "tz_dst_auto": True,
-            "lat": 38.7223,
-            "lng": -9.1393,
-            "discoverable": True,
-            "led_status_disable": False,
-            "led_power_disable": False,
-            "max_power": 3500,
-            "longpush_time": 1000,
-            "factory_reset_from_switch": True,
-            "wifirecovery_reboot_enabled": True,
-            "debug_enable": False,
-            "allow_cross_origin": False,
-            "supply_voltage": 0,
-            "power_correction": 1,
-            "favorites_enabled": True,
-            "coiot_enable": True,
-            "coiot_update_period": 15,
-            "coiot_peer": "10.0.0.2:5683",
-            "ap_roaming_enabled": True,
-            "ap_roaming_threshold": -70,
-            "longpush_duration_ms_min": 800,
-            "longpush_duration_ms_max": 3000,
-            "multipush_time_between_pushes_ms_max": 500,
-            "sntp_server": "pool.ntp.org",
-        }
-
-    async def test_it_never_sends_mode_in_the_sys_batch(
-        self, use_case, mock_device_gateway
-    ):
-        await use_case.restore(1, IP, component_keys=["sys"])
-
-        # A mode change reboots the device, so it only ever travels through the
-        # dedicated pre-phase, never the sys param batch.
-        assert "mode" not in self._sent(mock_device_gateway)["sys"]
-
-    async def test_it_prefixes_mqtt_params(self, use_case, mock_device_gateway):
-        await use_case.restore(1, IP, component_keys=["mqtt"])
-
-        # Gen1 has no /settings/mqtt: the settings are mqtt_*-prefixed on /settings.
-        assert self._sent(mock_device_gateway)["mqtt"] == {
-            "mqtt_enable": True,
-            "mqtt_server": "10.0.0.1:1883",
-            "mqtt_user": "shelly",
-            "mqtt_id": "shelly1-DDEEFF",
-            "mqtt_clean_session": True,
-            "mqtt_retain": False,
-            "mqtt_keep_alive": 60,
-            "mqtt_max_qos": 0,
-            "mqtt_update_period": 30,
-            "mqtt_reconnect_timeout_min": 2.0,
-            "mqtt_reconnect_timeout_max": 60.0,
-        }
 
     async def test_it_excludes_network_components_by_default(
         self, use_case, mock_device_gateway
@@ -814,19 +675,6 @@ class TestRestoreGen1DeviceConfig:
         entry = next(c for c in result.components if c.key == "legacy_settings")
         assert entry.skipped is True
         assert entry.skipped_reason == "not a restorable component"
-
-    async def test_it_restores_input_settings_via_their_own_endpoint(
-        self, use_case, mock_device_gateway
-    ):
-        result = await use_case.restore(1, IP, component_keys=["input:0"])
-
-        # i3/Button1 expose /settings/input/{i}; the snapshot echoes its params.
-        assert result.success is True
-        assert self._sent(mock_device_gateway)["input:0"] == {
-            "name": "Left button",
-            "btn_type": "momentary",
-            "btn_reverse": 0,
-        }
 
     async def test_it_skips_inputs_when_the_snapshot_has_no_input_settings(
         self, use_case, mock_device_gateway, mock_repository


### PR DESCRIPTION
## Purpose

Cut the generation seam: restore and capture get per-generation strategies, the Gen1 wire knowledge moves to a pure domain service, and the three ad hoc generation representations collapse into one domain value.

## Context

Follow-on refactor to #51 (design doc: the generation-seam plan reviewed after PR #53). restore_device_config.py owned two complete protocols in ~950 lines, the Gen1 wire tables lived inside a use case whose job is orchestration, and generation was reconciled inline in three shapes (device gen int, backup label string, missing /shelly field). The contract is zero behavior change: every existing test passes with only import moves and fixture relocation, and the literal Gen1 wire-param pins now run against the pure translation service with no mocks. Reviewed commit by commit it reads as code moved and names introduced.

## Notes

The legacy mapper now declares component actions as a first-class available_actions list on its payload instead of the private attrs key the domain entity used to reach into; nothing in the repo consumed the old shape. Two independent adversarial reviews (Codex plus a fresh agent) found no behavior drift in any runtime flow.