### PR TITLE
One route to Gen1 and one action envelope

### DIFF
--- a/packages/core/src/core/dependencies/container_base.py
+++ b/packages/core/src/core/dependencies/container_base.py
@@ -106,6 +106,7 @@ class BaseContainer:
             self._device_gateway = ShellyDeviceGateway(
                 rpc_client=self.get_rpc_client(),
                 legacy_gateway=legacy_gateway,
+                auth_state_cache=self.get_auth_state_cache(),
             )
         return self._device_gateway
 

--- a/packages/core/src/core/domain/value_objects/action_envelope.py
+++ b/packages/core/src/core/domain/value_objects/action_envelope.py
@@ -10,7 +10,7 @@ from typing import Any
 
 from pydantic import BaseModel, ConfigDict
 
-from ...domain.value_objects.action_result import ActionResult
+from .action_result import ActionResult
 
 
 class ActionEnvelope(BaseModel):

--- a/packages/core/src/core/gateways/device/action_envelope.py
+++ b/packages/core/src/core/gateways/device/action_envelope.py
@@ -1,0 +1,41 @@
+"""The answer shape of a component action.
+
+Every execute path answers with an ``ActionResult``, whether the action ran,
+was refused before reaching the device, or failed on the wire. Which device and
+which action are being reported is fixed for the whole call, so they are bound
+once here and each exit says only what happened.
+"""
+
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict
+
+from ...domain.value_objects.action_result import ActionResult
+
+
+class ActionEnvelope(BaseModel):
+
+    model_config = ConfigDict(frozen=True)
+
+    device_ip: str
+    action_type: str
+
+    def succeeded(
+        self, message: str, data: dict[str, Any] | None = None
+    ) -> ActionResult:
+        return ActionResult(
+            device_ip=self.device_ip,
+            action_type=self.action_type,
+            success=True,
+            message=message,
+            data=data,
+        )
+
+    def failed(self, message: str, error: str) -> ActionResult:
+        return ActionResult(
+            device_ip=self.device_ip,
+            action_type=self.action_type,
+            success=False,
+            message=message,
+            error=error,
+        )

--- a/packages/core/src/core/gateways/device/legacy_device_gateway.py
+++ b/packages/core/src/core/gateways/device/legacy_device_gateway.py
@@ -130,7 +130,7 @@ class LegacyDeviceGateway:
             mac = device_info.get("mac")
             auth: tuple[str, str] | None = None
 
-            if auth_enabled and mac and self._auth_state_cache:
+            if auth_enabled and mac and self._auth_state_cache is not None:
                 normalized_mac = normalize_mac(mac)
                 self._ip_to_mac[normalize_mac(ip)] = normalized_mac
                 self._auth_state_cache.mark_auth_required(normalized_mac)

--- a/packages/core/src/core/gateways/device/legacy_route.py
+++ b/packages/core/src/core/gateways/device/legacy_route.py
@@ -10,8 +10,8 @@ from typing import Any
 
 from ...domain.entities.device_status import DeviceStatus
 from ...domain.entities.discovered_device import DiscoveredDevice
+from ...domain.value_objects.action_envelope import ActionEnvelope
 from ...domain.value_objects.action_result import ActionResult
-from .action_envelope import ActionEnvelope
 from .legacy_device_gateway import LegacyDeviceGateway
 
 

--- a/packages/core/src/core/gateways/device/legacy_route.py
+++ b/packages/core/src/core/gateways/device/legacy_route.py
@@ -1,0 +1,64 @@
+"""The way to a Gen1 device, whether or not there is one.
+
+``ShellyDeviceGateway`` speaks RPC to Gen2+ devices and the legacy HTTP API to
+Gen1 ones, and is also built with no legacy gateway at all. This is the single
+seam between the two paths: with no legacy gateway behind it, it answers
+"nothing here" rather than asking every caller to check first.
+"""
+
+from typing import Any
+
+from ...domain.entities.device_status import DeviceStatus
+from ...domain.entities.discovered_device import DiscoveredDevice
+from ...domain.value_objects.action_result import ActionResult
+from .action_envelope import ActionEnvelope
+from .legacy_device_gateway import LegacyDeviceGateway
+
+
+class LegacyRoute:
+
+    def __init__(self, gateway: LegacyDeviceGateway | None) -> None:
+        self._gateway = gateway
+
+    async def discover_device(self, ip: str, timeout: float) -> DiscoveredDevice | None:
+        if self._gateway is None:
+            return None
+        return await self._gateway.discover_device(ip, timeout=timeout)
+
+    async def get_device_status(self, ip: str) -> DeviceStatus | None:
+        if self._gateway is None:
+            return None
+        return await self._gateway.get_device_status(ip)
+
+    async def get_settings(self, ip: str) -> dict[str, Any] | None:
+        if self._gateway is None:
+            return None
+        return await self._gateway.fetch_settings(ip)
+
+    async def execute_action(
+        self,
+        ip: str,
+        component_key: str,
+        action: str,
+        parameters: dict[str, Any] | None = None,
+    ) -> ActionResult:
+        """Run a ``Legacy.`` action, or report that there is nowhere to run it.
+
+        The action name stays as written, so the refusal carries the same
+        action type the legacy gateway would have reported for it.
+        """
+        if self._gateway is None:
+            envelope = ActionEnvelope(
+                device_ip=ip, action_type=f"{component_key}.{action}"
+            )
+            return envelope.failed(
+                message="Legacy gateway not available",
+                error="Legacy operations require legacy gateway injection",
+            )
+        return await self._gateway.execute_action(
+            ip, component_key, action, parameters or {}
+        )
+
+    def invalidate_credentials(self, mac: str) -> None:
+        if self._gateway is not None:
+            self._gateway.invalidate_credential_cache(mac)

--- a/packages/core/src/core/gateways/device/rpc_read.py
+++ b/packages/core/src/core/gateways/device/rpc_read.py
@@ -1,0 +1,30 @@
+"""One read of a device over RPC.
+
+Status is gathered from several reads at once and each one is optional, so a
+caller has to tell an empty answer apart from an absent one. ``body`` alone
+cannot say which happened; this pairs it with whether the device answered.
+"""
+
+import logging
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict
+
+logger = logging.getLogger(__name__)
+
+
+class RpcRead(BaseModel):
+
+    model_config = ConfigDict(frozen=True)
+
+    body: Any = None
+    answered: bool = False
+
+    @classmethod
+    def of(cls, result: Any, what: str, missing: Any = None) -> "RpcRead":
+        """Read one result of a gathered call, logging what failed to answer."""
+        if isinstance(result, BaseException):
+            logger.error(f"Error getting {what}: {result}")
+            return cls(body=missing)
+        response, _ = result
+        return cls(body=response.get("result", response), answered=True)

--- a/packages/core/src/core/gateways/device/shelly_device_gateway.py
+++ b/packages/core/src/core/gateways/device/shelly_device_gateway.py
@@ -19,9 +19,12 @@ from ...domain.value_objects.action_name import ActionName
 from ...domain.value_objects.action_result import ActionResult
 from ...utils.validation import normalize_mac
 from ..network.network import RpcNetworkGateway
+from .action_envelope import ActionEnvelope
 from .device import DeviceGateway
 from .legacy_device_gateway import LegacyDeviceGateway
+from .legacy_route import LegacyRoute
 from .rpc_methods import RpcMethods
+from .rpc_read import RpcRead
 
 logger = logging.getLogger(__name__)
 
@@ -38,16 +41,13 @@ class ShellyDeviceGateway(DeviceGateway):
     ) -> None:
         self._rpc_client = rpc_client
         self.timeout = timeout
-        self._legacy_gateway = legacy_gateway
+        self._legacy = LegacyRoute(legacy_gateway)
 
     def invalidate_legacy_credential_cache(self, mac: str) -> None:
-        if self._legacy_gateway:
-            self._legacy_gateway.invalidate_credential_cache(mac)
+        self._legacy.invalidate_credentials(mac)
 
     async def get_legacy_settings(self, ip: str) -> dict[str, Any] | None:
-        if self._legacy_gateway:
-            return await self._legacy_gateway.fetch_settings(ip)
-        return None
+        return await self._legacy.get_settings(ip)
 
     async def discover_device(
         self, ip: str, timeout: float | None = None
@@ -136,12 +136,9 @@ class ShellyDeviceGateway(DeviceGateway):
                 ip,
                 e,
             )
-            if self._legacy_gateway:
-                legacy_device = await self._legacy_gateway.discover_device(
-                    ip, timeout=effective_timeout
-                )
-                if legacy_device:
-                    return legacy_device
+            legacy_device = await self._legacy.discover_device(ip, effective_timeout)
+            if legacy_device:
+                return legacy_device
 
             return DiscoveredDevice(
                 ip=ip,
@@ -161,78 +158,10 @@ class ShellyDeviceGateway(DeviceGateway):
             DeviceStatus with all component data, or None if unreachable
         """
         try:
-            # The device is already known to exist here, so these independent
-            # reads are issued concurrently rather than one round-trip at a time.
-            device_info_res, components_res, status_res, available_methods = (
-                await asyncio.gather(
-                    self._rpc_client.make_rpc_request(
-                        ip, RpcMethods.GET_DEVICE_INFO, timeout=self.timeout
-                    ),
-                    self._rpc_client.make_rpc_request(
-                        ip,
-                        RpcMethods.GET_COMPONENTS,
-                        params={"offset": 0},
-                        timeout=self.timeout,
-                    ),
-                    self._rpc_client.make_rpc_request(
-                        ip, RpcMethods.GET_STATUS, timeout=self.timeout
-                    ),
-                    self.get_available_methods(ip),
-                    return_exceptions=True,
-                )
-            )
-
-            # Authentication failures from components/status must surface to the
-            # caller (preserving the original sequential behaviour).
-            for res in (components_res, status_res):
-                if isinstance(res, DeviceAuthenticationError):
-                    raise res
-
-            rpc_success = False
-            device_info_data = None
-            if isinstance(device_info_res, BaseException):
-                logger.error(f"Error getting device info: {device_info_res}")
-            else:
-                device_info_data = device_info_res[0].get("result", device_info_res[0])
-                rpc_success = True
-                if (
-                    device_info_data
-                    and device_info_data.get("auth_en", False)
-                    and hasattr(self._rpc_client, "auth_state_cache")
-                    and self._rpc_client.auth_state_cache
-                ):
-                    self._rpc_client.auth_state_cache.mark_auth_required(
-                        normalize_mac(ip)
-                    )
-
-            components_data: Any = {}
-            if isinstance(components_res, BaseException):
-                logger.error(f"Error getting components: {components_res}")
-            else:
-                components_data = components_res[0].get("result", components_res[0])
-                rpc_success = True
-
-            status_response = None
-            if isinstance(status_res, BaseException):
-                logger.error(f"Error getting device status: {status_res}")
-            else:
-                status_response = status_res[0].get("result", status_res[0])
-                rpc_success = True
-
-            if isinstance(available_methods, BaseException):
-                available_methods = []
-
-            if not rpc_success:
-                raise RuntimeError("RPC status retrieval failed; use legacy path")
-
-            return DeviceStatus.from_raw_response(
-                ip,
-                components_data,
-                available_methods=available_methods,
-                device_info_data=device_info_data,
-                status_data=status_response,
-            )
-
+            status = await self._read_status_over_rpc(ip)
+            if status is not None:
+                return status
+            logger.debug("No RPC read answered for %s, attempting legacy fallback", ip)
         except DeviceAuthenticationError:
             raise
         except Exception as e:
@@ -240,11 +169,8 @@ class ShellyDeviceGateway(DeviceGateway):
                 f"Error getting device status via RPC, attempting legacy fallback: {e}",
                 exc_info=True,
             )
-            if self._legacy_gateway:
-                legacy_status = await self._legacy_gateway.get_device_status(ip)
-                if legacy_status:
-                    return legacy_status
-            return None
+
+        return await self._legacy.get_device_status(ip)
 
     async def get_component_keys(self, ip: str, component_type: str) -> list[str]:
         """Get component keys for a given type using a single RPC call."""
@@ -309,31 +235,21 @@ class ShellyDeviceGateway(DeviceGateway):
             ActionResult with success/failure details
         """
         action_name = ActionName.of(action)
-        action_type = f"{component_key}.{action_name.method}"
+        envelope = ActionEnvelope(
+            device_ip=ip, action_type=f"{component_key}.{action_name.method}"
+        )
 
         try:
             if action_name.is_legacy:
-                if self._legacy_gateway:
-                    return await self._legacy_gateway.execute_action(
-                        ip, component_key, action, parameters or {}
-                    )
-                else:
-                    return ActionResult(
-                        device_ip=ip,
-                        action_type=f"{component_key}.{action}",
-                        success=False,
-                        message="Legacy gateway not available",
-                        error="Legacy operations require legacy gateway injection",
-                    )
+                return await self._legacy.execute_action(
+                    ip, component_key, action, parameters
+                )
 
             available_methods = await self.get_available_methods(ip)
             rpc_method = action_name.resolve(component_key, available_methods)
 
             if rpc_method is None:
-                return ActionResult(
-                    device_ip=ip,
-                    action_type=action_type,
-                    success=False,
+                return envelope.failed(
                     message=f"Action {action} not supported by {component_key}",
                     error=f"Component {component_key} has no method {action}",
                 )
@@ -341,13 +257,9 @@ class ShellyDeviceGateway(DeviceGateway):
             params: dict[str, Any] = {}
             if ":" in component_key and component_key != "sys":
                 try:
-                    component_id = int(component_key.split(":")[1])
-                    params["id"] = component_id
+                    params["id"] = int(component_key.split(":")[1])
                 except (IndexError, ValueError):
-                    return ActionResult(
-                        device_ip=ip,
-                        action_type=action_type,
-                        success=False,
+                    return envelope.failed(
                         message=f"Invalid component key format: {component_key}",
                         error=f"Could not parse component ID from {component_key}",
                     )
@@ -355,16 +267,14 @@ class ShellyDeviceGateway(DeviceGateway):
             if parameters:
                 params.update(parameters)
 
-            rpc_params: dict[str, Any] | None = params if params else None
             response, _ = await self._rpc_client.make_rpc_request(
-                ip, rpc_method, params=rpc_params, timeout=self.timeout
+                ip, rpc_method, params=params or None, timeout=self.timeout
             )
 
-            return ActionResult(
-                device_ip=ip,
-                action_type=action_type,
-                success=True,
-                message=f"{action_name.method} executed successfully on {component_key}",
+            return envelope.succeeded(
+                message=(
+                    f"{action_name.method} executed successfully on {component_key}"
+                ),
                 data=response,
             )
 
@@ -375,10 +285,7 @@ class ShellyDeviceGateway(DeviceGateway):
             else:
                 error_message = DeviceCommunicationError(ip, err, err).message
 
-            return ActionResult(
-                device_ip=ip,
-                action_type=action_type,
-                success=False,
+            return envelope.failed(
                 message=f"Action failed: {err}",
                 error=error_message,
             )
@@ -430,3 +337,64 @@ class ShellyDeviceGateway(DeviceGateway):
         ]
 
         return await asyncio.gather(*tasks, return_exceptions=False)
+
+    async def _read_status_over_rpc(self, ip: str) -> DeviceStatus | None:
+        """Ask the device for its status every way at once.
+
+        The device is already known to exist here, so these independent reads
+        are issued concurrently rather than one round-trip at a time, and each
+        one is optional: a device that answers only some of them still has a
+        status worth reporting. None means it answered none of them, which is
+        what a Gen1 device looks like from this side.
+        """
+        device_info_res, components_res, status_res, methods_res = await asyncio.gather(
+            self._rpc_client.make_rpc_request(
+                ip, RpcMethods.GET_DEVICE_INFO, timeout=self.timeout
+            ),
+            self._rpc_client.make_rpc_request(
+                ip,
+                RpcMethods.GET_COMPONENTS,
+                params={"offset": 0},
+                timeout=self.timeout,
+            ),
+            self._rpc_client.make_rpc_request(
+                ip, RpcMethods.GET_STATUS, timeout=self.timeout
+            ),
+            self.get_available_methods(ip),
+            return_exceptions=True,
+        )
+
+        # Only these two: a device info read that fails still leaves a status
+        # worth building, so it is logged rather than raised.
+        for res in (components_res, status_res):
+            if isinstance(res, DeviceAuthenticationError):
+                raise res
+
+        device_info = RpcRead.of(device_info_res, "device info")
+        self._remember_auth_requirement(ip, device_info.body)
+
+        components = RpcRead.of(components_res, "components", missing={})
+        status = RpcRead.of(status_res, "device status")
+
+        # The method list cannot join them: it comes back empty both when the
+        # device has none to report and when the read failed.
+        if not (device_info.answered or components.answered or status.answered):
+            return None
+
+        return DeviceStatus.from_raw_response(
+            ip,
+            components.body,
+            available_methods=(
+                [] if isinstance(methods_res, BaseException) else methods_res
+            ),
+            device_info_data=device_info.body,
+            status_data=status.body,
+        )
+
+    def _remember_auth_requirement(self, ip: str, device_info: Any) -> None:
+        """Record that a device asks for credentials, so later calls send them."""
+        if not device_info or not device_info.get("auth_en", False):
+            return
+        auth_state_cache = getattr(self._rpc_client, "auth_state_cache", None)
+        if auth_state_cache:
+            auth_state_cache.mark_auth_required(normalize_mac(ip))

--- a/packages/core/src/core/gateways/device/shelly_device_gateway.py
+++ b/packages/core/src/core/gateways/device/shelly_device_gateway.py
@@ -15,11 +15,12 @@ from ...domain.entities.exceptions import (
     DeviceUnreachableError,
 )
 from ...domain.enums.enums import Status
+from ...domain.value_objects.action_envelope import ActionEnvelope
 from ...domain.value_objects.action_name import ActionName
 from ...domain.value_objects.action_result import ActionResult
+from ...services.auth_state_cache import AuthStateCache
 from ...utils.validation import normalize_mac
 from ..network.network import RpcNetworkGateway
-from .action_envelope import ActionEnvelope
 from .device import DeviceGateway
 from .legacy_device_gateway import LegacyDeviceGateway
 from .legacy_route import LegacyRoute
@@ -38,10 +39,12 @@ class ShellyDeviceGateway(DeviceGateway):
         rpc_client: RpcNetworkGateway,
         timeout: float = 10.0,
         legacy_gateway: LegacyDeviceGateway | None = None,
+        auth_state_cache: AuthStateCache | None = None,
     ) -> None:
         self._rpc_client = rpc_client
         self.timeout = timeout
         self._legacy = LegacyRoute(legacy_gateway)
+        self._auth_state_cache = auth_state_cache
         self._method_lists: dict[str, list[str]] = {}
 
     def invalidate_legacy_credential_cache(self, mac: str) -> None:
@@ -73,13 +76,12 @@ class ShellyDeviceGateway(DeviceGateway):
 
             auth_required = device_data.get("auth_en", False)
 
-            auth_state_cache = getattr(self._rpc_client, "auth_state_cache", None)
-            if auth_state_cache is not None:
+            if self._auth_state_cache is not None:
                 if auth_required:
-                    auth_state_cache.mark_auth_required(normalize_mac(ip))
+                    self._auth_state_cache.mark_auth_required(normalize_mac(ip))
                 else:
                     device_id = device_data.get("id") or ip
-                    auth_required = auth_state_cache.requires_auth(device_id)
+                    auth_required = self._auth_state_cache.requires_auth(device_id)
 
             device = DiscoveredDevice(
                 ip=ip,
@@ -383,9 +385,8 @@ class ShellyDeviceGateway(DeviceGateway):
         """Record that a device asks for credentials, so later calls send them."""
         if not device_info or not device_info.get("auth_en", False):
             return
-        auth_state_cache = getattr(self._rpc_client, "auth_state_cache", None)
-        if auth_state_cache is not None:
-            auth_state_cache.mark_auth_required(normalize_mac(ip))
+        if self._auth_state_cache is not None:
+            self._auth_state_cache.mark_auth_required(normalize_mac(ip))
 
     async def _fetch_available_methods(self, ip: str) -> list[str]:
         try:

--- a/packages/core/src/core/gateways/device/shelly_device_gateway.py
+++ b/packages/core/src/core/gateways/device/shelly_device_gateway.py
@@ -42,6 +42,7 @@ class ShellyDeviceGateway(DeviceGateway):
         self._rpc_client = rpc_client
         self.timeout = timeout
         self._legacy = LegacyRoute(legacy_gateway)
+        self._method_lists: dict[str, list[str]] = {}
 
     def invalidate_legacy_credential_cache(self, mac: str) -> None:
         self._legacy.invalidate_credentials(mac)
@@ -201,20 +202,14 @@ class ShellyDeviceGateway(DeviceGateway):
             against, whether the device could not be asked or answered with
             something unreadable; callers treat both as "unvalidated" rather
             than as proof that a method does not exist.
-        """
-        try:
-            methods_response, _ = await self._rpc_client.make_rpc_request(
-                ip, RpcMethods.LIST_METHODS, timeout=self.timeout
-            )
-            result = methods_response.get("result", methods_response)
-            if isinstance(result, dict) and isinstance(result.get("methods"), list):
-                return [m for m in result["methods"] if isinstance(m, str)]
 
-            logger.warning("Unreadable method list from %s: %r", ip, result)
-            return []
-        except Exception as e:
-            logger.warning(f"Failed to get available methods for {ip}: {e}")
-            return []
+        A list this asks for is always read fresh from the device, and is what
+        _remembered_methods hands to the next action on the same device.
+        """
+        methods = await self._fetch_available_methods(ip)
+        if methods:
+            self._method_lists[ip] = list(methods)
+        return methods
 
     async def execute_component_action(
         self,
@@ -245,8 +240,7 @@ class ShellyDeviceGateway(DeviceGateway):
                     ip, component_key, action, parameters
                 )
 
-            available_methods = await self.get_available_methods(ip)
-            rpc_method = action_name.resolve(component_key, available_methods)
+            rpc_method = await self._resolve_method(ip, component_key, action_name)
 
             if rpc_method is None:
                 return envelope.failed(
@@ -398,3 +392,45 @@ class ShellyDeviceGateway(DeviceGateway):
         auth_state_cache = getattr(self._rpc_client, "auth_state_cache", None)
         if auth_state_cache:
             auth_state_cache.mark_auth_required(normalize_mac(ip))
+
+    async def _fetch_available_methods(self, ip: str) -> list[str]:
+        try:
+            methods_response, _ = await self._rpc_client.make_rpc_request(
+                ip, RpcMethods.LIST_METHODS, timeout=self.timeout
+            )
+            result = methods_response.get("result", methods_response)
+            if isinstance(result, dict) and isinstance(result.get("methods"), list):
+                return [m for m in result["methods"] if isinstance(m, str)]
+
+            logger.warning("Unreadable method list from %s: %r", ip, result)
+            return []
+        except Exception as e:
+            logger.warning(f"Failed to get available methods for {ip}: {e}")
+            return []
+
+    async def _resolve_method(
+        self, ip: str, component_key: str, action_name: ActionName
+    ) -> str | None:
+        """The method to send, spending a round trip only when one would help.
+
+        Reading a device's status fetches its method list, so an action taken
+        from a status page already has the answer and need not ask again.
+
+        A remembered list that refuses is asked again before the refusal
+        stands, which is the round trip the device would have been asked for
+        anyway, so an action the device has gained since is never wrongly
+        refused. A remembered list that accepts is taken at its word: a method
+        the device has since dropped is sent and rejected by the device rather
+        than refused here, and the next status read corrects the list.
+        """
+        remembered = self._method_lists.get(ip)
+        if remembered is None:
+            return action_name.resolve(
+                component_key, await self.get_available_methods(ip)
+            )
+
+        rpc_method = action_name.resolve(component_key, remembered)
+        if rpc_method is not None:
+            return rpc_method
+
+        return action_name.resolve(component_key, await self.get_available_methods(ip))

--- a/packages/core/src/core/gateways/device/shelly_device_gateway.py
+++ b/packages/core/src/core/gateways/device/shelly_device_gateway.py
@@ -73,19 +73,13 @@ class ShellyDeviceGateway(DeviceGateway):
 
             auth_required = device_data.get("auth_en", False)
 
-            if (
-                hasattr(self._rpc_client, "auth_state_cache")
-                and self._rpc_client.auth_state_cache
-            ):
+            auth_state_cache = getattr(self._rpc_client, "auth_state_cache", None)
+            if auth_state_cache is not None:
                 if auth_required:
-                    self._rpc_client.auth_state_cache.mark_auth_required(
-                        normalize_mac(ip)
-                    )
+                    auth_state_cache.mark_auth_required(normalize_mac(ip))
                 else:
                     device_id = device_data.get("id") or ip
-                    auth_required = self._rpc_client.auth_state_cache.requires_auth(
-                        device_id
-                    )
+                    auth_required = auth_state_cache.requires_auth(device_id)
 
             device = DiscoveredDevice(
                 ip=ip,
@@ -203,8 +197,8 @@ class ShellyDeviceGateway(DeviceGateway):
             something unreadable; callers treat both as "unvalidated" rather
             than as proof that a method does not exist.
 
-        A list this asks for is always read fresh from the device, and is what
-        _remembered_methods hands to the next action on the same device.
+        A list this asks for is always read fresh from the device, and is the
+        one _resolve_method hands to the next action on the same device.
         """
         methods = await self._fetch_available_methods(ip)
         if methods:
@@ -390,7 +384,7 @@ class ShellyDeviceGateway(DeviceGateway):
         if not device_info or not device_info.get("auth_en", False):
             return
         auth_state_cache = getattr(self._rpc_client, "auth_state_cache", None)
-        if auth_state_cache:
+        if auth_state_cache is not None:
             auth_state_cache.mark_auth_required(normalize_mac(ip))
 
     async def _fetch_available_methods(self, ip: str) -> list[str]:

--- a/packages/core/src/core/gateways/network/async_shelly_rpc_client.py
+++ b/packages/core/src/core/gateways/network/async_shelly_rpc_client.py
@@ -248,12 +248,12 @@ class AsyncShellyRPCClient(RpcNetworkGateway):
         """
         normalized_ip = self._normalize_id(ip)
 
-        if self.auth_state_cache:
+        if self.auth_state_cache is not None:
             self.auth_state_cache.mark_auth_not_required(normalized_ip)
 
         mac = self._ip_to_mac.get(normalized_ip)
         if mac:
-            if self.auth_state_cache:
+            if self.auth_state_cache is not None:
                 self.auth_state_cache.mark_auth_not_required(mac)
             if mac in self._digest_auth_cache:
                 del self._digest_auth_cache[mac]

--- a/packages/core/tests/unit/dependencies/test_container_base.py
+++ b/packages/core/tests/unit/dependencies/test_container_base.py
@@ -57,6 +57,16 @@ class TestProviderWiring:
         finally:
             await client.close()
 
+    async def test_it_gives_the_device_gateway_the_shared_auth_state_cache(self):
+        container = BaseContainer()
+
+        try:
+            gateway = container.get_device_gateway()
+
+            assert gateway._auth_state_cache is container.get_auth_state_cache()
+        finally:
+            await container.close()
+
     def test_it_wires_the_auth_service_to_the_credentials_factory(self, container):
         service = container.get_authentication_service()
 

--- a/packages/core/tests/unit/domain/entities/test_device_status.py
+++ b/packages/core/tests/unit/domain/entities/test_device_status.py
@@ -559,7 +559,7 @@ class TestDeviceStatusMerging:
 class TestDeviceStatusEMComponents:
     """Test EM component support and total_power calculation."""
 
-    def test_total_power_with_em_only(self):
+    def test_it_totals_power_with_em_only(self):
         """Pro 3EM device with no switches -- total_power should come from EM."""
         em_comp = EMComponent(
             key="em:0",
@@ -576,7 +576,7 @@ class TestDeviceStatusEMComponents:
         assert summary["total_power"] == 312.278
         assert summary["switch_count"] == 0
 
-    def test_total_power_with_em1_only(self):
+    def test_it_totals_power_with_em1_only(self):
         """Pro EM device with multiple EM1 channels and no switches."""
         em1_a = EM1Component(key="em1:0", component_type="em1", act_power=951.2)
         em1_b = EM1Component(key="em1:1", component_type="em1", act_power=200.5)
@@ -589,7 +589,7 @@ class TestDeviceStatusEMComponents:
         assert summary["total_power"] == pytest.approx(1151.7)
         assert summary["switch_count"] == 0
 
-    def test_total_power_with_switches_and_em(self):
+    def test_it_totals_power_with_switches_and_em(self):
         """Mixed device with both switches and EM components."""
         switch_comp = SwitchComponent(
             key="switch:0", component_type="switch", output=True, power=100.0
@@ -604,7 +604,7 @@ class TestDeviceStatusEMComponents:
         assert summary["total_power"] == pytest.approx(412.278)
         assert summary["switch_count"] == 1
 
-    def test_total_power_with_switches_only(self):
+    def test_it_totals_power_with_switches_only(self):
         """Backward compatibility: switch-only devices still work."""
         switch_a = SwitchComponent(
             key="switch:0", component_type="switch", output=True, power=50.0
@@ -621,14 +621,14 @@ class TestDeviceStatusEMComponents:
         assert summary["total_power"] == 50.0
         assert summary["switch_count"] == 2
 
-    def test_total_power_with_no_power_components(self):
+    def test_it_totals_power_with_no_power_components(self):
         """Pure sensor device with no power-producing components."""
         device_status = DeviceStatus(device_ip="192.168.1.100", components=[])
 
         summary = device_status.get_device_summary()
         assert summary["total_power"] == 0
 
-    def test_total_power_with_null_em_power(self):
+    def test_it_totals_power_with_null_em_power(self):
         """EM component with None total_act_power should not break sum."""
         em_comp = EMComponent(key="em:0", component_type="em", total_act_power=None)
         switch_comp = SwitchComponent(
@@ -642,7 +642,7 @@ class TestDeviceStatusEMComponents:
         summary = device_status.get_device_summary()
         assert summary["total_power"] == 100.0
 
-    def test_total_power_with_null_em1_power(self):
+    def test_it_totals_power_with_null_em1_power(self):
         """EM1 component with None act_power should not break sum."""
         em1_comp = EM1Component(key="em1:0", component_type="em1", act_power=None)
 
@@ -651,7 +651,7 @@ class TestDeviceStatusEMComponents:
         summary = device_status.get_device_summary()
         assert summary["total_power"] == 0
 
-    def test_get_em_components(self):
+    def test_it_gets_em_components(self):
         em_comp = EMComponent(key="em:0", component_type="em", total_act_power=312.0)
         switch_comp = SwitchComponent(
             key="switch:0", component_type="switch", output=True, power=50.0
@@ -665,7 +665,7 @@ class TestDeviceStatusEMComponents:
         assert len(em_components) == 1
         assert em_components[0].total_act_power == 312.0
 
-    def test_get_em1_components(self):
+    def test_it_gets_em1_components(self):
         em1_a = EM1Component(key="em1:0", component_type="em1", act_power=951.2)
         em1_b = EM1Component(key="em1:1", component_type="em1", act_power=200.5)
 
@@ -676,7 +676,7 @@ class TestDeviceStatusEMComponents:
         em1_components = device_status.get_em1_components()
         assert len(em1_components) == 2
 
-    def test_get_em_data_components(self):
+    def test_it_gets_em_data_components(self):
         emdata_comp = EMDataComponent(
             key="emdata:0", component_type="emdata", total_act=344297.48
         )
@@ -689,7 +689,7 @@ class TestDeviceStatusEMComponents:
         assert len(em_data) == 1
         assert em_data[0].total_act == 344297.48
 
-    def test_get_em1_data_components(self):
+    def test_it_gets_em1_data_components(self):
         em1data_comp = EM1DataComponent(
             key="em1data:0", component_type="em1data", total_act_energy=12345.67
         )
@@ -702,7 +702,7 @@ class TestDeviceStatusEMComponents:
         assert len(em1_data) == 1
         assert em1_data[0].total_act_energy == 12345.67
 
-    def test_em_components_created_from_raw_response(self):
+    def test_it_creates_em_components_from_a_raw_response(self):
         """Test that EM components are properly created from raw API response."""
         device_ip = "192.168.1.100"
         response_data = {

--- a/packages/core/tests/unit/domain/value_objects/test_action_name.py
+++ b/packages/core/tests/unit/domain/value_objects/test_action_name.py
@@ -184,7 +184,7 @@ class TestResolveHonoursAnExplicitNamespace:
     ):
         assert ActionName.of(action).resolve(component_key, self.METHODS) == expected
 
-    def test_a_bare_method_still_searches_the_components_namespaces(self):
+    def test_it_searches_the_components_namespaces_for_a_bare_method(self):
         assert ActionName.of("FactoryReset").resolve("sys", self.METHODS) == (
             "Shelly.FactoryReset"
         )
@@ -197,7 +197,7 @@ class TestResolveHonoursAnExplicitNamespace:
     def test_it_refuses_an_unowned_qualified_action_without_a_method_list(self):
         assert ActionName.of("Shelly.FactoryReset").resolve("wifi", []) is None
 
-    def test_a_bare_method_still_works_without_a_method_list(self):
+    def test_it_resolves_a_bare_method_without_a_method_list(self):
         assert ActionName.of("SetConfig").resolve("wifi", []) == "Wifi.SetConfig"
 
 
@@ -212,12 +212,12 @@ class TestMethodNamesContainingDots:
         assert action.namespace == "BLE"
         assert action.method == "CloudRelay.List"
 
-    def test_a_listed_name_pasted_back_still_resolves(self):
+    def test_it_resolves_a_listed_name_pasted_back(self):
         action = ActionName.of("BLE.CloudRelay.List")
 
         assert action.resolve("ble", self.METHODS) == "BLE.CloudRelay.List"
 
-    def test_dropping_the_leading_namespace_reads_as_another_one_and_is_refused(self):
+    def test_it_refuses_a_name_whose_leading_namespace_was_dropped(self):
         action = ActionName.of("CloudRelay.List")
 
         assert action.namespace == "CloudRelay"

--- a/packages/core/tests/unit/domain/value_objects/test_component_namespace.py
+++ b/packages/core/tests/unit/domain/value_objects/test_component_namespace.py
@@ -145,19 +145,19 @@ class TestActionsIn:
 
 
 class TestOwnershipIsNotALoosePrefix:
-    def test_zigbee_owns_its_named_shelly_method_and_nothing_else_under_shelly(self):
+    def test_it_gives_zigbee_its_named_shelly_method_and_nothing_else(self):
         namespace = ComponentNamespace.for_component_type("zigbee")
 
         assert namespace.owns("Shelly.ZigbeeClear") is True
         assert namespace.owns("Shelly.ZigbeeAnything") is False
         assert namespace.owns("Shelly.FactoryReset") is False
 
-    def test_an_exact_entry_still_matches_the_device_casing(self):
+    def test_it_matches_the_device_casing_from_an_exact_entry(self):
         namespace = ComponentNamespace.for_component_type("zigbee")
 
         assert namespace.actions_in(["shelly.zigbeeclear"]) == ["shelly.zigbeeclear"]
 
-    def test_a_namespace_prefix_entry_still_matches_a_whole_family(self):
+    def test_it_matches_a_whole_family_from_a_namespace_prefix_entry(self):
         namespace = ComponentNamespace.for_component_type("zigbee")
 
         assert namespace.actions_in(["Zigbee.GetStatus", "Zigbee.SetConfig"]) == [

--- a/packages/core/tests/unit/gateways/device/test_legacy_component_mapper.py
+++ b/packages/core/tests/unit/gateways/device/test_legacy_component_mapper.py
@@ -94,7 +94,7 @@ class TestLegacyAutoTimerMapping:
 
 
 class TestSwitchComponentAcceptsMappedGen1Relay:
-    def test_switch_component_accepts_mapped_relay_with_timer(self, mapper):
+    def test_it_accepts_a_mapped_relay_with_a_timer(self, mapper):
         components = mapper.map(
             {"mac": "AABBCCDDEEFF", "type": "SHSW-1"},
             {"relays": [{"ison": True}]},
@@ -110,7 +110,7 @@ class TestSwitchComponentAcceptsMappedGen1Relay:
         assert component.config["auto_off_delay"] == 0.5
         assert component.config["auto_on_delay"] == 30.0
 
-    def test_raw_numeric_seconds_still_raise_at_the_component(self):
+    def test_it_still_raises_at_the_component_on_raw_numeric_seconds(self):
         # The component stays strict on purpose; only the mapper heals raw seconds.
         with pytest.raises(ValidationError):
             SwitchComponent.from_raw_data(

--- a/packages/core/tests/unit/gateways/device/test_legacy_device_gateway_auth.py
+++ b/packages/core/tests/unit/gateways/device/test_legacy_device_gateway_auth.py
@@ -69,15 +69,17 @@ class TestLegacyDeviceGatewayAuth:
 
     # --- _ensure_mac ---
 
-    async def test_ensure_mac_fetches_from_shelly(self, gateway, mock_http_client):
+    async def test_it_fetches_the_mac_from_shelly(self, gateway, mock_http_client):
         mock_http_client.fetch_json.return_value = {"mac": "AA:BB:CC:DD:EE:FF"}
 
         mac = await gateway._ensure_mac("192.168.1.100")
 
         assert mac == "AABBCCDDEEFF"
-        mock_http_client.fetch_json.assert_called_once_with("192.168.1.100", "shelly")
+        mock_http_client.fetch_json.assert_called_once_with(
+            "192.168.1.100", "shelly", timeout=None
+        )
 
-    async def test_ensure_mac_caches_result(self, gateway, mock_http_client):
+    async def test_it_caches_the_mac_it_fetched(self, gateway, mock_http_client):
         mock_http_client.fetch_json.return_value = {"mac": "AABBCCDDEEFF"}
 
         await gateway._ensure_mac("192.168.1.100")
@@ -86,14 +88,16 @@ class TestLegacyDeviceGatewayAuth:
         assert mac == "AABBCCDDEEFF"
         assert mock_http_client.fetch_json.call_count == 1
 
-    async def test_ensure_mac_returns_none_on_failure(self, gateway, mock_http_client):
+    async def test_it_has_no_mac_when_the_fetch_fails(self, gateway, mock_http_client):
         mock_http_client.fetch_json.side_effect = Exception("timeout")
 
         mac = await gateway._ensure_mac("192.168.1.100")
 
         assert mac is None
 
-    async def test_ensure_mac_returns_none_when_no_mac(self, gateway, mock_http_client):
+    async def test_it_has_no_mac_when_the_device_reports_none(
+        self, gateway, mock_http_client
+    ):
         mock_http_client.fetch_json.return_value = {"type": "SHSW-1"}
 
         mac = await gateway._ensure_mac("192.168.1.100")
@@ -102,7 +106,7 @@ class TestLegacyDeviceGatewayAuth:
 
     # --- _resolve_auth ---
 
-    async def test_resolve_auth_returns_credentials(
+    async def test_it_resolves_credentials(
         self, gateway, mock_http_client, mock_auth_service, sample_credential
     ):
         mock_http_client.fetch_json.return_value = {"mac": "AABBCCDDEEFF"}
@@ -113,7 +117,7 @@ class TestLegacyDeviceGatewayAuth:
         assert auth == ("admin", "secret")
         mock_auth_service.resolve_credentials.assert_called_once_with("AABBCCDDEEFF")
 
-    async def test_resolve_auth_caches_credentials(
+    async def test_it_caches_resolved_credentials(
         self, gateway, mock_http_client, mock_auth_service, sample_credential
     ):
         mock_http_client.fetch_json.return_value = {"mac": "AABBCCDDEEFF"}
@@ -125,14 +129,14 @@ class TestLegacyDeviceGatewayAuth:
         assert auth == ("admin", "secret")
         assert mock_auth_service.resolve_credentials.call_count == 1
 
-    async def test_resolve_auth_returns_none_without_service(
+    async def test_it_resolves_nothing_without_an_authentication_service(
         self, gateway_no_auth, mock_http_client
     ):
         auth = await gateway_no_auth._resolve_auth("192.168.1.100")
 
         assert auth is None
 
-    async def test_resolve_auth_returns_none_when_no_credential(
+    async def test_it_resolves_nothing_when_no_credential_is_stored(
         self, gateway, mock_http_client, mock_auth_service
     ):
         mock_http_client.fetch_json.return_value = {"mac": "AABBCCDDEEFF"}
@@ -144,7 +148,7 @@ class TestLegacyDeviceGatewayAuth:
 
     # --- discover_device with auth ---
 
-    async def test_discover_detects_auth_and_fetches_with_credentials(
+    async def test_it_detects_auth_and_discovers_with_credentials(
         self,
         gateway,
         mock_http_client,
@@ -169,7 +173,7 @@ class TestLegacyDeviceGatewayAuth:
         for call in mock_http_client.fetch_json_optional.call_args_list:
             assert call[1].get("auth") == ("admin", "secret")
 
-    async def test_discover_no_auth_when_not_required(
+    async def test_it_discovers_without_auth_when_it_is_not_required(
         self,
         gateway,
         mock_http_client,
@@ -192,7 +196,7 @@ class TestLegacyDeviceGatewayAuth:
 
     # --- get_device_status with auth ---
 
-    async def test_get_device_status_uses_proactive_auth(
+    async def test_it_reads_status_with_proactive_auth(
         self,
         gateway,
         mock_http_client,
@@ -217,7 +221,7 @@ class TestLegacyDeviceGatewayAuth:
         status_call = mock_http_client.fetch_json.call_args_list[1]
         assert status_call[1].get("auth") == ("admin", "secret")
 
-    async def test_get_device_status_raises_on_auth_failure(
+    async def test_it_raises_on_auth_failure_while_reading_status(
         self,
         gateway,
         mock_http_client,
@@ -236,7 +240,7 @@ class TestLegacyDeviceGatewayAuth:
 
     # --- execute_action with auth ---
 
-    async def test_execute_action_sends_auth(
+    async def test_it_sends_auth_with_an_action(
         self,
         gateway,
         mock_http_client,
@@ -255,7 +259,7 @@ class TestLegacyDeviceGatewayAuth:
         call_kwargs = mock_http_client.get_with_params.call_args[1]
         assert call_kwargs.get("auth") == ("admin", "secret")
 
-    async def test_execute_action_no_auth_without_service(
+    async def test_it_sends_no_auth_with_an_action_without_a_service(
         self, gateway_no_auth, mock_http_client
     ):
         mock_http_client.get_with_params.return_value = {"ison": True}
@@ -270,13 +274,13 @@ class TestLegacyDeviceGatewayAuth:
 
     # --- invalidate_credential_cache ---
 
-    async def test_invalidate_credential_cache(self, gateway):
+    async def test_it_invalidates_the_credential_cache(self, gateway):
         gateway._basic_auth_cache["AABBCCDDEEFF"] = ("admin", "old_pass")
 
         gateway.invalidate_credential_cache("AA:BB:CC:DD:EE:FF")
 
         assert "AABBCCDDEEFF" not in gateway._basic_auth_cache
 
-    async def test_invalidate_credential_cache_noop_for_unknown(self, gateway):
+    async def test_it_invalidates_nothing_for_an_unknown_device(self, gateway):
         # Should not raise
         gateway.invalidate_credential_cache("FFFFFFFFFFFF")

--- a/packages/core/tests/unit/gateways/device/test_shelly_device_gateway.py
+++ b/packages/core/tests/unit/gateways/device/test_shelly_device_gateway.py
@@ -308,10 +308,12 @@ class TestShellyDeviceGateway:
     async def test_it_detects_auth_required_from_auth_en(
         self, mock_rpc_client, mock_legacy_gateway
     ):
-        mock_rpc_client.auth_state_cache = MagicMock()
-        mock_rpc_client.auth_state_cache.requires_auth.return_value = False
+        auth_state_cache = MagicMock()
+        auth_state_cache.requires_auth.return_value = False
         gateway = ShellyDeviceGateway(
-            rpc_client=mock_rpc_client, legacy_gateway=mock_legacy_gateway
+            rpc_client=mock_rpc_client,
+            legacy_gateway=mock_legacy_gateway,
+            auth_state_cache=auth_state_cache,
         )
 
         device_info = {
@@ -331,15 +333,17 @@ class TestShellyDeviceGateway:
 
         assert result is not None
         assert result.auth_required is True
-        mock_rpc_client.auth_state_cache.mark_auth_required.assert_called_once()
+        auth_state_cache.mark_auth_required.assert_called_once()
 
     async def test_it_keeps_update_status_when_auth_succeeds(
         self, mock_rpc_client, mock_legacy_gateway
     ):
-        mock_rpc_client.auth_state_cache = MagicMock()
-        mock_rpc_client.auth_state_cache.requires_auth.return_value = False
+        auth_state_cache = MagicMock()
+        auth_state_cache.requires_auth.return_value = False
         gateway = ShellyDeviceGateway(
-            rpc_client=mock_rpc_client, legacy_gateway=mock_legacy_gateway
+            rpc_client=mock_rpc_client,
+            legacy_gateway=mock_legacy_gateway,
+            auth_state_cache=auth_state_cache,
         )
 
         device_info = {
@@ -362,7 +366,6 @@ class TestShellyDeviceGateway:
     async def test_it_propagates_auth_error_from_get_device_status(
         self, mock_rpc_client, mock_legacy_gateway
     ):
-        mock_rpc_client.auth_state_cache = None
         gateway = ShellyDeviceGateway(
             rpc_client=mock_rpc_client, legacy_gateway=mock_legacy_gateway
         )
@@ -380,9 +383,11 @@ class TestShellyDeviceGateway:
     async def test_it_marks_auth_required_while_the_cache_is_still_empty(
         self, mock_rpc_client, mock_legacy_gateway
     ):
-        mock_rpc_client.auth_state_cache = AuthStateCache()
+        auth_state_cache = AuthStateCache()
         gateway = ShellyDeviceGateway(
-            rpc_client=mock_rpc_client, legacy_gateway=mock_legacy_gateway
+            rpc_client=mock_rpc_client,
+            legacy_gateway=mock_legacy_gateway,
+            auth_state_cache=auth_state_cache,
         )
         mock_rpc_client.make_rpc_request = AsyncMock(
             side_effect=[
@@ -394,14 +399,16 @@ class TestShellyDeviceGateway:
         result = await gateway.discover_device("192.168.1.100")
 
         assert result.auth_required is True
-        assert mock_rpc_client.auth_state_cache.requires_auth("192.168.1.100") is True
+        assert auth_state_cache.requires_auth("192.168.1.100") is True
 
     async def test_it_marks_auth_required_before_a_later_read_can_fail(
         self, mock_rpc_client, mock_legacy_gateway
     ):
-        mock_rpc_client.auth_state_cache = MagicMock()
+        auth_state_cache = MagicMock()
         gateway = ShellyDeviceGateway(
-            rpc_client=mock_rpc_client, legacy_gateway=mock_legacy_gateway
+            rpc_client=mock_rpc_client,
+            legacy_gateway=mock_legacy_gateway,
+            auth_state_cache=auth_state_cache,
         )
         mock_legacy_gateway.get_device_status.return_value = None
         mock_rpc_client.make_rpc_request = AsyncMock(
@@ -415,7 +422,7 @@ class TestShellyDeviceGateway:
 
         await gateway.get_device_status("192.168.1.100")
 
-        mock_rpc_client.auth_state_cache.mark_auth_required.assert_called_once()
+        auth_state_cache.mark_auth_required.assert_called_once()
 
     async def test_it_does_not_propagate_an_auth_error_from_device_info_alone(
         self, gateway, mock_rpc_client

--- a/packages/core/tests/unit/gateways/device/test_shelly_device_gateway.py
+++ b/packages/core/tests/unit/gateways/device/test_shelly_device_gateway.py
@@ -1449,3 +1449,181 @@ class TestLegacyRouting:
         rpc_only_gateway.invalidate_legacy_credential_cache("AA:BB:CC:DD:EE:FF")
 
         mock_rpc_client.make_rpc_request.assert_not_called()
+
+
+class TestMethodListReuse:
+
+    STATUS_READS = [
+        ({"name": "Test Device"}, 0.05),
+        ({"components": [], "cfg_rev": 1, "total": 0}, 0.1),
+        ({"sys": {}}, 0.1),
+        ({"methods": ["Switch.Toggle"]}, 0.05),
+    ]
+
+    @pytest.fixture
+    def mock_rpc_client(self):
+        return MagicMock()
+
+    @pytest.fixture
+    def gateway(self, mock_rpc_client):
+        return ShellyDeviceGateway(rpc_client=mock_rpc_client)
+
+    @staticmethod
+    def _methods_sent(mock_rpc_client):
+        return [c.args[1] for c in mock_rpc_client.make_rpc_request.call_args_list]
+
+    async def test_it_asks_a_device_for_its_method_list_once(
+        self, gateway, mock_rpc_client
+    ):
+        mock_rpc_client.make_rpc_request = AsyncMock(
+            return_value=({"methods": ["Switch.Toggle"]}, 0.1)
+        )
+
+        await gateway.execute_component_action("192.168.1.100", "switch:0", "Toggle")
+        await gateway.execute_component_action("192.168.1.100", "switch:0", "Toggle")
+
+        assert self._methods_sent(mock_rpc_client) == [
+            "Shelly.ListMethods",
+            "Switch.Toggle",
+            "Switch.Toggle",
+        ]
+
+    async def test_it_asks_each_device_for_its_own_method_list(
+        self, gateway, mock_rpc_client
+    ):
+        mock_rpc_client.make_rpc_request = AsyncMock(
+            return_value=({"methods": ["Switch.Toggle"]}, 0.1)
+        )
+
+        await gateway.execute_component_action("192.168.1.100", "switch:0", "Toggle")
+        await gateway.execute_component_action("192.168.1.101", "switch:0", "Toggle")
+
+        assert self._methods_sent(mock_rpc_client).count("Shelly.ListMethods") == 2
+
+    async def test_it_saves_the_next_action_a_round_trip_after_a_status_read(
+        self, gateway, mock_rpc_client
+    ):
+        mock_rpc_client.make_rpc_request = AsyncMock(
+            side_effect=[*self.STATUS_READS, ({}, 0.1)]
+        )
+
+        await gateway.get_device_status("192.168.1.100")
+        result = await gateway.execute_component_action(
+            "192.168.1.100", "switch:0", "Toggle"
+        )
+
+        assert result.success is True
+        assert self._methods_sent(mock_rpc_client).count("Shelly.ListMethods") == 1
+
+    async def test_it_asks_the_device_again_on_every_status_read(
+        self, gateway, mock_rpc_client
+    ):
+        mock_rpc_client.make_rpc_request = AsyncMock(
+            side_effect=[*self.STATUS_READS, *self.STATUS_READS]
+        )
+
+        await gateway.get_device_status("192.168.1.100")
+        await gateway.get_device_status("192.168.1.100")
+
+        assert self._methods_sent(mock_rpc_client).count("Shelly.ListMethods") == 2
+
+    async def test_it_does_not_let_a_caller_grow_a_remembered_list(
+        self, gateway, mock_rpc_client
+    ):
+        mock_rpc_client.make_rpc_request = AsyncMock(
+            return_value=({"methods": ["Switch.Toggle"]}, 0.1)
+        )
+
+        reported = await gateway.get_available_methods("192.168.1.100")
+        reported.append("Switch.Nonsense")
+
+        result = await gateway.execute_component_action(
+            "192.168.1.100", "switch:0", "Switch.Nonsense"
+        )
+
+        assert result.success is False
+
+    async def test_it_asks_the_device_again_before_refusing_a_remembered_miss(
+        self, gateway, mock_rpc_client
+    ):
+        mock_rpc_client.make_rpc_request = AsyncMock(
+            side_effect=[
+                ({"methods": ["Switch.Toggle"]}, 0.1),
+                ({}, 0.1),
+                ({"methods": ["Switch.Set"]}, 0.1),
+                ({}, 0.1),
+            ]
+        )
+
+        await gateway.execute_component_action("192.168.1.100", "switch:0", "Toggle")
+        result = await gateway.execute_component_action(
+            "192.168.1.100", "switch:0", "Set"
+        )
+
+        assert result.success is True
+        assert self._methods_sent(mock_rpc_client) == [
+            "Shelly.ListMethods",
+            "Switch.Toggle",
+            "Shelly.ListMethods",
+            "Switch.Set",
+        ]
+
+    async def test_it_sends_a_remembered_method_the_device_has_since_dropped(
+        self, gateway, mock_rpc_client
+    ):
+        mock_rpc_client.make_rpc_request = AsyncMock(
+            side_effect=[
+                ({"methods": ["Switch.Toggle"]}, 0.1),
+                ({}, 0.1),
+                Exception("unknown method"),
+            ]
+        )
+
+        await gateway.execute_component_action("192.168.1.100", "switch:0", "Toggle")
+        result = await gateway.execute_component_action(
+            "192.168.1.100", "switch:0", "Toggle"
+        )
+
+        assert result.success is False
+        assert "unknown method" in result.message
+        assert self._methods_sent(mock_rpc_client) == [
+            "Shelly.ListMethods",
+            "Switch.Toggle",
+            "Switch.Toggle",
+        ]
+
+    async def test_it_asks_only_once_when_a_remembered_list_already_refuses(
+        self, gateway, mock_rpc_client
+    ):
+        mock_rpc_client.make_rpc_request = AsyncMock(
+            return_value=({"methods": ["Switch.Toggle"]}, 0.1)
+        )
+
+        result = await gateway.execute_component_action(
+            "192.168.1.100", "switch:0", "Nonsense"
+        )
+
+        assert result.success is False
+        assert self._methods_sent(mock_rpc_client) == ["Shelly.ListMethods"]
+
+    async def test_it_does_not_remember_an_unanswered_method_list(
+        self, gateway, mock_rpc_client
+    ):
+        mock_rpc_client.make_rpc_request = AsyncMock(
+            side_effect=[
+                Exception("ListMethods timed out"),
+                ({}, 0.1),
+                ({"methods": ["Switch.Toggle"]}, 0.1),
+                ({}, 0.1),
+            ]
+        )
+
+        await gateway.execute_component_action("192.168.1.100", "switch:0", "Toggle")
+        await gateway.execute_component_action("192.168.1.100", "switch:0", "Toggle")
+
+        assert self._methods_sent(mock_rpc_client) == [
+            "Shelly.ListMethods",
+            "Switch.Toggle",
+            "Shelly.ListMethods",
+            "Switch.Toggle",
+        ]

--- a/packages/core/tests/unit/gateways/device/test_shelly_device_gateway.py
+++ b/packages/core/tests/unit/gateways/device/test_shelly_device_gateway.py
@@ -9,6 +9,7 @@ from core.domain.entities.exceptions import (
     DeviceUnreachableError,
 )
 from core.domain.enums.enums import Status
+from core.domain.value_objects.action_result import ActionResult
 from core.gateways.device.legacy_device_gateway import LegacyDeviceGateway
 from core.gateways.device.shelly_device_gateway import ShellyDeviceGateway
 
@@ -103,60 +104,6 @@ class TestShellyDeviceGateway:
         assert result.status == Status.UNREACHABLE
         assert result.error_message == "Network timeout"
         assert isinstance(result.last_seen, datetime)
-
-    async def test_it_discovers_legacy_device_when_rpc_fails(
-        self, gateway, mock_rpc_client, mock_legacy_gateway
-    ):
-        mock_rpc_client.make_rpc_request = AsyncMock(side_effect=Exception("RPC fail"))
-
-        legacy_device = DiscoveredDevice(
-            ip="192.168.1.200",
-            status=Status.UPDATE_AVAILABLE,
-            device_id="legacy-001",
-            device_type="SHSW-1",
-            device_name="Legacy Switch Friendly",
-            firmware_version="20220101-121314",
-            response_time=0.1,
-            last_seen=datetime.now(),
-            has_update=True,
-        )
-        mock_legacy_gateway.discover_device.return_value = legacy_device
-
-        result = await gateway.discover_device("192.168.1.200")
-
-        assert result is legacy_device
-        mock_legacy_gateway.discover_device.assert_awaited_once_with(
-            "192.168.1.200", timeout=10.0
-        )
-
-    async def test_it_skips_legacy_fallback_when_host_unreachable(
-        self, gateway, mock_rpc_client, mock_legacy_gateway
-    ):
-        mock_rpc_client.make_rpc_request = AsyncMock(
-            side_effect=DeviceUnreachableError("192.168.1.250", "connect timeout")
-        )
-
-        result = await gateway.discover_device("192.168.1.250")
-
-        assert result is not None
-        assert result.status == Status.UNREACHABLE
-        mock_legacy_gateway.discover_device.assert_not_called()
-
-    async def test_it_forwards_timeout_to_rpc_and_legacy(
-        self, gateway, mock_rpc_client, mock_legacy_gateway
-    ):
-        mock_rpc_client.make_rpc_request = AsyncMock(side_effect=Exception("RPC fail"))
-        mock_legacy_gateway.discover_device.return_value = None
-
-        await gateway.discover_device("192.168.1.42", timeout=2.5)
-
-        assert mock_rpc_client.make_rpc_request.call_args_list[0] == (
-            ("192.168.1.42", "Shelly.GetDeviceInfo"),
-            {"timeout": 2.5},
-        )
-        mock_legacy_gateway.discover_device.assert_awaited_once_with(
-            "192.168.1.42", timeout=2.5
-        )
 
     async def test_it_gets_device_status_with_updates(self, gateway, mock_rpc_client):
         components_data = {
@@ -341,86 +288,6 @@ class TestShellyDeviceGateway:
         assert calls[2] == (("192.168.1.100", "Shelly.GetStatus"), {"timeout": 10.0})
         assert calls[3] == (("192.168.1.100", "Shelly.ListMethods"), {"timeout": 10.0})
 
-    async def test_it_gets_legacy_status_when_rpc_not_supported(
-        self, gateway, mock_rpc_client, mock_legacy_gateway
-    ):
-        mock_rpc_client.make_rpc_request = AsyncMock(side_effect=Exception("RPC fail"))
-
-        legacy_status = DeviceStatus(
-            device_ip="192.168.1.200",
-            components=[],
-            total_components=0,
-            device_name="Legacy Switch",
-        )
-        mock_legacy_gateway.get_device_status.return_value = legacy_status
-
-        result = await gateway.get_device_status("192.168.1.200")
-
-        assert result is legacy_status
-        mock_legacy_gateway.get_device_status.assert_awaited_once_with("192.168.1.200")
-
-    async def test_it_executes_legacy_switch_action(self, gateway, mock_legacy_gateway):
-        from core.domain.value_objects.action_result import ActionResult
-
-        expected_result = ActionResult(
-            device_ip="192.168.1.200",
-            action_type="switch:0.Legacy.Toggle",
-            success=True,
-            message="Relay toggled successfully",
-        )
-        mock_legacy_gateway.execute_action.return_value = expected_result
-
-        result = await gateway.execute_component_action(
-            "192.168.1.200", "switch:0", "Legacy.Toggle"
-        )
-
-        assert result is expected_result
-        mock_legacy_gateway.execute_action.assert_awaited_once_with(
-            "192.168.1.200", "switch:0", "Legacy.Toggle", {}
-        )
-
-    async def test_it_handles_unsupported_legacy_action(
-        self, gateway, mock_rpc_client, mock_legacy_gateway
-    ):
-        from core.domain.value_objects.action_result import ActionResult
-
-        mock_legacy_gateway.execute_action.return_value = ActionResult(
-            device_ip="192.168.1.200",
-            action_type="wifi.Legacy.Toggle",
-            success=False,
-            message="Legacy action Legacy.Toggle not supported for wifi",
-            error="Legacy action Legacy.Toggle not supported for wifi",
-        )
-
-        result = await gateway.execute_component_action(
-            "192.168.1.200", "wifi", "Legacy.Toggle"
-        )
-
-        assert result.success is False
-        assert "not supported" in result.message
-
-    async def test_it_executes_legacy_input_mode_change(
-        self, gateway, mock_legacy_gateway
-    ):
-        from core.domain.value_objects.action_result import ActionResult
-
-        expected_result = ActionResult(
-            device_ip="192.168.1.200",
-            action_type="input:0.Legacy.InputMomentary",
-            success=True,
-            message="Input set to momentary",
-        )
-        mock_legacy_gateway.execute_action.return_value = expected_result
-
-        result = await gateway.execute_component_action(
-            "192.168.1.200", "input:0", "Legacy.InputMomentary"
-        )
-
-        assert result is expected_result
-        mock_legacy_gateway.execute_action.assert_awaited_once_with(
-            "192.168.1.200", "input:0", "Legacy.InputMomentary", {}
-        )
-
     async def test_it_handles_update_check_failure_gracefully(
         self, gateway, mock_rpc_client
     ):
@@ -508,6 +375,45 @@ class TestShellyDeviceGateway:
 
         with pytest.raises(DeviceAuthenticationError):
             await gateway.get_device_status("192.168.1.100")
+
+    async def test_it_marks_auth_required_before_a_later_read_can_fail(
+        self, mock_rpc_client, mock_legacy_gateway
+    ):
+        mock_rpc_client.auth_state_cache = MagicMock()
+        gateway = ShellyDeviceGateway(
+            rpc_client=mock_rpc_client, legacy_gateway=mock_legacy_gateway
+        )
+        mock_legacy_gateway.get_device_status.return_value = None
+        mock_rpc_client.make_rpc_request = AsyncMock(
+            side_effect=[
+                ({"auth_en": True}, 0.1),
+                (None, 0.1),
+                ({}, 0.1),
+                ({"methods": []}, 0.05),
+            ]
+        )
+
+        await gateway.get_device_status("192.168.1.100")
+
+        mock_rpc_client.auth_state_cache.mark_auth_required.assert_called_once()
+
+    async def test_it_does_not_propagate_an_auth_error_from_device_info_alone(
+        self, gateway, mock_rpc_client
+    ):
+        components_data = {"components": [], "cfg_rev": 1, "total": 0}
+        mock_rpc_client.make_rpc_request = AsyncMock(
+            side_effect=[
+                DeviceAuthenticationError("192.168.1.100", "No credentials stored"),
+                (components_data, 0.1),
+                ({"sys": {}}, 0.1),
+                ({"methods": ["Switch.Toggle"]}, 0.05),
+            ]
+        )
+
+        result = await gateway.get_device_status("192.168.1.100")
+
+        assert isinstance(result, DeviceStatus)
+        assert result.device_name is None
 
     async def test_it_continues_on_generic_error_in_get_device_status(
         self, gateway, mock_rpc_client
@@ -1091,20 +997,6 @@ class TestActionNameResolution:
             "192.168.1.100", "Switch.Toggle", params={"id": 0}, timeout=10.0
         )
 
-    async def test_it_routes_a_qualified_legacy_action_to_the_legacy_gateway(
-        self, gateway, mock_rpc_client
-    ):
-        mock_rpc_client.make_rpc_request = AsyncMock()
-
-        await gateway.execute_component_action(
-            "192.168.1.100", "switch:0", "Legacy.Toggle"
-        )
-
-        gateway._legacy_gateway.execute_action.assert_awaited_once_with(
-            "192.168.1.100", "switch:0", "Legacy.Toggle", {}
-        )
-        mock_rpc_client.make_rpc_request.assert_not_called()
-
     @pytest.mark.parametrize("action", ["Reboot", "Shelly.Reboot"])
     async def test_it_accepts_bulk_actions_bare_or_qualified(
         self, gateway, mock_rpc_client, action
@@ -1241,7 +1133,7 @@ class TestComponentOwnershipOnExecute:
         sent = [c.args[1] for c in mock_rpc_client.make_rpc_request.call_args_list]
         assert sent == ["Shelly.ListMethods"]
 
-    async def test_a_bare_action_still_runs_when_list_methods_fails(
+    async def test_it_still_runs_a_bare_action_when_list_methods_fails(
         self, gateway, mock_rpc_client
     ):
         mock_rpc_client.make_rpc_request = AsyncMock(
@@ -1285,7 +1177,7 @@ class TestUnreadableMethodLists:
 
         assert await gateway.get_available_methods("192.168.1.100") == expected
 
-    async def test_a_list_of_non_names_does_not_break_execution(
+    async def test_it_does_not_break_execution_on_a_list_of_non_names(
         self, gateway, mock_rpc_client
     ):
         mock_rpc_client.make_rpc_request = AsyncMock(
@@ -1352,3 +1244,208 @@ class TestBulkAllowlistCasing:
     ):
         with pytest.raises(ValueError):
             await gateway.execute_bulk_action(["192.168.1.100"], component_key, action)
+
+
+class TestLegacyRouting:
+    """The one seam between the RPC path and the Gen1 HTTP path."""
+
+    @pytest.fixture
+    def mock_rpc_client(self):
+        return MagicMock()
+
+    @pytest.fixture
+    def mock_legacy_gateway(self):
+        return AsyncMock(spec=LegacyDeviceGateway)
+
+    @pytest.fixture
+    def gateway(self, mock_rpc_client, mock_legacy_gateway):
+        return ShellyDeviceGateway(
+            rpc_client=mock_rpc_client, legacy_gateway=mock_legacy_gateway
+        )
+
+    @pytest.fixture
+    def rpc_only_gateway(self, mock_rpc_client):
+        return ShellyDeviceGateway(rpc_client=mock_rpc_client)
+
+    async def test_it_discovers_over_the_legacy_path_when_rpc_fails(
+        self, gateway, mock_rpc_client, mock_legacy_gateway
+    ):
+        mock_rpc_client.make_rpc_request = AsyncMock(side_effect=Exception("RPC fail"))
+        legacy_device = DiscoveredDevice(
+            ip="192.168.1.200",
+            status=Status.UPDATE_AVAILABLE,
+            device_id="legacy-001",
+            device_type="SHSW-1",
+            last_seen=datetime.now(),
+            has_update=True,
+        )
+        mock_legacy_gateway.discover_device.return_value = legacy_device
+
+        result = await gateway.discover_device("192.168.1.200")
+
+        assert result is legacy_device
+        mock_legacy_gateway.discover_device.assert_awaited_once_with(
+            "192.168.1.200", timeout=10.0
+        )
+
+    async def test_it_skips_the_legacy_path_when_the_host_is_unreachable(
+        self, gateway, mock_rpc_client, mock_legacy_gateway
+    ):
+        mock_rpc_client.make_rpc_request = AsyncMock(
+            side_effect=DeviceUnreachableError("192.168.1.250", "connect timeout")
+        )
+
+        result = await gateway.discover_device("192.168.1.250")
+
+        assert result.status == Status.UNREACHABLE
+        mock_legacy_gateway.discover_device.assert_not_called()
+
+    async def test_it_forwards_the_timeout_to_both_paths(
+        self, gateway, mock_rpc_client, mock_legacy_gateway
+    ):
+        mock_rpc_client.make_rpc_request = AsyncMock(side_effect=Exception("RPC fail"))
+        mock_legacy_gateway.discover_device.return_value = None
+
+        await gateway.discover_device("192.168.1.42", timeout=2.5)
+
+        assert mock_rpc_client.make_rpc_request.call_args_list[0] == (
+            ("192.168.1.42", "Shelly.GetDeviceInfo"),
+            {"timeout": 2.5},
+        )
+        mock_legacy_gateway.discover_device.assert_awaited_once_with(
+            "192.168.1.42", timeout=2.5
+        )
+
+    async def test_it_reads_status_over_the_legacy_path_when_no_read_answers(
+        self, gateway, mock_rpc_client, mock_legacy_gateway
+    ):
+        mock_rpc_client.make_rpc_request = AsyncMock(side_effect=Exception("RPC fail"))
+        legacy_status = DeviceStatus(
+            device_ip="192.168.1.200",
+            components=[],
+            total_components=0,
+            device_name="Legacy Switch",
+        )
+        mock_legacy_gateway.get_device_status.return_value = legacy_status
+
+        result = await gateway.get_device_status("192.168.1.200")
+
+        assert result is legacy_status
+        mock_legacy_gateway.get_device_status.assert_awaited_once_with("192.168.1.200")
+
+    async def test_it_keeps_the_rpc_status_when_a_single_read_answers(
+        self, gateway, mock_rpc_client, mock_legacy_gateway
+    ):
+        mock_rpc_client.make_rpc_request = AsyncMock(
+            side_effect=[
+                Exception("no device info"),
+                ({"components": [], "cfg_rev": 1, "total": 0}, 0.1),
+                Exception("no status"),
+                Exception("no methods"),
+            ]
+        )
+
+        result = await gateway.get_device_status("192.168.1.100")
+
+        assert isinstance(result, DeviceStatus)
+        mock_legacy_gateway.get_device_status.assert_not_called()
+
+    @pytest.mark.parametrize(
+        "component_key,action,success",
+        [
+            ("switch:0", "Legacy.Toggle", True),
+            ("input:0", "Legacy.InputMomentary", True),
+            ("wifi", "Legacy.SetConfig", True),
+            ("wifi", "Legacy.Toggle", False),
+        ],
+    )
+    async def test_it_hands_a_legacy_action_to_the_legacy_gateway_untouched(
+        self,
+        gateway,
+        mock_rpc_client,
+        mock_legacy_gateway,
+        component_key,
+        action,
+        success,
+    ):
+        mock_rpc_client.make_rpc_request = AsyncMock()
+        expected = ActionResult(
+            device_ip="192.168.1.200",
+            action_type=f"{component_key}.{action}",
+            success=success,
+            message="done" if success else f"Legacy action {action} not supported",
+            error=None if success else "Unsupported legacy action",
+        )
+        mock_legacy_gateway.execute_action.return_value = expected
+
+        result = await gateway.execute_component_action(
+            "192.168.1.200", component_key, action
+        )
+
+        assert result is expected
+        mock_legacy_gateway.execute_action.assert_awaited_once_with(
+            "192.168.1.200", component_key, action, {}
+        )
+        mock_rpc_client.make_rpc_request.assert_not_called()
+
+    async def test_it_reads_legacy_settings_through_the_route(
+        self, gateway, mock_legacy_gateway
+    ):
+        mock_legacy_gateway.fetch_settings.return_value = {"name": "Gen1"}
+
+        assert await gateway.get_legacy_settings("192.168.1.200") == {"name": "Gen1"}
+
+    async def test_it_invalidates_legacy_credentials_through_the_route(
+        self, gateway, mock_legacy_gateway
+    ):
+        gateway.invalidate_legacy_credential_cache("AA:BB:CC:DD:EE:FF")
+
+        mock_legacy_gateway.invalidate_credential_cache.assert_called_once_with(
+            "AA:BB:CC:DD:EE:FF"
+        )
+
+    async def test_it_reports_unreachable_when_there_is_no_legacy_path(
+        self, rpc_only_gateway, mock_rpc_client
+    ):
+        mock_rpc_client.make_rpc_request = AsyncMock(side_effect=Exception("RPC fail"))
+
+        result = await rpc_only_gateway.discover_device("192.168.1.200")
+
+        assert result.status == Status.UNREACHABLE
+        assert result.error_message == "RPC fail"
+
+    async def test_it_has_no_status_when_there_is_no_legacy_path(
+        self, rpc_only_gateway, mock_rpc_client
+    ):
+        mock_rpc_client.make_rpc_request = AsyncMock(side_effect=Exception("RPC fail"))
+
+        assert await rpc_only_gateway.get_device_status("192.168.1.200") is None
+
+    async def test_it_refuses_a_legacy_action_when_there_is_no_legacy_path(
+        self, rpc_only_gateway, mock_rpc_client
+    ):
+        mock_rpc_client.make_rpc_request = AsyncMock()
+
+        result = await rpc_only_gateway.execute_component_action(
+            "192.168.1.200", "switch:0", "Legacy.Toggle"
+        )
+
+        assert result.success is False
+        assert result.action_type == "switch:0.Legacy.Toggle"
+        assert result.message == "Legacy gateway not available"
+        assert result.error == "Legacy operations require legacy gateway injection"
+        mock_rpc_client.make_rpc_request.assert_not_called()
+
+    async def test_it_has_no_legacy_settings_when_there_is_no_legacy_path(
+        self, rpc_only_gateway
+    ):
+        assert await rpc_only_gateway.get_legacy_settings("192.168.1.200") is None
+
+    async def test_it_invalidates_nothing_when_there_is_no_legacy_path(
+        self, rpc_only_gateway, mock_rpc_client
+    ):
+        mock_rpc_client.make_rpc_request = AsyncMock()
+
+        rpc_only_gateway.invalidate_legacy_credential_cache("AA:BB:CC:DD:EE:FF")
+
+        mock_rpc_client.make_rpc_request.assert_not_called()

--- a/packages/core/tests/unit/gateways/device/test_shelly_device_gateway.py
+++ b/packages/core/tests/unit/gateways/device/test_shelly_device_gateway.py
@@ -76,18 +76,18 @@ class TestShellyDeviceGateway:
             side_effect=[(device_info, 0.2), (update_info, 0.05)]
         )
 
-        result = await gateway.discover_device("192.168.1.100")
+        result = await gateway.discover_device("192.168.1.100", timeout=2.5)
 
         assert result is not None
         assert mock_rpc_client.make_rpc_request.call_count == 2
         calls = mock_rpc_client.make_rpc_request.call_args_list
         assert calls[0] == (
             ("192.168.1.100", "Shelly.GetDeviceInfo"),
-            {"timeout": 10.0},
+            {"timeout": 2.5},
         )
         assert calls[1] == (
             ("192.168.1.100", "Shelly.CheckForUpdate"),
-            {"timeout": 10.0},
+            {"timeout": 2.5},
         )
 
     async def test_it_handles_device_discovery_failure(
@@ -374,6 +374,8 @@ class TestShellyDeviceGateway:
             side_effect=[
                 ({"name": "Test", "model": "SAWD-0A1XX10EU1"}, 0.05),
                 DeviceAuthenticationError("192.168.1.100", "No credentials stored"),
+                ({"sys": {}}, 0.1),
+                ({"methods": []}, 0.05),
             ]
         )
 
@@ -399,6 +401,28 @@ class TestShellyDeviceGateway:
         result = await gateway.discover_device("192.168.1.100")
 
         assert result.auth_required is True
+        assert auth_state_cache.requires_auth("192.168.1.100") is True
+
+    async def test_it_marks_auth_required_from_a_status_read_on_an_empty_cache(
+        self, mock_rpc_client, mock_legacy_gateway
+    ):
+        auth_state_cache = AuthStateCache()
+        gateway = ShellyDeviceGateway(
+            rpc_client=mock_rpc_client,
+            legacy_gateway=mock_legacy_gateway,
+            auth_state_cache=auth_state_cache,
+        )
+        mock_rpc_client.make_rpc_request = AsyncMock(
+            side_effect=[
+                ({"auth_en": True}, 0.05),
+                ({"components": [], "cfg_rev": 1, "total": 0}, 0.1),
+                ({"sys": {}}, 0.1),
+                ({"methods": []}, 0.05),
+            ]
+        )
+
+        await gateway.get_device_status("192.168.1.100")
+
         assert auth_state_cache.requires_auth("192.168.1.100") is True
 
     async def test_it_marks_auth_required_before_a_later_read_can_fail(

--- a/packages/core/tests/unit/gateways/device/test_shelly_device_gateway.py
+++ b/packages/core/tests/unit/gateways/device/test_shelly_device_gateway.py
@@ -12,6 +12,7 @@ from core.domain.enums.enums import Status
 from core.domain.value_objects.action_result import ActionResult
 from core.gateways.device.legacy_device_gateway import LegacyDeviceGateway
 from core.gateways.device.shelly_device_gateway import ShellyDeviceGateway
+from core.services.auth_state_cache import AuthStateCache
 
 
 class TestShellyDeviceGateway:
@@ -375,6 +376,25 @@ class TestShellyDeviceGateway:
 
         with pytest.raises(DeviceAuthenticationError):
             await gateway.get_device_status("192.168.1.100")
+
+    async def test_it_marks_auth_required_while_the_cache_is_still_empty(
+        self, mock_rpc_client, mock_legacy_gateway
+    ):
+        mock_rpc_client.auth_state_cache = AuthStateCache()
+        gateway = ShellyDeviceGateway(
+            rpc_client=mock_rpc_client, legacy_gateway=mock_legacy_gateway
+        )
+        mock_rpc_client.make_rpc_request = AsyncMock(
+            side_effect=[
+                ({"id": "shelly1-abc", "auth_en": True}, 0.1),
+                ({}, 0.05),
+            ]
+        )
+
+        result = await gateway.discover_device("192.168.1.100")
+
+        assert result.auth_required is True
+        assert mock_rpc_client.auth_state_cache.requires_auth("192.168.1.100") is True
 
     async def test_it_marks_auth_required_before_a_later_read_can_fail(
         self, mock_rpc_client, mock_legacy_gateway

--- a/packages/core/tests/unit/gateways/network/test_async_shelly_rpc_client.py
+++ b/packages/core/tests/unit/gateways/network/test_async_shelly_rpc_client.py
@@ -9,6 +9,7 @@ from core.domain.entities.exceptions import (
     DeviceUnreachableError,
 )
 from core.gateways.network.async_shelly_rpc_client import AsyncShellyRPCClient
+from core.services.auth_state_cache import AuthStateCache
 
 
 class TestAsyncShellyRPCClient:
@@ -251,3 +252,31 @@ class TestAsyncShellyRPCClient:
         assert isinstance(timeout_arg, httpx.Timeout)
         assert timeout_arg.read == 3.0
         assert timeout_arg.connect == 2.0
+
+
+class TestAuthStateCacheGating:
+    """An empty AuthStateCache is falsy, so presence must decide these paths."""
+
+    async def test_it_clears_auth_state_while_the_cache_is_still_empty(self):
+        auth_state_cache = AuthStateCache()
+        client = AsyncShellyRPCClient(
+            session=AsyncMock(spec=httpx.AsyncClient),
+            auth_state_cache=auth_state_cache,
+        )
+
+        client._invalidate_auth_cache("192.168.1.100")
+
+        assert auth_state_cache.is_known("192.168.1.100") is True
+        assert auth_state_cache.requires_auth("192.168.1.100") is False
+
+    async def test_it_clears_auth_state_for_a_known_mac_while_the_cache_is_empty(self):
+        auth_state_cache = AuthStateCache()
+        client = AsyncShellyRPCClient(
+            session=AsyncMock(spec=httpx.AsyncClient),
+            auth_state_cache=auth_state_cache,
+        )
+        client._ip_to_mac["192.168.1.100"] = "AABBCCDDEEFF"
+
+        client._invalidate_auth_cache("192.168.1.100")
+
+        assert auth_state_cache.is_known("AABBCCDDEEFF") is True

--- a/packages/core/tests/unit/gateways/network/test_legacy_http_client_auth.py
+++ b/packages/core/tests/unit/gateways/network/test_legacy_http_client_auth.py
@@ -24,7 +24,7 @@ class TestLegacyHttpClientAuth:
         resp.json.return_value = data
         return resp
 
-    async def test_fetch_json_passes_auth_to_session(self, client, mock_session):
+    async def test_it_passes_auth_to_the_session(self, client, mock_session):
         mock_session.get.return_value = self._mock_ok_response({"ok": True})
 
         result = await client.fetch_json(
@@ -35,7 +35,7 @@ class TestLegacyHttpClientAuth:
         call_kwargs = mock_session.get.call_args[1]
         assert call_kwargs["auth"] == ("admin", "secret")
 
-    async def test_fetch_json_passes_none_auth_by_default(self, client, mock_session):
+    async def test_it_passes_no_auth_by_default(self, client, mock_session):
         mock_session.get.return_value = self._mock_ok_response({"ok": True})
 
         await client.fetch_json("192.168.1.1", "status")
@@ -43,7 +43,7 @@ class TestLegacyHttpClientAuth:
         call_kwargs = mock_session.get.call_args[1]
         assert call_kwargs["auth"] is None
 
-    async def test_fetch_json_optional_passes_auth(self, client, mock_session):
+    async def test_it_passes_auth_on_an_optional_fetch(self, client, mock_session):
         mock_session.get.return_value = self._mock_ok_response({"ok": True})
 
         result = await client.fetch_json_optional(
@@ -54,7 +54,7 @@ class TestLegacyHttpClientAuth:
         call_kwargs = mock_session.get.call_args[1]
         assert call_kwargs["auth"] == ("admin", "pw")
 
-    async def test_get_with_params_passes_auth(self, client, mock_session):
+    async def test_it_passes_auth_with_params(self, client, mock_session):
         mock_session.get.return_value = self._mock_ok_response({"ison": True})
 
         result = await client.get_with_params(
@@ -65,7 +65,7 @@ class TestLegacyHttpClientAuth:
         call_kwargs = mock_session.get.call_args[1]
         assert call_kwargs["auth"] == ("admin", "pass")
 
-    async def test_get_with_params_none_auth_by_default(self, client, mock_session):
+    async def test_it_passes_no_auth_with_params_by_default(self, client, mock_session):
         mock_session.get.return_value = self._mock_ok_response({"ison": True})
 
         await client.get_with_params("192.168.1.1", "relay/0", {"turn": "on"})

--- a/packages/core/tests/unit/services/test_auth_state_cache.py
+++ b/packages/core/tests/unit/services/test_auth_state_cache.py
@@ -106,7 +106,7 @@ class TestAuthStateCache:
             # Entry should be gone
             assert "AABBCCDDEEFF" not in cache._auth_required
 
-    def test_is_known_removes_expired_entry(self):
+    def test_it_removes_an_expired_entry_when_asked_if_it_is_known(self):
         with patch("core.services.auth_state_cache.time") as mock_time:
             mock_time.return_value = 1000000
             cache = AuthStateCache(ttl_seconds=1)
@@ -133,7 +133,7 @@ class TestAuthStateCache:
             _, timestamp = cache._auth_required["AABBCCDDEEFF"]
             assert timestamp == initial_time + 1800
 
-    def test_cleanup_expired_removes_old_entries(self):
+    def test_it_removes_expired_entries_on_cleanup(self):
         with patch("core.services.auth_state_cache.time") as mock_time:
             mock_time.return_value = 1000000
             cache = AuthStateCache(ttl_seconds=1)
@@ -145,11 +145,11 @@ class TestAuthStateCache:
             mock_time.return_value = 1000000 + 2  # After TTL for first device
             removed = cache.cleanup_expired()
 
-            assert removed == 1
+            assert removed == 2
             assert "OLD_DEVICE" not in cache._auth_required
-            assert "NEW_DEVICE" not in cache._auth_required  # Also expired by now
+            assert "NEW_DEVICE" not in cache._auth_required
 
-    def test_cleanup_expired_returns_zero_when_no_expired(self, cache):
+    def test_it_removes_nothing_when_no_entry_has_expired(self, cache):
         cache.mark_auth_required("DEVICE1")
         cache.mark_auth_required("DEVICE2")
 
@@ -166,5 +166,5 @@ class TestAuthStateCache:
 
 
 class TestDefaultTTL:
-    def test_default_ttl_is_one_hour(self):
+    def test_it_defaults_to_a_one_hour_ttl(self):
         assert DEFAULT_TTL_SECONDS == 3600


### PR DESCRIPTION
## Purpose

Deepen the device gateway: one seam between the RPC path and the Gen1 HTTP path, and a device's method list read once rather than before every action. Plus the forty six core tests that turned out never to run, and the bug one of them was already catching.

## Context

Phase 4 of the refactor, after the generation seam and the action-name module. Most of the gateway was routing, defensive unwrapping and envelope construction: the same legacy-gateway presence check written out at five branch points, five near-identical `ActionResult` constructions, three `isinstance(BaseException)` unwrap blocks, and a `RuntimeError` raised only to be caught two lines later as the way to reach the legacy fallback. Reading the method list once also closes the item deferred out of the standalone bug fixes, where `execute_component_action` re-fetched `Shelly.ListMethods` on every call even though `get_device_status` had just fetched it.

Only the first commit is behaviour-neutral. The rest are not, so they are separate and worth reading on their own.

core matches `python_functions = ["test_it_*"]`, which does not skip a differently named test so much as make it invisible: no report, no count, no failure. Forty six had built up that way, including every test of the Gen1 auth path, of the legacy HTTP client's auth handling, and of the EM component accessors. They now carry the name the convention asks for. Running them showed that `AuthStateCache` defines `__len__` and no `__bool__`, so an empty one is falsy, and every caller asked `if cache:` rather than `is not None`, which meant the cache was ignored for exactly as long as it held nothing.

The last two commits put two things back on the right side of the gateway's boundaries. `ActionEnvelope` builds an `ActionResult`, which is a domain value, so it belongs beside `ActionResult` and `ActionName` rather than in the adapter that uses it. And the gateway had been reading the authentication state cache off the RPC client with `getattr`, a lookup the `RpcNetworkGateway` interface does not promise and which worked only because the concrete client happens to expose it; the cache is a dependency, so it is injected, the way `LegacyDeviceGateway` has always taken it.

## Notes

Checked against a Gen4 device (1PM Mini, fw 1.7.1) with authentication switched on for the purpose, read-only throughout.

The auth fix is worth one HTTP request per device. Cold discovery of an authenticated device costs four requests before it and three after, because the unauthenticated `CheckForUpdate` that takes a 401 and retries no longer happens; every read after the first is identical either way. It is an efficiency fix, not the auth failure it might read as, since the 401 challenge path resolves credentials and retries regardless.

The same measurement found something this branch does not address: a cold `get_device_status` on an authenticated device spends ten HTTP requests on four RPC calls, three of them 401s, because the four reads are gathered concurrently and the cache is only marked once they return, so each authenticated method challenges separately. Filed separately.

The method-list reuse is the one place the refactor's behaviour could drift, so it is built to fail closed. A status read always asks the device again, so the action list the UI renders is never a remembered one; only actions reuse. A remembered list that refuses is asked again before the refusal stands, so an action the device has gained since is never wrongly refused. Confirmed on the same device: two status reads each re-read the method list, a warm action sends only itself, a cold one reads the list first, and a refusal re-reads before refusing.

Three residuals, all bounded by the device rejecting what it does not have, and all corrected by the next successful status read. A remembered list that accepts is taken at its word, so a method the device has since dropped is sent and rejected by the device rather than refused locally. Two concurrent first actions on the same device both read the list, since there is no single flight. And two overlapping reads can land out of order, leaving the older answer remembered. The cache is keyed by IP with no eviction, bounded in practice by the devices whose status is read.

One log line changed level. When no RPC read answers, which is what a Gen1 device looks like from this side, the fallback logged at error with a traceback on every status read; it now logs at debug.

Two of the recovered tests had drifted while nothing ran them, and both were the test's fault rather than the code's: the legacy gateway gained a timeout argument its caller now passes, and an expired-entry count had been written for one entry in a case that expires two, which the same test's later assertions already said.

Nothing here is verified against a Gen1 device, because there is none to hand. The Gen1 half of the gateway rests entirely on the tests, which is part of why the twenty three legacy-path tests among the forty six were worth recovering.
