### PR TITLE
One table for component models, one set for export

### DIFF
--- a/packages/cli/src/cli/use_cases/export/device_export.py
+++ b/packages/cli/src/cli/use_cases/export/device_export.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from typing import Any
 
 from core.domain.entities import DeviceStatus
+from core.domain.entities.config_snapshot import EXPORTABLE_COMPONENT_TYPES
 from core.domain.value_objects.check_device_status_request import (
     CheckDeviceStatusRequest,
 )
@@ -139,17 +140,8 @@ class DeviceExportUseCase:
             bulk_operations = self._container.get_bulk_operations_interactor()
             device_ips = [device.device_ip for device in devices]
 
-            component_types = [
-                "switch",
-                "input",
-                "cover",
-                "sys",
-                "cloud",
-                "ble",
-                "zigbee",
-            ]
             bulk_config_result = await bulk_operations.export_bulk_config(
-                device_ips, component_types
+                device_ips, sorted(EXPORTABLE_COMPONENT_TYPES)
             )
 
             devices_data = bulk_config_result.get("devices", {})

--- a/packages/cli/tests/unit/use_cases/export/test_device_export.py
+++ b/packages/cli/tests/unit/use_cases/export/test_device_export.py
@@ -1,0 +1,35 @@
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from cli.use_cases.export.device_export import DeviceExportUseCase
+from core.domain.entities.config_snapshot import EXPORTABLE_COMPONENT_TYPES
+
+
+class TestDeviceExportConfiguration:
+    @pytest.fixture
+    def bulk_operations(self):
+        bulk = AsyncMock()
+        bulk.export_bulk_config.return_value = {"devices": {}}
+        return bulk
+
+    @pytest.fixture
+    def export_use_case(self, bulk_operations):
+        container = MagicMock()
+        container.get_bulk_operations_interactor.return_value = bulk_operations
+        return DeviceExportUseCase(container, MagicMock())
+
+    @pytest.mark.asyncio
+    async def test_it_exports_every_exportable_component_type(
+        self, export_use_case, bulk_operations
+    ):
+        device = MagicMock()
+        device.device_ip = "192.168.1.100"
+
+        await export_use_case._get_configurations_for_devices([device])
+
+        # The caller swallows every exception, so an export that never reached
+        # the device would otherwise read here as an unsubscriptable None.
+        bulk_operations.export_bulk_config.assert_awaited_once()
+
+        _, requested_types = bulk_operations.export_bulk_config.call_args[0]
+        assert set(requested_types) == EXPORTABLE_COMPONENT_TYPES

--- a/packages/core/src/core/domain/entities/components/factory.py
+++ b/packages/core/src/core/domain/entities/components/factory.py
@@ -1,23 +1,7 @@
 from typing import Any
 
 from .base import Component
-from .bluetooth_home import BluetoothHomeComponent
-from .bluetooth_le import BluetoothLEComponent
-from .cloud import CloudComponent
-from .cover import CoverComponent
-from .em import EMComponent
-from .em1 import EM1Component
-from .em1data import EM1DataComponent
-from .emdata import EMDataComponent
-from .ethernet import EthernetComponent
-from .input import InputComponent
-from .knx import KnxComponent
-from .mqtt import MqttComponent
-from .switch import SwitchComponent
-from .system import SystemComponent
-from .websocket import WebSocketComponent
-from .wifi import WifiComponent
-from .zigbee import ZigbeeComponent
+from .registry import model_for
 
 
 class ComponentFactory:
@@ -26,42 +10,7 @@ class ComponentFactory:
         key = component_data.get("key", "")
         component_type = key.split(":")[0] if ":" in key else key
 
-        if component_type == "switch":
-            return SwitchComponent.from_raw_data(component_data)
-        elif component_type == "input":
-            return InputComponent.from_raw_data(component_data)
-        elif component_type == "cover":
-            return CoverComponent.from_raw_data(component_data)
-        elif component_type == "sys":
-            return SystemComponent.from_raw_data(component_data)
-        elif component_type == "cloud":
-            return CloudComponent.from_raw_data(component_data)
-        elif component_type == "zigbee":
-            return ZigbeeComponent.from_raw_data(component_data)
-        elif component_type == "wifi":
-            return WifiComponent.from_raw_data(component_data)
-        elif component_type == "ws":
-            return WebSocketComponent.from_raw_data(component_data)
-        elif component_type == "eth":
-            return EthernetComponent.from_raw_data(component_data)
-        elif component_type == "bthome":
-            return BluetoothHomeComponent.from_raw_data(component_data)
-        elif component_type == "ble":
-            return BluetoothLEComponent.from_raw_data(component_data)
-        elif component_type == "knx":
-            return KnxComponent.from_raw_data(component_data)
-        elif component_type == "mqtt":
-            return MqttComponent.from_raw_data(component_data)
-        elif component_type == "em":
-            return EMComponent.from_raw_data(component_data)
-        elif component_type == "em1":
-            return EM1Component.from_raw_data(component_data)
-        elif component_type == "emdata":
-            return EMDataComponent.from_raw_data(component_data)
-        elif component_type == "em1data":
-            return EM1DataComponent.from_raw_data(component_data)
-        else:
-            return Component.from_raw_data(component_data)
+        return model_for(component_type).from_raw_data(component_data)
 
     @staticmethod
     def create_component_from_status(

--- a/packages/core/src/core/domain/entities/components/registry.py
+++ b/packages/core/src/core/domain/entities/components/registry.py
@@ -1,0 +1,55 @@
+"""Which model class parses which component type.
+
+The key set is a subset of the namespace table's, held there by
+``test_it_registers_only_known_component_types``. That table is the list of
+type keys Shelly actually uses, so a key only this one knows is either a
+misspelling no device will ever match or a new type the namespace table has to
+learn as well. Its fallback for an unknown type guesses one title-cased
+namespace, which matches case-insensitively and so usually discovers the same
+methods, but it loses the second namespace ``sys`` answers to and the exact
+method ``zigbee`` owns outside its own.
+"""
+
+from .base import Component
+from .bluetooth_home import BluetoothHomeComponent
+from .bluetooth_le import BluetoothLEComponent
+from .cloud import CloudComponent
+from .cover import CoverComponent
+from .em import EMComponent
+from .em1 import EM1Component
+from .em1data import EM1DataComponent
+from .emdata import EMDataComponent
+from .ethernet import EthernetComponent
+from .input import InputComponent
+from .knx import KnxComponent
+from .mqtt import MqttComponent
+from .switch import SwitchComponent
+from .system import SystemComponent
+from .websocket import WebSocketComponent
+from .wifi import WifiComponent
+from .zigbee import ZigbeeComponent
+
+COMPONENT_MODELS: dict[str, type[Component]] = {
+    "ble": BluetoothLEComponent,
+    "bthome": BluetoothHomeComponent,
+    "cloud": CloudComponent,
+    "cover": CoverComponent,
+    "em": EMComponent,
+    "em1": EM1Component,
+    "em1data": EM1DataComponent,
+    "emdata": EMDataComponent,
+    "eth": EthernetComponent,
+    "input": InputComponent,
+    "knx": KnxComponent,
+    "mqtt": MqttComponent,
+    "switch": SwitchComponent,
+    "sys": SystemComponent,
+    "wifi": WifiComponent,
+    "ws": WebSocketComponent,
+    "zigbee": ZigbeeComponent,
+}
+
+
+def model_for(component_type: str) -> type[Component]:
+    """The model class parsing a component type, or the untyped base."""
+    return COMPONENT_MODELS.get(component_type, Component)

--- a/packages/core/src/core/domain/entities/device_status.py
+++ b/packages/core/src/core/domain/entities/device_status.py
@@ -4,8 +4,6 @@ from typing import Any
 from pydantic import BaseModel, Field
 
 from .components import (
-    BluetoothHomeComponent,
-    BluetoothLEComponent,
     CloudComponent,
     ComponentType,
     CoverComponent,
@@ -13,10 +11,7 @@ from .components import (
     EM1DataComponent,
     EMComponent,
     EMDataComponent,
-    EthernetComponent,
     InputComponent,
-    KnxComponent,
-    MqttComponent,
     SwitchComponent,
     SystemComponent,
     WebSocketComponent,
@@ -151,36 +146,6 @@ class DeviceStatus(BaseModel):
     def get_websocket_info(self) -> WebSocketComponent | None:
         for comp in self.components:
             if isinstance(comp, WebSocketComponent):
-                return comp
-        return None
-
-    def get_ethernet_info(self) -> EthernetComponent | None:
-        for comp in self.components:
-            if isinstance(comp, EthernetComponent):
-                return comp
-        return None
-
-    def get_bluetooth_home_info(self) -> BluetoothHomeComponent | None:
-        for comp in self.components:
-            if isinstance(comp, BluetoothHomeComponent):
-                return comp
-        return None
-
-    def get_bluetooth_le_info(self) -> BluetoothLEComponent | None:
-        for comp in self.components:
-            if isinstance(comp, BluetoothLEComponent):
-                return comp
-        return None
-
-    def get_knx_info(self) -> KnxComponent | None:
-        for comp in self.components:
-            if isinstance(comp, KnxComponent):
-                return comp
-        return None
-
-    def get_mqtt_info(self) -> MqttComponent | None:
-        for comp in self.components:
-            if isinstance(comp, MqttComponent):
                 return comp
         return None
 

--- a/packages/core/tests/unit/domain/entities/test_component_registry.py
+++ b/packages/core/tests/unit/domain/entities/test_component_registry.py
@@ -1,0 +1,131 @@
+from typing import get_args
+
+import pytest
+from core.domain.entities.components import (
+    BluetoothHomeComponent,
+    BluetoothLEComponent,
+    CloudComponent,
+    Component,
+    ComponentFactory,
+    ComponentType,
+    CoverComponent,
+    EM1Component,
+    EM1DataComponent,
+    EMComponent,
+    EMDataComponent,
+    EthernetComponent,
+    InputComponent,
+    KnxComponent,
+    MqttComponent,
+    SwitchComponent,
+    SystemComponent,
+    WebSocketComponent,
+    WifiComponent,
+    ZigbeeComponent,
+)
+from core.domain.entities.components.registry import COMPONENT_MODELS, model_for
+from core.domain.value_objects.component_namespace import known_component_types
+
+# Spelled out rather than derived from the registry: a test that walks the table
+# it is checking passes just as happily when an entry is dropped or points at
+# the wrong model.
+EXPECTED_MODELS = {
+    "ble": BluetoothLEComponent,
+    "bthome": BluetoothHomeComponent,
+    "cloud": CloudComponent,
+    "cover": CoverComponent,
+    "em": EMComponent,
+    "em1": EM1Component,
+    "em1data": EM1DataComponent,
+    "emdata": EMDataComponent,
+    "eth": EthernetComponent,
+    "input": InputComponent,
+    "knx": KnxComponent,
+    "mqtt": MqttComponent,
+    "switch": SwitchComponent,
+    "sys": SystemComponent,
+    "wifi": WifiComponent,
+    "ws": WebSocketComponent,
+    "zigbee": ZigbeeComponent,
+}
+
+
+class TestComponentRegistry:
+    def test_it_maps_every_type_to_its_own_model(self):
+        assert COMPONENT_MODELS == EXPECTED_MODELS
+
+    def test_it_dispatches_to_every_model_the_union_declares(self):
+        declared = set(get_args(ComponentType)) - {Component}
+
+        assert set(COMPONENT_MODELS.values()) == declared
+
+    def test_it_registers_only_known_component_types(self):
+        assert set(COMPONENT_MODELS) <= known_component_types()
+
+    def test_it_falls_back_to_the_base_model_for_an_unregistered_type(self):
+        assert model_for("light") is Component
+        assert model_for("nonsense") is Component
+
+
+class TestRegisteredModelsParseTheirOwnFields:
+    """The types the rest of the suite never builds through the factory.
+
+    ``isinstance`` is what proves the mapping, since every model subclasses
+    ``Component`` directly and a wrong entry fails it. Reading a field then
+    shows the model parsed its own payload rather than merely being built.
+    Six of the seven fields are unique to their model; ``connected`` is not,
+    so the cloud case rests on ``isinstance`` alone.
+    """
+
+    @pytest.mark.parametrize(
+        "raw,expected_model,field,value",
+        [
+            (
+                {"key": "cover:0", "status": {"state": "open", "current_pos": 70}},
+                CoverComponent,
+                "position",
+                70,
+            ),
+            (
+                {"key": "cloud", "status": {"connected": True}},
+                CloudComponent,
+                "connected",
+                True,
+            ),
+            (
+                {"key": "eth", "status": {"ip": "10.0.0.4"}},
+                EthernetComponent,
+                "eth_ip",
+                "10.0.0.4",
+            ),
+            (
+                {"key": "bthome", "status": {"errors": ["no_bt"]}},
+                BluetoothHomeComponent,
+                "errors",
+                ["no_bt"],
+            ),
+            (
+                {"key": "ble", "config": {"rpc": {"enable": True}}},
+                BluetoothLEComponent,
+                "rpc_enabled",
+                True,
+            ),
+            (
+                {"key": "knx", "config": {"ia": "1.1.5"}},
+                KnxComponent,
+                "individual_address",
+                "1.1.5",
+            ),
+            (
+                {"key": "mqtt", "config": {"client_id": "shelly-1"}},
+                MqttComponent,
+                "client_id",
+                "shelly-1",
+            ),
+        ],
+    )
+    def test_it_parses_a_type_specific_field(self, raw, expected_model, field, value):
+        component = ComponentFactory.create_component(raw)
+
+        assert isinstance(component, expected_model)
+        assert getattr(component, field) == value


### PR DESCRIPTION
## Purpose

Component type dispatch moves from a branch chain to a table, and the CLI's device export asks core which types are exportable instead of naming seven of them.

## Context

The factory's branch chain and the namespace table both spelled out component type keys with nothing holding them in step. A key misspelled in one and not the other parsed that component into the untyped base model, which still discovered its actions, since the type comes from the key prefix, but vanished from everything narrowing by isinstance: a device with two live switches drawing 12.5 W reported a switch count of zero and no power. The table is now checked against the namespace table and against the component union, so an entry that is missing, misspelled or pointed at the wrong model fails.

The device export named seven component types, so a config export left out ethernet, energy metering, bthome, knx and whatever else the device carried. It takes core's exportable set now, which is what the API validates and what the bulk export command accepts.

Five typed accessors on DeviceStatus had no caller in any package and no test.

## Notes

Widening the export set costs round trips on Gen2: one GetConfig per newly present component, one Schedule.List per device whether or not it has any, and up to one GetCode per script, only once that script's GetConfig succeeded. Gen1 makes no extra calls, since its capture reads configs already on the status. Both generations write a larger file, and script source appears in it now. A backup of the same device already captures all of this, so none of it is new data, only new to the export.

The web's bulk actions dialog still hard-codes its own list of 13 configurable types, which disagrees with the 36 core derives. That is untouched here and worth its own change.
