### PR TITLE
One shape for the web's server state

### DIFF
--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -10,8 +10,11 @@ import { Provisioning } from "@/pages/provisioning";
 import { BackupSchedules } from "@/pages/backup-schedules";
 import { Settings } from "@/pages/settings";
 import { queryClient, persister } from "@/lib/query-client";
+import { queryKeys } from "@/lib/query-keys";
 
 import "@/i18n";
+
+const SCAN_QUERY_KEY = queryKeys.devices.scan();
 
 function App() {
   return (
@@ -21,14 +24,11 @@ function App() {
         persister,
         maxAge: 1000 * 60 * 60 * 24 * 7, // 7 days (longer than our 2-day stale threshold)
         dehydrateOptions: {
-          shouldDehydrateQuery: (query: Query) => {
-            return (
-              query.queryKey.length >= 2 &&
-              query.queryKey[0] === "devices" &&
-              query.queryKey[1] === "scan" &&
-              query.state.data !== undefined
-            );
-          },
+          shouldDehydrateQuery: (query: Query) =>
+            query.state.data !== undefined &&
+            SCAN_QUERY_KEY.every(
+              (segment, index) => query.queryKey[index] === segment,
+            ),
         },
       }}
     >

--- a/packages/web/src/components/backup-schedules/backups-table-section.tsx
+++ b/packages/web/src/components/backup-schedules/backups-table-section.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { Trash2, Loader2, Save } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
@@ -20,8 +20,8 @@ import {
 } from "@/components/ui/table";
 import { handleApiError } from "@/lib/api";
 import { useAllBackups, useDeleteBackup } from "@/hooks/useBackups";
-
-const PAGE_SIZE = 50;
+import { PAGE_SIZE, useRewindEmptyPage } from "@/hooks/useOffsetPagination";
+import { OffsetPager } from "@/components/shared/offset-pager";
 
 function formatSize(bytes: number): string {
   if (bytes < 1024) return `${bytes} B`;
@@ -45,20 +45,9 @@ export function BackupsTableSection() {
   const items = data?.items ?? [];
   const total = data?.total ?? 0;
 
-  // Step back only on a *successful* empty page, not on a transient error,
-  // which also yields items=[] and would otherwise rewind pagination state.
-  useEffect(() => {
-    if (isSuccess && items.length === 0 && offset >= PAGE_SIZE) {
-      setOffset((current) => Math.max(0, current - PAGE_SIZE));
-    }
-  }, [isSuccess, items.length, offset]);
+  useRewindEmptyPage(isSuccess, items.length, offset, setOffset);
 
   const deleteMutation = useDeleteBackup();
-
-  const rangeStart = total === 0 ? 0 : offset + 1;
-  const rangeEnd = offset + items.length;
-  const canPrev = offset > 0;
-  const canNext = offset + PAGE_SIZE < total;
 
   return (
     <Card>
@@ -148,31 +137,12 @@ export function BackupsTableSection() {
                 ))}
               </TableBody>
             </Table>
-            <div className="flex items-center justify-between pt-4">
-              <p className="text-sm text-muted-foreground">
-                Showing {rangeStart}–{rangeEnd} of {total}
-              </p>
-              <div className="space-x-2">
-                <Button
-                  variant="outline"
-                  size="sm"
-                  onClick={() =>
-                    setOffset((current) => Math.max(0, current - PAGE_SIZE))
-                  }
-                  disabled={!canPrev}
-                >
-                  Previous
-                </Button>
-                <Button
-                  variant="outline"
-                  size="sm"
-                  onClick={() => setOffset((current) => current + PAGE_SIZE)}
-                  disabled={!canNext}
-                >
-                  Next
-                </Button>
-              </div>
-            </div>
+            <OffsetPager
+              offset={offset}
+              itemCount={items.length}
+              total={total}
+              onOffsetChange={setOffset}
+            />
           </>
         )}
       </CardContent>

--- a/packages/web/src/components/backup-schedules/backups-table-section.tsx
+++ b/packages/web/src/components/backup-schedules/backups-table-section.tsx
@@ -1,7 +1,5 @@
 import { useEffect, useState } from "react";
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Trash2, Loader2, Save } from "lucide-react";
-import { toast } from "sonner";
 
 import { Button } from "@/components/ui/button";
 import {
@@ -20,8 +18,8 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
-import { backupApi, handleApiError } from "@/lib/api";
-import { queryKeys } from "@/lib/query-keys";
+import { handleApiError } from "@/lib/api";
+import { useAllBackups, useDeleteBackup } from "@/hooks/useBackups";
 
 const PAGE_SIZE = 50;
 
@@ -37,12 +35,11 @@ function formatTimestamp(ts: number | null): string {
 }
 
 export function BackupsTableSection() {
-  const queryClient = useQueryClient();
   const [offset, setOffset] = useState(0);
 
-  const { data, isLoading, isSuccess, error } = useQuery({
-    queryKey: queryKeys.backups.list({ limit: PAGE_SIZE, offset }),
-    queryFn: () => backupApi.listBackups({ limit: PAGE_SIZE, offset }),
+  const { data, isLoading, isSuccess, error } = useAllBackups({
+    limit: PAGE_SIZE,
+    offset,
   });
 
   const items = data?.items ?? [];
@@ -56,14 +53,7 @@ export function BackupsTableSection() {
     }
   }, [isSuccess, items.length, offset]);
 
-  const deleteMutation = useMutation({
-    mutationFn: (id: number) => backupApi.deleteBackup(id),
-    onSuccess: () => {
-      toast.success("Backup deleted");
-      queryClient.invalidateQueries({ queryKey: queryKeys.backups.all() });
-    },
-    onError: (err) => toast.error(handleApiError(err)),
-  });
+  const deleteMutation = useDeleteBackup();
 
   const rangeStart = total === 0 ? 0 : offset + 1;
   const rangeEnd = offset + items.length;

--- a/packages/web/src/components/backup-schedules/backups-table-section.tsx
+++ b/packages/web/src/components/backup-schedules/backups-table-section.tsx
@@ -43,7 +43,6 @@ export function BackupsTableSection() {
   const { data, isLoading, isSuccess, error } = useQuery({
     queryKey: queryKeys.backups.list({ limit: PAGE_SIZE, offset }),
     queryFn: () => backupApi.listBackups({ limit: PAGE_SIZE, offset }),
-    enabled: true,
   });
 
   const items = data?.items ?? [];

--- a/packages/web/src/components/backup-schedules/backups-table-section.tsx
+++ b/packages/web/src/components/backup-schedules/backups-table-section.tsx
@@ -21,6 +21,7 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import { backupApi, handleApiError } from "@/lib/api";
+import { queryKeys } from "@/lib/query-keys";
 
 const PAGE_SIZE = 50;
 
@@ -40,7 +41,7 @@ export function BackupsTableSection() {
   const [offset, setOffset] = useState(0);
 
   const { data, isLoading, isSuccess, error } = useQuery({
-    queryKey: ["backups", "all", offset],
+    queryKey: queryKeys.backups.list({ limit: PAGE_SIZE, offset }),
     queryFn: () => backupApi.listBackups({ limit: PAGE_SIZE, offset }),
     enabled: true,
   });
@@ -58,10 +59,9 @@ export function BackupsTableSection() {
 
   const deleteMutation = useMutation({
     mutationFn: (id: number) => backupApi.deleteBackup(id),
-    onSuccess: (_data, id) => {
+    onSuccess: () => {
       toast.success("Backup deleted");
-      queryClient.removeQueries({ queryKey: ["backup", id] });
-      queryClient.invalidateQueries({ queryKey: ["backups"] });
+      queryClient.invalidateQueries({ queryKey: queryKeys.backups.all() });
     },
     onError: (err) => toast.error(handleApiError(err)),
   });

--- a/packages/web/src/components/dashboard/credentials-manager.tsx
+++ b/packages/web/src/components/dashboard/credentials-manager.tsx
@@ -25,6 +25,7 @@ import {
   DialogTrigger,
 } from "@/components/ui/dialog";
 import { credentialsApi, handleApiError } from "@/lib/api";
+import { queryKeys } from "@/lib/query-keys";
 import type { Credential, CredentialCreateRequest } from "@/types/api";
 
 interface CredentialsManagerProps {
@@ -48,7 +49,7 @@ export function CredentialsManager({
   const setMutation = useMutation({
     mutationFn: credentialsApi.setCredential,
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["credentials"] });
+      queryClient.invalidateQueries({ queryKey: queryKeys.credentials.all() });
       toast.success(t("common.success"));
       setIsOpen(false);
       setNewCred({ mac: "", username: "admin", password: "" });
@@ -61,7 +62,7 @@ export function CredentialsManager({
   const deleteMutation = useMutation({
     mutationFn: credentialsApi.deleteCredential,
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["credentials"] });
+      queryClient.invalidateQueries({ queryKey: queryKeys.credentials.all() });
       toast.success(t("common.success"));
     },
     onError: (error) => {

--- a/packages/web/src/components/dashboard/credentials-manager.tsx
+++ b/packages/web/src/components/dashboard/credentials-manager.tsx
@@ -1,7 +1,6 @@
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Plus, Trash2, Shield, Loader2, Globe } from "lucide-react";
-import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 
 import { Button } from "@/components/ui/button";
@@ -24,8 +23,7 @@ import {
   DialogTitle,
   DialogTrigger,
 } from "@/components/ui/dialog";
-import { credentialsApi, handleApiError } from "@/lib/api";
-import { queryKeys } from "@/lib/query-keys";
+import { useDeleteCredential, useSetCredential } from "@/hooks/useCredentials";
 import type { Credential, CredentialCreateRequest } from "@/types/api";
 
 interface CredentialsManagerProps {
@@ -38,7 +36,6 @@ export function CredentialsManager({
   isLoading,
 }: CredentialsManagerProps) {
   const { t } = useTranslation();
-  const queryClient = useQueryClient();
   const [isOpen, setIsOpen] = useState(false);
   const [newCred, setNewCred] = useState<CredentialCreateRequest>({
     mac: "",
@@ -46,29 +43,17 @@ export function CredentialsManager({
     password: "",
   });
 
-  const setMutation = useMutation({
-    mutationFn: credentialsApi.setCredential,
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: queryKeys.credentials.all() });
-      toast.success(t("common.success"));
-      setIsOpen(false);
-      setNewCred({ mac: "", username: "admin", password: "" });
-    },
-    onError: (error) => {
-      toast.error(handleApiError(error));
-    },
-  });
+  const setMutation = useSetCredential();
+  const deleteMutation = useDeleteCredential();
 
-  const deleteMutation = useMutation({
-    mutationFn: credentialsApi.deleteCredential,
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: queryKeys.credentials.all() });
-      toast.success(t("common.success"));
-    },
-    onError: (error) => {
-      toast.error(handleApiError(error));
-    },
-  });
+  const saveCredential = (credential: CredentialCreateRequest) => {
+    setMutation.mutate(credential, {
+      onSuccess: () => {
+        setIsOpen(false);
+        setNewCred({ mac: "", username: "admin", password: "" });
+      },
+    });
+  };
 
   const handleAdd = () => {
     if (!newCred.mac || !newCred.password) {
@@ -77,7 +62,7 @@ export function CredentialsManager({
     }
     // Ensure MAC is uppercase
     const mac = newCred.mac.trim().toUpperCase();
-    setMutation.mutate({ ...newCred, mac });
+    saveCredential({ ...newCred, mac });
   };
 
   const handleSetGlobal = () => {
@@ -85,7 +70,7 @@ export function CredentialsManager({
       toast.error("Password is required for global fallback");
       return;
     }
-    setMutation.mutate({ ...newCred, mac: "*" });
+    saveCredential({ ...newCred, mac: "*" });
   };
 
   return (

--- a/packages/web/src/components/dashboard/scan-form.tsx
+++ b/packages/web/src/components/dashboard/scan-form.tsx
@@ -7,6 +7,7 @@ import { useEffect, useRef } from "react";
 import { Search } from "lucide-react";
 import { useQuery } from "@tanstack/react-query";
 import { credentialsApi } from "@/lib/api";
+import { queryKeys } from "@/lib/query-keys";
 import { Button } from "@/components/ui/button";
 import {
   Card,
@@ -57,7 +58,7 @@ export function ScanForm({ onSubmit, isLoading = false }: ScanFormProps) {
 
   // Load credentials when authentication is enabled
   const credentialsQuery = useQuery({
-    queryKey: ["credentials"],
+    queryKey: queryKeys.credentials.all(),
     queryFn: credentialsApi.listCredentials,
     enabled: useAuth, // Only fetch when authentication is enabled
     staleTime: 0, // Always refetch to ensure fresh data

--- a/packages/web/src/components/dashboard/scan-form.tsx
+++ b/packages/web/src/components/dashboard/scan-form.tsx
@@ -5,9 +5,7 @@ import { useForm } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 import { useEffect, useRef } from "react";
 import { Search } from "lucide-react";
-import { useQuery } from "@tanstack/react-query";
-import { credentialsApi } from "@/lib/api";
-import { queryKeys } from "@/lib/query-keys";
+import { useCredentials } from "@/hooks/useCredentials";
 import { Button } from "@/components/ui/button";
 import {
   Card,
@@ -56,13 +54,7 @@ export function ScanForm({ onSubmit, isLoading = false }: ScanFormProps) {
   const scanMode = form.watch("scan_mode");
   const useAuth = form.watch("use_auth");
 
-  // Load credentials when authentication is enabled
-  const credentialsQuery = useQuery({
-    queryKey: queryKeys.credentials.all(),
-    queryFn: credentialsApi.listCredentials,
-    enabled: useAuth, // Only fetch when authentication is enabled
-    staleTime: 0, // Always refetch to ensure fresh data
-  });
+  const credentialsQuery = useCredentials({ enabled: useAuth });
   const timeoutRef = useRef<NodeJS.Timeout | undefined>(undefined);
 
   useEffect(() => {

--- a/packages/web/src/components/device-detail/backups-section.tsx
+++ b/packages/web/src/components/device-detail/backups-section.tsx
@@ -27,6 +27,7 @@ import {
 } from "@/components/ui/dialog";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Label } from "@/components/ui/label";
+import { handleApiError } from "@/lib/api";
 import {
   useBackup,
   useBackups,
@@ -34,10 +35,11 @@ import {
   useDeleteBackup,
   useRestoreBackup,
 } from "@/hooks/useBackups";
+import { PAGE_SIZE, useRewindEmptyPage } from "@/hooks/useOffsetPagination";
+import { OffsetPager } from "@/components/shared/offset-pager";
 import type { BackupSummary } from "@/types/api";
 
 const NETWORK_TYPES = new Set(["wifi", "eth", "mqtt", "ws", "cloud"]);
-const PAGE_SIZE = 50;
 
 interface BackupsSectionProps {
   deviceIp: string;
@@ -59,6 +61,7 @@ export function BackupsSection({
     data: backups,
     isLoading,
     isSuccess,
+    error,
   } = useBackups(deviceMac, {
     limit: PAGE_SIZE,
     offset,
@@ -76,21 +79,10 @@ export function BackupsSection({
     setOffset(0);
   }, [deviceMac]);
 
-  // Step back only on a *successful* empty page, not on a transient error,
-  // which also yields items=[] and would otherwise rewind pagination state.
-  useEffect(() => {
-    if (isSuccess && items.length === 0 && offset >= PAGE_SIZE) {
-      setOffset((current) => Math.max(0, current - PAGE_SIZE));
-    }
-  }, [isSuccess, items.length, offset]);
+  useRewindEmptyPage(isSuccess, items.length, offset, setOffset);
 
   const formatDate = (ts: number | null) =>
     ts ? new Date(ts * 1000).toLocaleString() : "-";
-
-  const rangeStart = total === 0 ? 0 : offset + 1;
-  const rangeEnd = offset + items.length;
-  const canPrev = offset > 0;
-  const canNext = offset + PAGE_SIZE < total;
 
   return (
     <Card>
@@ -116,6 +108,10 @@ export function BackupsSection({
           </p>
         ) : isLoading ? (
           <p className="text-sm text-muted-foreground">Loading backups...</p>
+        ) : error ? (
+          <p className="text-sm text-destructive">
+            Failed to load backups: {handleApiError(error)}
+          </p>
         ) : total === 0 ? (
           <p className="text-sm text-muted-foreground">No backups yet.</p>
         ) : (
@@ -142,31 +138,12 @@ export function BackupsSection({
               </TableBody>
             </Table>
             {total > PAGE_SIZE && (
-              <div className="flex items-center justify-between pt-4">
-                <p className="text-sm text-muted-foreground">
-                  Showing {rangeStart}–{rangeEnd} of {total}
-                </p>
-                <div className="space-x-2">
-                  <Button
-                    variant="outline"
-                    size="sm"
-                    onClick={() =>
-                      setOffset((current) => Math.max(0, current - PAGE_SIZE))
-                    }
-                    disabled={!canPrev}
-                  >
-                    Previous
-                  </Button>
-                  <Button
-                    variant="outline"
-                    size="sm"
-                    onClick={() => setOffset((current) => current + PAGE_SIZE)}
-                    disabled={!canNext}
-                  >
-                    Next
-                  </Button>
-                </div>
-              </div>
+              <OffsetPager
+                offset={offset}
+                itemCount={items.length}
+                total={total}
+                onOffsetChange={setOffset}
+              />
             )}
           </>
         )}

--- a/packages/web/src/components/device-detail/backups-section.tsx
+++ b/packages/web/src/components/device-detail/backups-section.tsx
@@ -104,42 +104,48 @@ export function BackupsSection({
           </p>
         ) : isLoading ? (
           <p className="text-sm text-muted-foreground">Loading backups...</p>
-        ) : error && items.length === 0 ? (
-          <p className="text-sm text-destructive">
-            Failed to load backups: {handleApiError(error)}
-          </p>
-        ) : total === 0 ? (
-          <p className="text-sm text-muted-foreground">No backups yet.</p>
         ) : (
           <>
-            <Table>
-              <TableHeader>
-                <TableRow>
-                  <TableHead>ID</TableHead>
-                  <TableHead>Created</TableHead>
-                  <TableHead>Firmware</TableHead>
-                  <TableHead>Source</TableHead>
-                  <TableHead className="text-right">Actions</TableHead>
-                </TableRow>
-              </TableHeader>
-              <TableBody>
-                {items.map((backup) => (
-                  <BackupRow
-                    key={backup.id}
-                    backup={backup}
-                    formatDate={formatDate}
-                    onRestore={() => setRestoreTarget(backup)}
+            {error && (
+              <p className="text-sm text-destructive pb-2">
+                Failed to load backups: {handleApiError(error)}
+              </p>
+            )}
+            {!error && total === 0 && (
+              <p className="text-sm text-muted-foreground">No backups yet.</p>
+            )}
+            {items.length > 0 && (
+              <>
+                <Table>
+                  <TableHeader>
+                    <TableRow>
+                      <TableHead>ID</TableHead>
+                      <TableHead>Created</TableHead>
+                      <TableHead>Firmware</TableHead>
+                      <TableHead>Source</TableHead>
+                      <TableHead className="text-right">Actions</TableHead>
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {items.map((backup) => (
+                      <BackupRow
+                        key={backup.id}
+                        backup={backup}
+                        formatDate={formatDate}
+                        onRestore={() => setRestoreTarget(backup)}
+                      />
+                    ))}
+                  </TableBody>
+                </Table>
+                {total > PAGE_SIZE && (
+                  <OffsetPager
+                    offset={offset}
+                    itemCount={items.length}
+                    total={total}
+                    onOffsetChange={setOffset}
                   />
-                ))}
-              </TableBody>
-            </Table>
-            {total > PAGE_SIZE && (
-              <OffsetPager
-                offset={offset}
-                itemCount={items.length}
-                total={total}
-                onOffsetChange={setOffset}
-              />
+                )}
+              </>
             )}
           </>
         )}
@@ -209,8 +215,7 @@ function RestoreDialog({
     const components = detail?.snapshot.components ?? {};
     return Object.entries(components).map(([key, value]) => ({
       key,
-      type: value.type ?? "",
-      network: NETWORK_TYPES.has(value.type ?? ""),
+      network: isNetworkComponent(key, value.type),
     }));
   }, [detail]);
 
@@ -258,34 +263,38 @@ function RestoreDialog({
 
         {isLoading ? (
           <p className="text-sm text-muted-foreground">Loading components...</p>
-        ) : error ? (
-          <p className="text-sm text-destructive">
-            Failed to load this backup: {handleApiError(error)}
-          </p>
         ) : (
-          <div className="max-h-72 overflow-y-auto space-y-2">
-            {componentTypes.map((c) => (
-              <div key={c.key} className="flex items-center gap-2">
-                <Checkbox
-                  id={`restore-${c.key}`}
-                  checked={effectiveSelected.has(c.key)}
-                  onCheckedChange={() => toggle(c.key)}
-                />
-                <Label
-                  htmlFor={`restore-${c.key}`}
-                  className="flex items-center gap-2 font-normal"
-                >
-                  {c.key}
-                  {c.network && (
-                    <span className="inline-flex items-center gap-1 text-xs text-amber-600">
-                      <AlertTriangle className="h-3 w-3" />
-                      network (may disconnect)
-                    </span>
-                  )}
-                </Label>
-              </div>
-            ))}
-          </div>
+          <>
+            {error && (
+              <p className="text-sm text-destructive">
+                Failed to load this backup: {handleApiError(error)}
+                {detail ? " Showing the components last loaded." : ""}
+              </p>
+            )}
+            <div className="max-h-72 overflow-y-auto space-y-2">
+              {componentTypes.map((c) => (
+                <div key={c.key} className="flex items-center gap-2">
+                  <Checkbox
+                    id={`restore-${c.key}`}
+                    checked={effectiveSelected.has(c.key)}
+                    onCheckedChange={() => toggle(c.key)}
+                  />
+                  <Label
+                    htmlFor={`restore-${c.key}`}
+                    className="flex items-center gap-2 font-normal"
+                  >
+                    {c.key}
+                    {c.network && (
+                      <span className="inline-flex items-center gap-1 text-xs text-amber-600">
+                        <AlertTriangle className="h-3 w-3" />
+                        network (may disconnect)
+                      </span>
+                    )}
+                  </Label>
+                </div>
+              ))}
+            </div>
+          </>
         )}
 
         <div className="flex items-center gap-2 pt-2">
@@ -312,5 +321,15 @@ function RestoreDialog({
         </DialogFooter>
       </DialogContent>
     </Dialog>
+  );
+}
+
+// Either signal is enough to treat a component as network: an entry can reach
+// the store untyped, and a type the device spells differently would otherwise
+// win over the key and leave wifi selected for restore.
+function isNetworkComponent(key: string, type: string | null | undefined) {
+  const keyType = key.split(":")[0].toLowerCase();
+  return (
+    NETWORK_TYPES.has((type ?? "").toLowerCase()) || NETWORK_TYPES.has(keyType)
   );
 }

--- a/packages/web/src/components/device-detail/backups-section.tsx
+++ b/packages/web/src/components/device-detail/backups-section.tsx
@@ -235,10 +235,6 @@ function RestoreDialog({
   const { data: detail, isLoading } = useQuery({
     queryKey: queryKeys.backups.detail(backup.id),
     queryFn: () => backupApi.getBackup(backup.id),
-    // The app sets a global `enabled: false` default, so every query must opt
-    // in explicitly; without this the snapshot never loads and the restore
-    // dialog shows no components (Restore stays disabled).
-    enabled: true,
   });
 
   const componentTypes = useMemo(() => {

--- a/packages/web/src/components/device-detail/backups-section.tsx
+++ b/packages/web/src/components/device-detail/backups-section.tsx
@@ -47,10 +47,6 @@ interface BackupsSectionProps {
   deviceName: string | null;
 }
 
-interface SnapshotComponent {
-  type?: string;
-}
-
 export function BackupsSection({
   deviceIp,
   deviceMac,
@@ -108,7 +104,7 @@ export function BackupsSection({
           </p>
         ) : isLoading ? (
           <p className="text-sm text-muted-foreground">Loading backups...</p>
-        ) : error ? (
+        ) : error && items.length === 0 ? (
           <p className="text-sm text-destructive">
             Failed to load backups: {handleApiError(error)}
           </p>
@@ -207,17 +203,14 @@ function RestoreDialog({
   onClose: () => void;
 }) {
   const restore = useRestoreBackup();
-  const { data: detail, isLoading } = useBackup(backup.id);
+  const { data: detail, isLoading, error } = useBackup(backup.id);
 
   const componentTypes = useMemo(() => {
-    const components = (detail?.snapshot?.components ?? {}) as Record<
-      string,
-      SnapshotComponent
-    >;
+    const components = detail?.snapshot.components ?? {};
     return Object.entries(components).map(([key, value]) => ({
       key,
-      type: value?.type ?? "",
-      network: NETWORK_TYPES.has(value?.type ?? ""),
+      type: value.type ?? "",
+      network: NETWORK_TYPES.has(value.type ?? ""),
     }));
   }, [detail]);
 
@@ -265,6 +258,10 @@ function RestoreDialog({
 
         {isLoading ? (
           <p className="text-sm text-muted-foreground">Loading components...</p>
+        ) : error ? (
+          <p className="text-sm text-destructive">
+            Failed to load this backup: {handleApiError(error)}
+          </p>
         ) : (
           <div className="max-h-72 overflow-y-auto space-y-2">
             {componentTypes.map((c) => (

--- a/packages/web/src/components/device-detail/backups-section.tsx
+++ b/packages/web/src/components/device-detail/backups-section.tsx
@@ -29,6 +29,7 @@ import {
 import { Checkbox } from "@/components/ui/checkbox";
 import { Label } from "@/components/ui/label";
 import { backupApi } from "@/lib/api";
+import { queryKeys } from "@/lib/query-keys";
 import {
   useBackups,
   useCreateBackup,
@@ -232,7 +233,7 @@ function RestoreDialog({
 }) {
   const restore = useRestoreBackup();
   const { data: detail, isLoading } = useQuery({
-    queryKey: ["backup", backup.id],
+    queryKey: queryKeys.backups.detail(backup.id),
     queryFn: () => backupApi.getBackup(backup.id),
     // The app sets a global `enabled: false` default, so every query must opt
     // in explicitly; without this the snapshot never loads and the restore

--- a/packages/web/src/components/device-detail/backups-section.tsx
+++ b/packages/web/src/components/device-detail/backups-section.tsx
@@ -1,5 +1,4 @@
 import { useEffect, useMemo, useState } from "react";
-import { useQuery } from "@tanstack/react-query";
 import { Save, RotateCcw, Trash2, AlertTriangle } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
@@ -28,9 +27,8 @@ import {
 } from "@/components/ui/dialog";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Label } from "@/components/ui/label";
-import { backupApi } from "@/lib/api";
-import { queryKeys } from "@/lib/query-keys";
 import {
+  useBackup,
   useBackups,
   useCreateBackup,
   useDeleteBackup,
@@ -232,10 +230,7 @@ function RestoreDialog({
   onClose: () => void;
 }) {
   const restore = useRestoreBackup();
-  const { data: detail, isLoading } = useQuery({
-    queryKey: queryKeys.backups.detail(backup.id),
-    queryFn: () => backupApi.getBackup(backup.id),
-  });
+  const { data: detail, isLoading } = useBackup(backup.id);
 
   const componentTypes = useMemo(() => {
     const components = (detail?.snapshot?.components ?? {}) as Record<

--- a/packages/web/src/components/provisioning/profiles-section.tsx
+++ b/packages/web/src/components/provisioning/profiles-section.tsx
@@ -130,7 +130,6 @@ export function ProfilesSection() {
   } = useQuery({
     queryKey: queryKeys.provisioning.profiles(),
     queryFn: provisioningApi.listProfiles,
-    enabled: true,
   });
 
   const createMutation = useMutation({

--- a/packages/web/src/components/provisioning/profiles-section.tsx
+++ b/packages/web/src/components/provisioning/profiles-section.tsx
@@ -34,6 +34,7 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import { provisioningApi, handleApiError } from "@/lib/api";
+import { queryKeys } from "@/lib/query-keys";
 import type {
   CreateProvisioningProfileRequest,
   UpdateProvisioningProfileRequest,
@@ -127,7 +128,7 @@ export function ProfilesSection() {
     isLoading,
     error,
   } = useQuery({
-    queryKey: ["provisioning", "profiles"],
+    queryKey: queryKeys.provisioning.profiles(),
     queryFn: provisioningApi.listProfiles,
     enabled: true,
   });
@@ -137,7 +138,7 @@ export function ProfilesSection() {
       provisioningApi.createProfile(data),
     onSuccess: () => {
       queryClient.invalidateQueries({
-        queryKey: ["provisioning", "profiles"],
+        queryKey: queryKeys.provisioning.profiles(),
       });
       toast.success(t("provisioning.profiles.created"));
       setCreateOpen(false);
@@ -156,7 +157,7 @@ export function ProfilesSection() {
     }) => provisioningApi.updateProfile(id, data),
     onSuccess: () => {
       queryClient.invalidateQueries({
-        queryKey: ["provisioning", "profiles"],
+        queryKey: queryKeys.provisioning.profiles(),
       });
       toast.success(t("provisioning.editDialog.updated"));
       setEditOpen(false);
@@ -169,7 +170,7 @@ export function ProfilesSection() {
     mutationFn: provisioningApi.deleteProfile,
     onSuccess: () => {
       queryClient.invalidateQueries({
-        queryKey: ["provisioning", "profiles"],
+        queryKey: queryKeys.provisioning.profiles(),
       });
       toast.success(t("provisioning.profiles.deleted"));
     },
@@ -180,7 +181,7 @@ export function ProfilesSection() {
     mutationFn: provisioningApi.setDefaultProfile,
     onSuccess: () => {
       queryClient.invalidateQueries({
-        queryKey: ["provisioning", "profiles"],
+        queryKey: queryKeys.provisioning.profiles(),
       });
       toast.success(t("provisioning.profiles.defaultUpdated"));
     },

--- a/packages/web/src/components/provisioning/profiles-section.tsx
+++ b/packages/web/src/components/provisioning/profiles-section.tsx
@@ -1,10 +1,8 @@
 import { useState } from "react";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
-import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { useTranslation } from "react-i18next";
 import { Wifi, Plus, Trash2, Star, Loader2, Pencil } from "lucide-react";
-import { toast } from "sonner";
 
 import { Button } from "@/components/ui/button";
 import {
@@ -33,8 +31,14 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
-import { provisioningApi, handleApiError } from "@/lib/api";
-import { queryKeys } from "@/lib/query-keys";
+import { handleApiError } from "@/lib/api";
+import {
+  useCreateProvisioningProfile,
+  useDeleteProvisioningProfile,
+  useProvisioningProfiles,
+  useSetDefaultProvisioningProfile,
+  useUpdateProvisioningProfile,
+} from "@/hooks/useProvisioning";
 import type {
   CreateProvisioningProfileRequest,
   UpdateProvisioningProfileRequest,
@@ -107,7 +111,6 @@ function profileToFormData(profile: ProvisioningProfile): ProfileFormData {
 
 export function ProfilesSection() {
   const { t } = useTranslation();
-  const queryClient = useQueryClient();
   const [createOpen, setCreateOpen] = useState(false);
   const [editOpen, setEditOpen] = useState(false);
   const [editingProfile, setEditingProfile] =
@@ -123,72 +126,20 @@ export function ProfilesSection() {
     defaultValues: defaultProfileFormValues,
   });
 
-  const {
-    data: profiles,
-    isLoading,
-    error,
-  } = useQuery({
-    queryKey: queryKeys.provisioning.profiles(),
-    queryFn: provisioningApi.listProfiles,
-  });
+  const { data: profiles, isLoading, error } = useProvisioningProfiles();
 
-  const createMutation = useMutation({
-    mutationFn: (data: CreateProvisioningProfileRequest) =>
-      provisioningApi.createProfile(data),
-    onSuccess: () => {
-      queryClient.invalidateQueries({
-        queryKey: queryKeys.provisioning.profiles(),
-      });
-      toast.success(t("provisioning.profiles.created"));
-      setCreateOpen(false);
-      createForm.reset(defaultProfileFormValues);
-    },
-    onError: (err) => toast.error(handleApiError(err)),
-  });
-
-  const updateMutation = useMutation({
-    mutationFn: ({
-      id,
-      data,
-    }: {
-      id: number;
-      data: UpdateProvisioningProfileRequest;
-    }) => provisioningApi.updateProfile(id, data),
-    onSuccess: () => {
-      queryClient.invalidateQueries({
-        queryKey: queryKeys.provisioning.profiles(),
-      });
-      toast.success(t("provisioning.editDialog.updated"));
-      setEditOpen(false);
-      setEditingProfile(null);
-    },
-    onError: (err) => toast.error(handleApiError(err)),
-  });
-
-  const deleteMutation = useMutation({
-    mutationFn: provisioningApi.deleteProfile,
-    onSuccess: () => {
-      queryClient.invalidateQueries({
-        queryKey: queryKeys.provisioning.profiles(),
-      });
-      toast.success(t("provisioning.profiles.deleted"));
-    },
-    onError: (err) => toast.error(handleApiError(err)),
-  });
-
-  const setDefaultMutation = useMutation({
-    mutationFn: provisioningApi.setDefaultProfile,
-    onSuccess: () => {
-      queryClient.invalidateQueries({
-        queryKey: queryKeys.provisioning.profiles(),
-      });
-      toast.success(t("provisioning.profiles.defaultUpdated"));
-    },
-    onError: (err) => toast.error(handleApiError(err)),
-  });
+  const createMutation = useCreateProvisioningProfile();
+  const updateMutation = useUpdateProvisioningProfile();
+  const deleteMutation = useDeleteProvisioningProfile();
+  const setDefaultMutation = useSetDefaultProvisioningProfile();
 
   const handleCreate = (data: ProfileFormData) => {
-    createMutation.mutate(formDataToCreateRequest(data));
+    createMutation.mutate(formDataToCreateRequest(data), {
+      onSuccess: () => {
+        setCreateOpen(false);
+        createForm.reset(defaultProfileFormValues);
+      },
+    });
   };
 
   const handleEdit = (profile: ProvisioningProfile) => {
@@ -199,10 +150,15 @@ export function ProfilesSection() {
 
   const handleUpdate = (data: ProfileFormData) => {
     if (!editingProfile) return;
-    updateMutation.mutate({
-      id: editingProfile.id,
-      data: formDataToUpdateRequest(data),
-    });
+    updateMutation.mutate(
+      { id: editingProfile.id, data: formDataToUpdateRequest(data) },
+      {
+        onSuccess: () => {
+          setEditOpen(false);
+          setEditingProfile(null);
+        },
+      },
+    );
   };
 
   return (

--- a/packages/web/src/components/provisioning/provision-device-section.tsx
+++ b/packages/web/src/components/provisioning/provision-device-section.tsx
@@ -1,5 +1,4 @@
 import { useState } from "react";
-import { useQuery, useMutation } from "@tanstack/react-query";
 import { useTranslation } from "react-i18next";
 import {
   Search,
@@ -9,8 +8,6 @@ import {
   Loader2,
   Radio,
 } from "lucide-react";
-import { toast } from "sonner";
-
 import { Button } from "@/components/ui/button";
 import {
   Card,
@@ -28,8 +25,12 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import { provisioningApi, handleApiError } from "@/lib/api";
-import { queryKeys } from "@/lib/query-keys";
+import {
+  useDetectDevice,
+  useProvisionDevice,
+  useProvisioningProfiles,
+  useVerifyProvision,
+} from "@/hooks/useProvisioning";
 import type { APDeviceInfo, ProvisionResult } from "@/types/api";
 
 export function ProvisionDeviceSection() {
@@ -45,65 +46,38 @@ export function ProvisionDeviceSection() {
     useState<ProvisionResult | null>(null);
   const [verifyTargets, setVerifyTargets] = useState("");
 
-  const { data: profiles } = useQuery({
-    queryKey: queryKeys.provisioning.profiles(),
-    queryFn: provisioningApi.listProfiles,
-  });
+  const { data: profiles } = useProvisioningProfiles();
 
-  const detectMutation = useMutation({
-    mutationFn: () => provisioningApi.detectDevice(deviceIp),
-    onSuccess: (info) => {
-      setDetectedDevice(info);
-      setProvisionResult(null);
-      toast.success(
-        t("provisioning.provision.detect.success", {
-          app: info.app || info.model,
-          generation: info.generation,
-        }),
-      );
-    },
-    onError: (err) => {
-      setDetectedDevice(null);
-      toast.error(handleApiError(err));
-    },
-  });
+  const detectMutation = useDetectDevice();
+  const provisionMutation = useProvisionDevice();
+  const verifyMutation = useVerifyProvision();
 
-  const provisionMutation = useMutation({
-    mutationFn: () => {
-      const profileId = selectedProfileId
-        ? Number(selectedProfileId)
-        : undefined;
-      return provisioningApi.provisionDevice(deviceIp, profileId);
-    },
-    onSuccess: (result) => {
-      setProvisionResult(result);
-      if (result.success) {
-        toast.success(t("provisioning.messages.provisionSuccess"));
-      } else {
-        toast.error(result.error || t("provisioning.messages.provisionFailed"));
-      }
-    },
-    onError: (err) => toast.error(handleApiError(err)),
-  });
+  const handleDetect = () => {
+    detectMutation.mutate(deviceIp, {
+      onSuccess: (info) => {
+        setDetectedDevice(info);
+        setProvisionResult(null);
+      },
+      onError: () => setDetectedDevice(null),
+    });
+  };
 
-  const verifyMutation = useMutation({
-    mutationFn: () =>
-      provisioningApi.verifyProvision(provisionResult?.device_mac || "", [
-        verifyTargets,
-      ]),
-    onSuccess: (result) => {
-      if (result.found) {
-        toast.success(
-          t("provisioning.provision.verify.found", {
-            ip: result.device_ip,
-          }),
-        );
-      } else {
-        toast.error(t("provisioning.provision.verify.notFound"));
-      }
-    },
-    onError: (err) => toast.error(handleApiError(err)),
-  });
+  const handleProvision = () => {
+    provisionMutation.mutate(
+      {
+        deviceIp,
+        profileId: selectedProfileId ? Number(selectedProfileId) : undefined,
+      },
+      { onSuccess: setProvisionResult },
+    );
+  };
+
+  const handleVerify = () => {
+    verifyMutation.mutate({
+      deviceMac: provisionResult?.device_mac || "",
+      scanTargets: [verifyTargets],
+    });
+  };
 
   const defaultProfile = profiles?.find((p) => p.is_default);
 
@@ -134,10 +108,7 @@ export function ProvisionDeviceSection() {
               placeholder={t("provisioning.provision.detect.ipPlaceholder")}
               className="max-w-xs font-mono"
             />
-            <Button
-              onClick={() => detectMutation.mutate()}
-              disabled={detectMutation.isPending}
-            >
+            <Button onClick={handleDetect} disabled={detectMutation.isPending}>
               {detectMutation.isPending ? (
                 <Loader2 className="h-4 w-4 mr-1 animate-spin" />
               ) : (
@@ -229,7 +200,7 @@ export function ProvisionDeviceSection() {
               </Select>
             </div>
             <Button
-              onClick={() => provisionMutation.mutate()}
+              onClick={handleProvision}
               disabled={provisionMutation.isPending}
             >
               {provisionMutation.isPending ? (
@@ -321,7 +292,7 @@ export function ProvisionDeviceSection() {
                     className="max-w-xs font-mono"
                   />
                   <Button
-                    onClick={() => verifyMutation.mutate()}
+                    onClick={handleVerify}
                     disabled={verifyMutation.isPending || !verifyTargets}
                     variant="outline"
                   >

--- a/packages/web/src/components/provisioning/provision-device-section.tsx
+++ b/packages/web/src/components/provisioning/provision-device-section.tsx
@@ -29,6 +29,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { provisioningApi, handleApiError } from "@/lib/api";
+import { queryKeys } from "@/lib/query-keys";
 import type { APDeviceInfo, ProvisionResult } from "@/types/api";
 
 export function ProvisionDeviceSection() {
@@ -45,7 +46,7 @@ export function ProvisionDeviceSection() {
   const [verifyTargets, setVerifyTargets] = useState("");
 
   const { data: profiles } = useQuery({
-    queryKey: ["provisioning", "profiles"],
+    queryKey: queryKeys.provisioning.profiles(),
     queryFn: provisioningApi.listProfiles,
     enabled: true,
   });

--- a/packages/web/src/components/provisioning/provision-device-section.tsx
+++ b/packages/web/src/components/provisioning/provision-device-section.tsx
@@ -48,7 +48,6 @@ export function ProvisionDeviceSection() {
   const { data: profiles } = useQuery({
     queryKey: queryKeys.provisioning.profiles(),
     queryFn: provisioningApi.listProfiles,
-    enabled: true,
   });
 
   const detectMutation = useMutation({

--- a/packages/web/src/components/shared/offset-pager.tsx
+++ b/packages/web/src/components/shared/offset-pager.tsx
@@ -1,0 +1,49 @@
+import type { Dispatch, SetStateAction } from "react";
+
+import { Button } from "@/components/ui/button";
+import { PAGE_SIZE } from "@/hooks/useOffsetPagination";
+
+interface OffsetPagerProps {
+  offset: number;
+  itemCount: number;
+  total: number;
+  onOffsetChange: Dispatch<SetStateAction<number>>;
+}
+
+export function OffsetPager({
+  offset,
+  itemCount,
+  total,
+  onOffsetChange,
+}: OffsetPagerProps) {
+  const rangeStart = total === 0 ? 0 : offset + 1;
+  const rangeEnd = offset + itemCount;
+
+  return (
+    <div className="flex items-center justify-between pt-4">
+      <p className="text-sm text-muted-foreground">
+        Showing {rangeStart}–{rangeEnd} of {total}
+      </p>
+      <div className="space-x-2">
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={() =>
+            onOffsetChange((current) => Math.max(0, current - PAGE_SIZE))
+          }
+          disabled={offset <= 0}
+        >
+          Previous
+        </Button>
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={() => onOffsetChange((current) => current + PAGE_SIZE)}
+          disabled={offset + PAGE_SIZE >= total}
+        >
+          Next
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/packages/web/src/hooks/useBackupSchedules.ts
+++ b/packages/web/src/hooks/useBackupSchedules.ts
@@ -14,7 +14,6 @@ export function useBackupSchedules() {
   return useQuery({
     queryKey: QUERY_KEY,
     queryFn: backupScheduleApi.listSchedules,
-    enabled: true,
   });
 }
 

--- a/packages/web/src/hooks/useBackupSchedules.ts
+++ b/packages/web/src/hooks/useBackupSchedules.ts
@@ -2,12 +2,13 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 
 import { backupScheduleApi, handleApiError } from "@/lib/api";
+import { queryKeys } from "@/lib/query-keys";
 import type {
   CreateBackupScheduleRequest,
   UpdateBackupScheduleRequest,
 } from "@/types/api";
 
-const QUERY_KEY = ["backup-schedules"];
+const QUERY_KEY = queryKeys.backupSchedules.all();
 
 export function useBackupSchedules() {
   return useQuery({

--- a/packages/web/src/hooks/useBackups.ts
+++ b/packages/web/src/hooks/useBackups.ts
@@ -2,6 +2,7 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 
 import { backupApi, handleApiError } from "@/lib/api";
+import { queryKeys } from "@/lib/query-keys";
 import type { RestoreBackupRequest } from "@/types/api";
 
 export function useBackups(
@@ -11,7 +12,11 @@ export function useBackups(
   const limit = options?.limit ?? 50;
   const offset = options?.offset ?? 0;
   return useQuery({
-    queryKey: ["backups", deviceMac, limit, offset],
+    queryKey: queryKeys.backups.list({
+      deviceMac: deviceMac ?? undefined,
+      limit,
+      offset,
+    }),
     queryFn: () =>
       backupApi.listBackups({
         deviceMac: deviceMac ?? undefined,
@@ -29,7 +34,7 @@ export function useCreateBackup() {
       backupApi.createBackup({ device_ip: params.deviceIp, name: params.name }),
     onSuccess: (backup) => {
       toast.success(`Backup #${backup.id} created`);
-      queryClient.invalidateQueries({ queryKey: ["backups"] });
+      queryClient.invalidateQueries({ queryKey: queryKeys.backups.all() });
     },
     onError: (error) => toast.error(handleApiError(error)),
   });
@@ -39,10 +44,9 @@ export function useDeleteBackup() {
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: (backupId: number) => backupApi.deleteBackup(backupId),
-    onSuccess: (_data, backupId) => {
+    onSuccess: () => {
       toast.success("Backup deleted");
-      queryClient.removeQueries({ queryKey: ["backup", backupId] });
-      queryClient.invalidateQueries({ queryKey: ["backups"] });
+      queryClient.invalidateQueries({ queryKey: queryKeys.backups.all() });
     },
     onError: (error) => toast.error(handleApiError(error)),
   });

--- a/packages/web/src/hooks/useBackups.ts
+++ b/packages/web/src/hooks/useBackups.ts
@@ -5,25 +5,40 @@ import { backupApi, handleApiError } from "@/lib/api";
 import { queryKeys } from "@/lib/query-keys";
 import type { RestoreBackupRequest } from "@/types/api";
 
+interface BackupPageOptions {
+  limit?: number;
+  offset?: number;
+}
+
 export function useBackups(
   deviceMac: string | null | undefined,
-  options?: { limit?: number; offset?: number },
+  options?: BackupPageOptions,
 ) {
-  const limit = options?.limit ?? 50;
-  const offset = options?.offset ?? 0;
+  const page = pageOf(options);
   return useQuery({
     queryKey: queryKeys.backups.list({
-      deviceMac: deviceMac ?? undefined,
-      limit,
-      offset,
+      scope: "device",
+      deviceMac: deviceMac ?? null,
+      ...page,
     }),
     queryFn: () =>
-      backupApi.listBackups({
-        deviceMac: deviceMac ?? undefined,
-        limit,
-        offset,
-      }),
+      backupApi.listBackups({ deviceMac: deviceMac ?? undefined, ...page }),
     enabled: !!deviceMac,
+  });
+}
+
+export function useAllBackups(options?: BackupPageOptions) {
+  const page = pageOf(options);
+  return useQuery({
+    queryKey: queryKeys.backups.list({ scope: "all", ...page }),
+    queryFn: () => backupApi.listBackups(page),
+  });
+}
+
+export function useBackup(backupId: number) {
+  return useQuery({
+    queryKey: queryKeys.backups.detail(backupId),
+    queryFn: () => backupApi.getBackup(backupId),
   });
 }
 
@@ -44,8 +59,11 @@ export function useDeleteBackup() {
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: (backupId: number) => backupApi.deleteBackup(backupId),
-    onSuccess: () => {
+    onSuccess: (_data, backupId) => {
       toast.success("Backup deleted");
+      queryClient.removeQueries({
+        queryKey: queryKeys.backups.detail(backupId),
+      });
       queryClient.invalidateQueries({ queryKey: queryKeys.backups.all() });
     },
     onError: (error) => toast.error(handleApiError(error)),
@@ -66,4 +84,11 @@ export function useRestoreBackup() {
     },
     onError: (error) => toast.error(handleApiError(error)),
   });
+}
+
+function pageOf(options?: BackupPageOptions) {
+  return {
+    limit: options?.limit ?? 50,
+    offset: options?.offset ?? 0,
+  };
 }

--- a/packages/web/src/hooks/useComponentActions.ts
+++ b/packages/web/src/hooks/useComponentActions.ts
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 import { deviceApi } from "@/lib/api";
+import { queryKeys } from "@/lib/query-keys";
 import type { ComponentActionResult } from "@/types/api";
 
 export const LEGACY_PREFIX = "Legacy.";
@@ -95,7 +96,7 @@ export function useExecuteComponentAction(
         !GET_ACTIONS.some((getAction) => variables.action.includes(getAction))
       ) {
         queryClient.invalidateQueries({
-          queryKey: ["device", "status", variables.deviceIp],
+          queryKey: queryKeys.devices.status(variables.deviceIp),
         });
       }
 

--- a/packages/web/src/hooks/useCredentials.ts
+++ b/packages/web/src/hooks/useCredentials.ts
@@ -1,0 +1,41 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useTranslation } from "react-i18next";
+import { toast } from "sonner";
+
+import { credentialsApi, handleApiError } from "@/lib/api";
+import { queryKeys } from "@/lib/query-keys";
+
+export function useCredentials(options?: { enabled?: boolean }) {
+  return useQuery({
+    queryKey: queryKeys.credentials.all(),
+    queryFn: credentialsApi.listCredentials,
+    enabled: options?.enabled ?? true,
+    staleTime: 0,
+  });
+}
+
+export function useSetCredential() {
+  const { t } = useTranslation();
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: credentialsApi.setCredential,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.credentials.all() });
+      toast.success(t("common.success"));
+    },
+    onError: (error) => toast.error(handleApiError(error)),
+  });
+}
+
+export function useDeleteCredential() {
+  const { t } = useTranslation();
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: credentialsApi.deleteCredential,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.credentials.all() });
+      toast.success(t("common.success"));
+    },
+    onError: (error) => toast.error(handleApiError(error)),
+  });
+}

--- a/packages/web/src/hooks/useOffsetPagination.ts
+++ b/packages/web/src/hooks/useOffsetPagination.ts
@@ -1,0 +1,23 @@
+import { useEffect } from "react";
+import type { Dispatch, SetStateAction } from "react";
+
+export const PAGE_SIZE = 50;
+
+/**
+ * Step back a page once a page past the first turns out to be empty.
+ *
+ * Gated on a successful fetch: a transient error also yields zero items and
+ * would otherwise rewind pagination the user has not left.
+ */
+export function useRewindEmptyPage(
+  isSuccess: boolean,
+  itemCount: number,
+  offset: number,
+  setOffset: Dispatch<SetStateAction<number>>,
+) {
+  useEffect(() => {
+    if (isSuccess && itemCount === 0 && offset >= PAGE_SIZE) {
+      setOffset((current) => Math.max(0, current - PAGE_SIZE));
+    }
+  }, [isSuccess, itemCount, offset, setOffset]);
+}

--- a/packages/web/src/hooks/useOffsetPagination.ts
+++ b/packages/web/src/hooks/useOffsetPagination.ts
@@ -3,12 +3,6 @@ import type { Dispatch, SetStateAction } from "react";
 
 export const PAGE_SIZE = 50;
 
-/**
- * Step back a page once a page past the first turns out to be empty.
- *
- * Gated on a successful fetch: a transient error also yields zero items and
- * would otherwise rewind pagination the user has not left.
- */
 export function useRewindEmptyPage(
   isSuccess: boolean,
   itemCount: number,

--- a/packages/web/src/hooks/useProvisioning.ts
+++ b/packages/web/src/hooks/useProvisioning.ts
@@ -1,0 +1,130 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useTranslation } from "react-i18next";
+import { toast } from "sonner";
+
+import { provisioningApi, handleApiError } from "@/lib/api";
+import { queryKeys } from "@/lib/query-keys";
+import type {
+  CreateProvisioningProfileRequest,
+  UpdateProvisioningProfileRequest,
+} from "@/types/api";
+
+export function useProvisioningProfiles() {
+  return useQuery({
+    queryKey: queryKeys.provisioning.profiles(),
+    queryFn: provisioningApi.listProfiles,
+  });
+}
+
+export function useCreateProvisioningProfile() {
+  const { t } = useTranslation();
+  const invalidateProfiles = useProfileInvalidation();
+  return useMutation({
+    mutationFn: (data: CreateProvisioningProfileRequest) =>
+      provisioningApi.createProfile(data),
+    onSuccess: () => {
+      invalidateProfiles();
+      toast.success(t("provisioning.profiles.created"));
+    },
+    onError: (error) => toast.error(handleApiError(error)),
+  });
+}
+
+export function useUpdateProvisioningProfile() {
+  const { t } = useTranslation();
+  const invalidateProfiles = useProfileInvalidation();
+  return useMutation({
+    mutationFn: (params: {
+      id: number;
+      data: UpdateProvisioningProfileRequest;
+    }) => provisioningApi.updateProfile(params.id, params.data),
+    onSuccess: () => {
+      invalidateProfiles();
+      toast.success(t("provisioning.editDialog.updated"));
+    },
+    onError: (error) => toast.error(handleApiError(error)),
+  });
+}
+
+export function useDeleteProvisioningProfile() {
+  const { t } = useTranslation();
+  const invalidateProfiles = useProfileInvalidation();
+  return useMutation({
+    mutationFn: provisioningApi.deleteProfile,
+    onSuccess: () => {
+      invalidateProfiles();
+      toast.success(t("provisioning.profiles.deleted"));
+    },
+    onError: (error) => toast.error(handleApiError(error)),
+  });
+}
+
+export function useSetDefaultProvisioningProfile() {
+  const { t } = useTranslation();
+  const invalidateProfiles = useProfileInvalidation();
+  return useMutation({
+    mutationFn: provisioningApi.setDefaultProfile,
+    onSuccess: () => {
+      invalidateProfiles();
+      toast.success(t("provisioning.profiles.defaultUpdated"));
+    },
+    onError: (error) => toast.error(handleApiError(error)),
+  });
+}
+
+export function useDetectDevice() {
+  const { t } = useTranslation();
+  return useMutation({
+    mutationFn: (deviceIp: string) => provisioningApi.detectDevice(deviceIp),
+    onSuccess: (info) =>
+      toast.success(
+        t("provisioning.provision.detect.success", {
+          app: info.app || info.model,
+          generation: info.generation,
+        }),
+      ),
+    onError: (error) => toast.error(handleApiError(error)),
+  });
+}
+
+export function useProvisionDevice() {
+  const { t } = useTranslation();
+  return useMutation({
+    mutationFn: (params: { deviceIp: string; profileId?: number }) =>
+      provisioningApi.provisionDevice(params.deviceIp, params.profileId),
+    onSuccess: (result) => {
+      if (result.success) {
+        toast.success(t("provisioning.messages.provisionSuccess"));
+      } else {
+        toast.error(result.error || t("provisioning.messages.provisionFailed"));
+      }
+    },
+    onError: (error) => toast.error(handleApiError(error)),
+  });
+}
+
+export function useVerifyProvision() {
+  const { t } = useTranslation();
+  return useMutation({
+    mutationFn: (params: { deviceMac: string; scanTargets: string[] }) =>
+      provisioningApi.verifyProvision(params.deviceMac, params.scanTargets),
+    onSuccess: (result) => {
+      if (result.found) {
+        toast.success(
+          t("provisioning.provision.verify.found", { ip: result.device_ip }),
+        );
+      } else {
+        toast.error(t("provisioning.provision.verify.notFound"));
+      }
+    },
+    onError: (error) => toast.error(handleApiError(error)),
+  });
+}
+
+function useProfileInvalidation() {
+  const queryClient = useQueryClient();
+  return () =>
+    queryClient.invalidateQueries({
+      queryKey: queryKeys.provisioning.profiles(),
+    });
+}

--- a/packages/web/src/hooks/useScannedDevices.ts
+++ b/packages/web/src/hooks/useScannedDevices.ts
@@ -1,17 +1,18 @@
 import { useQuery } from "@tanstack/react-query";
 
+import { queryKeys } from "@/lib/query-keys";
 import { loadScanResults } from "@/lib/storage";
 import type { Device } from "@/types/api";
 
 /**
  * Read the devices from the most recent network scan.
  *
- * Shares the ["devices", "scan"] query key with the dashboard, so it reflects
- * whatever was last scanned (and never triggers a scan of its own).
+ * Shares the scan query key with the dashboard, so it reflects whatever was
+ * last scanned (and never triggers a scan of its own).
  */
 export function useScannedDevices() {
   return useQuery<Device[]>({
-    queryKey: ["devices", "scan"],
+    queryKey: queryKeys.devices.scan(),
     queryFn: () => {
       const cached = loadScanResults();
       return cached ? cached.devices : [];

--- a/packages/web/src/hooks/useScannedDevices.ts
+++ b/packages/web/src/hooks/useScannedDevices.ts
@@ -1,14 +1,21 @@
-import { useQuery } from "@tanstack/react-query";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useTranslation } from "react-i18next";
+import { toast } from "sonner";
 
+import { deviceApi, handleApiError } from "@/lib/api";
 import { queryKeys } from "@/lib/query-keys";
-import { loadScanResults } from "@/lib/storage";
-import type { Device } from "@/types/api";
+import {
+  clearScanResults,
+  loadScanResults,
+  saveScanResults,
+} from "@/lib/storage";
+import type { Device, ScanRequest } from "@/types/api";
 
 /**
  * Read the devices from the most recent network scan.
  *
- * Shares the scan query key with the dashboard, so it reflects whatever was
- * last scanned (and never triggers a scan of its own).
+ * Shares the scan query key with the scan mutation, so it reflects whatever
+ * was last scanned (and never triggers a scan of its own).
  */
 export function useScannedDevices() {
   return useQuery<Device[]>({
@@ -19,5 +26,31 @@ export function useScannedDevices() {
     },
     staleTime: Infinity,
     gcTime: Infinity,
+  });
+}
+
+/**
+ * Scan the network and make the result the cached scan.
+ *
+ * The previous results are dropped before the request rather than after, so a
+ * scan that fails leaves nothing stale behind claiming to be current.
+ */
+export function useScanDevices() {
+  const { t } = useTranslation();
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (params: ScanRequest) => {
+      clearScanResults();
+      queryClient.removeQueries({ queryKey: queryKeys.devices.scan() });
+      return deviceApi.scanDevices(params);
+    },
+    onSuccess: (devices, params) => {
+      saveScanResults(devices, params);
+      queryClient.setQueryData(queryKeys.devices.scan(), devices);
+      toast.success(
+        t("dashboard.messages.scanSuccess", { count: devices.length }),
+      );
+    },
+    onError: (error) => toast.error(handleApiError(error)),
   });
 }

--- a/packages/web/src/hooks/useScannedDevices.ts
+++ b/packages/web/src/hooks/useScannedDevices.ts
@@ -11,12 +11,6 @@ import {
 } from "@/lib/storage";
 import type { Device, ScanRequest } from "@/types/api";
 
-/**
- * Read the devices from the most recent network scan.
- *
- * Shares the scan query key with the scan mutation, so it reflects whatever
- * was last scanned (and never triggers a scan of its own).
- */
 export function useScannedDevices() {
   return useQuery<Device[]>({
     queryKey: queryKeys.devices.scan(),
@@ -29,12 +23,6 @@ export function useScannedDevices() {
   });
 }
 
-/**
- * Scan the network and make the result the cached scan.
- *
- * The previous results are dropped before the request rather than after, so a
- * scan that fails leaves nothing stale behind claiming to be current.
- */
 export function useScanDevices() {
   const { t } = useTranslation();
   const queryClient = useQueryClient();

--- a/packages/web/src/hooks/useScannedDevices.ts
+++ b/packages/web/src/hooks/useScannedDevices.ts
@@ -19,6 +19,5 @@ export function useScannedDevices() {
     },
     staleTime: Infinity,
     gcTime: Infinity,
-    enabled: true,
   });
 }

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -25,6 +25,12 @@ import type {
   ScheduleRunResult,
 } from "@/types/api";
 import { loadAppSettings } from "./settings";
+import { parseResponse } from "./schemas/parse";
+import {
+  backupDetailSchema,
+  paginatedBackupsSchema,
+  restoreResultSchema,
+} from "./schemas/backups";
 
 declare global {
   interface Window {
@@ -358,17 +364,21 @@ export const backupApi = {
         ...(params?.offset !== undefined ? { offset: params.offset } : {}),
       },
     });
-    return response.data;
+    return parseResponse(paginatedBackupsSchema, response.data, "GET /backups");
   },
 
   getBackup: async (backupId: number): Promise<BackupDetail> => {
     const response = await apiClient.get(`/backups/${backupId}`);
-    return response.data;
+    return parseResponse(
+      backupDetailSchema,
+      response.data,
+      `GET /backups/${backupId}`,
+    );
   },
 
   createBackup: async (data: CreateBackupRequest): Promise<BackupDetail> => {
     const response = await apiClient.post("/backups", data, { timeout: 60000 });
-    return response.data;
+    return parseResponse(backupDetailSchema, response.data, "POST /backups");
   },
 
   restoreBackup: async (
@@ -382,7 +392,11 @@ export const backupApi = {
         timeout: 60000,
       },
     );
-    return response.data;
+    return parseResponse(
+      restoreResultSchema,
+      response.data,
+      `POST /backups/${backupId}/restore`,
+    );
   },
 
   deleteBackup: async (backupId: number): Promise<void> => {

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -34,16 +34,15 @@ declare global {
   }
 }
 
-const getApiBaseUrl = (): string => {
-  const savedApiUrl = localStorage.getItem("shelly-manager-api-url");
+export const API_URL_STORAGE_KEY = "shelly-manager-api-url";
 
-  const runtimeApiUrl = window._env_?.VITE_BASE_API_URL;
-  const buildTimeApiUrl = import.meta.env.VITE_BASE_API_URL;
+export const getDefaultApiBaseUrl = (): string =>
+  window._env_?.VITE_BASE_API_URL ||
+  import.meta.env.VITE_BASE_API_URL ||
+  "http://localhost:8000";
 
-  return (
-    savedApiUrl || runtimeApiUrl || buildTimeApiUrl || "http://localhost:8000"
-  );
-};
+const getApiBaseUrl = (): string =>
+  localStorage.getItem(API_URL_STORAGE_KEY) || getDefaultApiBaseUrl();
 
 const baseURL = getApiBaseUrl();
 
@@ -430,6 +429,33 @@ export const backupScheduleApi = {
     );
     return response.data;
   },
+};
+
+export const healthApi = {
+  check: async (baseUrl: string): Promise<{ status?: string }> => {
+    const sanitizedUrl = baseUrl.replace(/\/+$/, "");
+    const response = await axios.get(`${sanitizedUrl}/api/health`, {
+      headers: { "Content-Type": "application/json" },
+      timeout: 5000,
+    });
+    // Axios leaves an unparseable body as a string rather than throwing, so a
+    // server answering 200 with a login page would otherwise read as healthy.
+    if (
+      typeof response.data !== "object" ||
+      response.data === null ||
+      Array.isArray(response.data)
+    ) {
+      throw new Error("the response was not a health payload");
+    }
+    return response.data;
+  },
+};
+
+export const describeConnectionFailure = (error: unknown): string => {
+  if (axios.isAxiosError(error) && error.response) {
+    return `HTTP ${error.response.status}: ${error.response.statusText}`;
+  }
+  return `Connection failed: ${handleApiError(error)}`;
 };
 
 export const handleApiError = (error: unknown): string => {

--- a/packages/web/src/lib/query-client.ts
+++ b/packages/web/src/lib/query-client.ts
@@ -21,7 +21,6 @@ export const queryClient = new QueryClient({
       retry: 2,
       staleTime: 5 * 60 * 1000,
       gcTime: 1000 * 60 * 60 * 24, // 24 hours for persistence
-      enabled: false,
     },
     mutations: {
       retry: 0,

--- a/packages/web/src/lib/query-keys.ts
+++ b/packages/web/src/lib/query-keys.ts
@@ -1,8 +1,10 @@
-export interface BackupListFilters {
-  deviceMac?: string;
-  limit: number;
-  offset: number;
-}
+// The scope is spelled out because key hashing drops undefined values, so a
+// device list still waiting for its MAC would otherwise share a cache entry
+// with the list of every device's backups.
+export type BackupListFilters = { limit: number; offset: number } & (
+  | { scope: "all" }
+  | { scope: "device"; deviceMac: string | null }
+);
 
 export const queryKeys = {
   devices: {

--- a/packages/web/src/lib/query-keys.ts
+++ b/packages/web/src/lib/query-keys.ts
@@ -1,0 +1,30 @@
+export interface BackupListFilters {
+  deviceMac?: string;
+  limit: number;
+  offset: number;
+}
+
+export const queryKeys = {
+  devices: {
+    scan: () => ["devices", "scan"] as const,
+    status: (ip: string | undefined) => ["devices", "status", ip] as const,
+  },
+  backups: {
+    all: () => ["backups"] as const,
+    lists: () => [...queryKeys.backups.all(), "list"] as const,
+    list: (filters: BackupListFilters) =>
+      [...queryKeys.backups.lists(), filters] as const,
+    details: () => [...queryKeys.backups.all(), "detail"] as const,
+    detail: (backupId: number) =>
+      [...queryKeys.backups.details(), backupId] as const,
+  },
+  backupSchedules: {
+    all: () => ["backup-schedules"] as const,
+  },
+  credentials: {
+    all: () => ["credentials"] as const,
+  },
+  provisioning: {
+    profiles: () => ["provisioning", "profiles"] as const,
+  },
+};

--- a/packages/web/src/lib/schemas/backups.ts
+++ b/packages/web/src/lib/schemas/backups.ts
@@ -1,0 +1,92 @@
+import { z } from "zod";
+
+const configBlobSchema = z.record(z.string(), z.unknown());
+
+// Each field degrades on its own so that a component whose payload cannot be
+// read keeps its type: the restore dialog leaves network components unchecked
+// by type, and a lost type would silently offer to overwrite wifi or cloud.
+export const componentSnapshotSchema = z
+  .object({
+    type: z.string().nullish().catch(null),
+    success: z.boolean().optional().catch(undefined),
+    config: configBlobSchema.nullish().catch(null),
+    error: z.string().nullish().catch(null),
+    code: configBlobSchema.nullish().catch(null),
+  })
+  .catch({});
+
+export const snapshotDeviceInfoSchema = z
+  .object({
+    device_name: z.string().nullish(),
+    device_type: z.string().nullish(),
+    firmware_version: z.string().nullish(),
+    mac_address: z.string().nullish(),
+    app_name: z.string().nullish(),
+  })
+  .catch({});
+
+export const deviceSnapshotSchema = z
+  .object({
+    device_info: snapshotDeviceInfoSchema.default({}),
+    components: z.record(z.string(), componentSnapshotSchema).default({}),
+  })
+  .catch({ device_info: {}, components: {} });
+
+export const backupSummarySchema = z.object({
+  id: z.number(),
+  device_mac: z.string(),
+  device_ip: z.string().nullable().default(null),
+  device_name: z.string().nullable().default(null),
+  device_type: z.string().nullable().default(null),
+  firmware_version: z.string().nullable().default(null),
+  generation: z.string().default("gen2"),
+  name: z.string().nullable().default(null),
+  source: z.string().default("manual"),
+  sha256: z.string().nullable().default(null),
+  size_bytes: z.number().default(0),
+  created_at: z.number().nullable().default(null),
+});
+
+export const backupDetailSchema = backupSummarySchema.extend({
+  snapshot: deviceSnapshotSchema.default({ device_info: {}, components: {} }),
+});
+
+// items and total are required: the API always sends them, and defaulting
+// them would turn any unrelated JSON body into a convincing empty page.
+export const paginatedBackupsSchema = z.object({
+  items: z.array(backupSummarySchema),
+  total: z.number(),
+  limit: z.number().default(50),
+  offset: z.number().default(0),
+});
+
+export const componentRestoreResultSchema = z.object({
+  key: z.string(),
+  action: z.string(),
+  success: z.boolean(),
+  skipped: z.boolean().default(false),
+  skipped_reason: z.string().nullable().default(null),
+  error: z.string().nullable().default(null),
+});
+
+export const restoreResultSchema = z.object({
+  success: z.boolean(),
+  device_ip: z.string(),
+  backup_id: z.number(),
+  total: z.number(),
+  succeeded: z.number().default(0),
+  failed: z.number().default(0),
+  skipped: z.number().default(0),
+  message: z.string().nullable().default(null),
+  components: z.array(componentRestoreResultSchema).default([]),
+});
+
+export type ComponentSnapshot = z.infer<typeof componentSnapshotSchema>;
+export type DeviceSnapshot = z.infer<typeof deviceSnapshotSchema>;
+export type BackupSummary = z.infer<typeof backupSummarySchema>;
+export type BackupDetail = z.infer<typeof backupDetailSchema>;
+export type PaginatedBackups = z.infer<typeof paginatedBackupsSchema>;
+export type ComponentRestoreResult = z.infer<
+  typeof componentRestoreResultSchema
+>;
+export type RestoreResult = z.infer<typeof restoreResultSchema>;

--- a/packages/web/src/lib/schemas/parse.ts
+++ b/packages/web/src/lib/schemas/parse.ts
@@ -1,0 +1,25 @@
+import type { z } from "zod";
+
+export function parseResponse<T>(
+  schema: z.ZodType<T>,
+  data: unknown,
+  source: string,
+): T {
+  const result = schema.safeParse(data);
+  if (result.success) {
+    return result.data;
+  }
+  throw new Error(
+    `Unexpected response from ${source}: ${describe(result.error)}`,
+  );
+}
+
+function describe(error: z.ZodError): string {
+  return error.issues
+    .slice(0, 3)
+    .map((issue) => {
+      const path = issue.path.join(".");
+      return path ? `${path}: ${issue.message}` : issue.message;
+    })
+    .join("; ");
+}

--- a/packages/web/src/pages/dashboard.tsx
+++ b/packages/web/src/pages/dashboard.tsx
@@ -1,58 +1,26 @@
 import { useState } from "react";
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useTranslation } from "react-i18next";
-import { toast } from "sonner";
 
 import { ScanForm } from "@/components/dashboard/scan-form";
 import { DeviceTable } from "@/components/dashboard/device-table";
 import { BulkActionsDialog } from "@/components/dashboard/bulk-actions-dialog";
 import { Footer } from "@/components/ui/footer";
-import { deviceApi, handleApiError } from "@/lib/api";
-import { queryKeys } from "@/lib/query-keys";
-import {
-  loadScanResults,
-  saveScanResults,
-  clearScanResults,
-} from "@/lib/storage";
+import { handleApiError } from "@/lib/api";
+import { useScanDevices, useScannedDevices } from "@/hooks/useScannedDevices";
 import type { Device, ScanRequest } from "@/types/api";
 
 export function Dashboard() {
   const { t } = useTranslation();
   const [selectedDevices, setSelectedDevices] = useState<Device[]>([]);
   const [bulkActionsOpen, setBulkActionsOpen] = useState(false);
-  const queryClient = useQueryClient();
 
   const {
     data: devices = [],
     isLoading: isLoadingCached,
     error: cacheError,
-  } = useQuery({
-    queryKey: queryKeys.devices.scan(),
-    queryFn: () => {
-      const cached = loadScanResults();
-      return cached ? cached.devices : [];
-    },
-    staleTime: Infinity, // Cached data never becomes stale automatically
-    gcTime: Infinity, // Keep in memory indefinitely
-  });
+  } = useScannedDevices();
 
-  const scanMutation = useMutation({
-    mutationFn: async (params: ScanRequest) => {
-      clearScanResults();
-      queryClient.removeQueries({ queryKey: queryKeys.devices.scan() });
-      return deviceApi.scanDevices(params);
-    },
-    onSuccess: (data, variables) => {
-      saveScanResults(data, variables);
-      queryClient.setQueryData(queryKeys.devices.scan(), data);
-      toast.success(
-        t("dashboard.messages.scanSuccess", { count: data.length }),
-      );
-    },
-    onError: (error) => {
-      toast.error(handleApiError(error));
-    },
-  });
+  const scanMutation = useScanDevices();
 
   const handleScan = (request: ScanRequest) => {
     scanMutation.mutate(request);

--- a/packages/web/src/pages/dashboard.tsx
+++ b/packages/web/src/pages/dashboard.tsx
@@ -8,6 +8,7 @@ import { DeviceTable } from "@/components/dashboard/device-table";
 import { BulkActionsDialog } from "@/components/dashboard/bulk-actions-dialog";
 import { Footer } from "@/components/ui/footer";
 import { deviceApi, handleApiError } from "@/lib/api";
+import { queryKeys } from "@/lib/query-keys";
 import {
   loadScanResults,
   saveScanResults,
@@ -26,7 +27,7 @@ export function Dashboard() {
     isLoading: isLoadingCached,
     error: cacheError,
   } = useQuery({
-    queryKey: ["devices", "scan"],
+    queryKey: queryKeys.devices.scan(),
     queryFn: () => {
       const cached = loadScanResults();
       return cached ? cached.devices : [];
@@ -39,12 +40,12 @@ export function Dashboard() {
   const scanMutation = useMutation({
     mutationFn: async (params: ScanRequest) => {
       clearScanResults();
-      queryClient.removeQueries({ queryKey: ["devices", "scan"] });
+      queryClient.removeQueries({ queryKey: queryKeys.devices.scan() });
       return deviceApi.scanDevices(params);
     },
     onSuccess: (data, variables) => {
       saveScanResults(data, variables);
-      queryClient.setQueryData(["devices", "scan"], data);
+      queryClient.setQueryData(queryKeys.devices.scan(), data);
       toast.success(
         t("dashboard.messages.scanSuccess", { count: data.length }),
       );

--- a/packages/web/src/pages/dashboard.tsx
+++ b/packages/web/src/pages/dashboard.tsx
@@ -34,7 +34,6 @@ export function Dashboard() {
     },
     staleTime: Infinity, // Cached data never becomes stale automatically
     gcTime: Infinity, // Keep in memory indefinitely
-    enabled: true, // Auto-load on mount
   });
 
   const scanMutation = useMutation({

--- a/packages/web/src/pages/device-detail.tsx
+++ b/packages/web/src/pages/device-detail.tsx
@@ -9,6 +9,7 @@ import { DeviceActions } from "@/components/device-detail/device-actions";
 import { DeviceComponents } from "@/components/device-detail/device-components";
 import { BackupsSection } from "@/components/device-detail/backups-section";
 import { deviceApi, handleApiError } from "@/lib/api";
+import { queryKeys } from "@/lib/query-keys";
 
 export function DeviceDetail() {
   const { t } = useTranslation();
@@ -21,7 +22,7 @@ export function DeviceDetail() {
     error,
     refetch,
   } = useQuery({
-    queryKey: ["device", "status", ip],
+    queryKey: queryKeys.devices.status(ip),
     queryFn: () => deviceApi.getDeviceStatus(ip!),
     enabled: !!ip,
   });

--- a/packages/web/src/pages/settings.tsx
+++ b/packages/web/src/pages/settings.tsx
@@ -37,7 +37,13 @@ import {
 import { Footer } from "@/components/ui/footer";
 import { useTheme } from "@/components/theme-provider";
 import { toast } from "sonner";
-import { validateApiUrl } from "@/lib/api";
+import {
+  API_URL_STORAGE_KEY,
+  describeConnectionFailure,
+  getDefaultApiBaseUrl,
+  healthApi,
+  validateApiUrl,
+} from "@/lib/api";
 
 interface ApiConnectionStatus {
   status: "checking" | "connected" | "error" | "unknown";
@@ -60,10 +66,8 @@ export function Settings() {
   useEffect(() => {
     setSettings(loadAppSettings());
 
-    const savedApiUrl = localStorage.getItem("shelly-manager-api-url");
-    const defaultApiUrl =
-      import.meta.env.VITE_BASE_API_URL || "http://localhost:8000";
-    const currentApiUrl = savedApiUrl || defaultApiUrl;
+    const currentApiUrl =
+      localStorage.getItem(API_URL_STORAGE_KEY) || getDefaultApiBaseUrl();
 
     setApiUrl(currentApiUrl);
     setTempApiUrl(currentApiUrl);
@@ -85,38 +89,16 @@ export function Settings() {
     setConnectionStatus({ status: "checking" });
 
     try {
-      const sanitizedUrl = url.replace(/\/+$/, ""); // Remove trailing slashes
-      const controller = new AbortController();
-      const timeoutId = setTimeout(() => controller.abort(), 5000);
-
-      const response = await fetch(`${sanitizedUrl}/api/health`, {
-        method: "GET",
-        headers: { "Content-Type": "application/json" },
-        signal: controller.signal,
+      const health = await healthApi.check(url);
+      setConnectionStatus({
+        status: "connected",
+        message: `Connected successfully (${health.status || "OK"})`,
       });
-
-      clearTimeout(timeoutId);
-
-      if (response.ok) {
-        const data = await response.json();
-        setConnectionStatus({
-          status: "connected",
-          message: `Connected successfully (${data.status || "OK"})`,
-        });
-        return true;
-      } else {
-        setConnectionStatus({
-          status: "error",
-          message: `HTTP ${response.status}: ${response.statusText}`,
-        });
-        return false;
-      }
+      return true;
     } catch (error) {
-      const errorMessage =
-        error instanceof Error ? error.message : "Unknown error";
       setConnectionStatus({
         status: "error",
-        message: `Connection failed: ${errorMessage}`,
+        message: describeConnectionFailure(error),
       });
       return false;
     }
@@ -129,7 +111,7 @@ export function Settings() {
 
     const isValid = await testApiConnection(tempApiUrl);
     if (isValid) {
-      localStorage.setItem("shelly-manager-api-url", tempApiUrl);
+      localStorage.setItem(API_URL_STORAGE_KEY, tempApiUrl);
       setApiUrl(tempApiUrl);
       toast.success("API URL saved successfully");
       setTimeout(() => window.location.reload(), 1000);
@@ -139,10 +121,9 @@ export function Settings() {
   };
 
   const resetApiUrl = () => {
-    const defaultApiUrl =
-      import.meta.env.VITE_BASE_API_URL || "http://localhost:8000";
+    const defaultApiUrl = getDefaultApiBaseUrl();
     setTempApiUrl(defaultApiUrl);
-    localStorage.removeItem("shelly-manager-api-url");
+    localStorage.removeItem(API_URL_STORAGE_KEY);
     setApiUrl(defaultApiUrl);
     setConnectionStatus({ status: "unknown" });
     toast.success("API URL reset to default");
@@ -333,7 +314,7 @@ export function Settings() {
                 <Button
                   variant="outline"
                   onClick={resetApiUrl}
-                  disabled={!localStorage.getItem("shelly-manager-api-url")}
+                  disabled={!localStorage.getItem(API_URL_STORAGE_KEY)}
                 >
                   Reset
                 </Button>

--- a/packages/web/src/types/api.ts
+++ b/packages/web/src/types/api.ts
@@ -591,31 +591,13 @@ export function isEM1DataComponent(
   return component.type === "em1data";
 }
 
-export interface BackupSummary {
-  id: number;
-  device_mac: string;
-  device_ip: string | null;
-  device_name: string | null;
-  device_type: string | null;
-  firmware_version: string | null;
-  generation: string;
-  name: string | null;
-  source: string;
-  sha256: string | null;
-  size_bytes: number;
-  created_at: number | null;
-}
-
-export interface BackupDetail extends BackupSummary {
-  snapshot: Record<string, unknown>;
-}
-
-export interface PaginatedBackups {
-  items: BackupSummary[];
-  total: number;
-  limit: number;
-  offset: number;
-}
+export type {
+  BackupSummary,
+  BackupDetail,
+  ComponentSnapshot,
+  DeviceSnapshot,
+  PaginatedBackups,
+} from "@/lib/schemas/backups";
 
 export interface CreateBackupRequest {
   device_ip: string;
@@ -629,14 +611,10 @@ export interface RestoreBackupRequest {
   reboot?: boolean;
 }
 
-export interface ComponentRestoreResult {
-  key: string;
-  action: string;
-  success: boolean;
-  skipped: boolean;
-  skipped_reason: string | null;
-  error: string | null;
-}
+export type {
+  ComponentRestoreResult,
+  RestoreResult,
+} from "@/lib/schemas/backups";
 
 export interface BackupSchedule {
   id: number;
@@ -688,16 +666,4 @@ export interface ScheduleRunResult {
   failed: number;
   skipped: number;
   message: string;
-}
-
-export interface RestoreResult {
-  success: boolean;
-  device_ip: string;
-  backup_id: number;
-  total: number;
-  succeeded: number;
-  failed: number;
-  skipped: number;
-  message: string | null;
-  components: ComponentRestoreResult[];
 }


### PR DESCRIPTION
## Purpose

Give the web app one definition of its server state, and check the backup responses it renders instead of trusting them.

## Context

Query keys were inline literals at every call site, so nothing tied a query to the mutations that invalidate it, and the client defaulted every query to disabled, so each one carried a line undoing that default and any query that forgot it silently never ran. The three conditions that gate on real state are kept.

Validation covers the backups and restore endpoints only; the rest of lib/api.ts still casts its responses.

The restore dialog's network-component default is a fix rather than part of the refactor: it chose which components to leave unchecked from the snapshot entry's type alone, and an entry can reach the store untyped, so it now reads the component key too.

## Notes

A response that fails validation is retried by the client's default retry policy before the error surfaces, which is wasted work for a failure that cannot succeed on retry.
