### PR TITLE
Devices without internet get firmware through the manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Manage Shelly devices on your local network without connecting them to the Shell
 - Gen1 (legacy HTTP) and Gen2 (RPC) device support with automatic detection
 - Device discovery using mDNS and Network Scanning
 - Firmware update management (stable/beta channels)
+- Firmware updates for devices with no internet access, served from the manager over the LAN
 - Device configuration management with bulk export/apply
 - Per-device configuration backup and restore with encrypted snapshots
 - Scheduled backups with retention (keep last N, drop older than N days)
@@ -212,6 +213,10 @@ For persistent storage of discovered devices in the Web UI, the application leve
 
 **Scheduled backups** run on the API server itself. When `SHELLY_BACKUP_SCHEDULER_ENABLED` is `true` (the default), an in-process poller captures backups for any due schedules every `SHELLY_BACKUP_POLL_INTERVAL_SECONDS` (default 60). Because the timer lives in-process, run the API as a single worker (the default); see the [API README](packages/api/README.md) for the full setting reference.
 
+**Local firmware updates** let a device that cannot reach the internet still be updated. Ask for one with `"source": "local"` on the update endpoint, or `--source local` from the CLI: the manager downloads the official firmware from Shelly once, keeps it, and tells the device to fetch it from the manager instead. The same copy serves every device running that model, so only the manager needs internet access.
+
+Set `SHELLY_FIRMWARE_ADVERTISED_BASE_URL` to a URL your devices can reach, for example `http://192.168.1.50:8000`. There is no default and a local update fails immediately without it, because the manager cannot work out its own device-facing address. The devices fetch that URL unauthenticated, so it has to be reachable from the device network.
+
 ## Architecture
 
 ```
@@ -298,6 +303,13 @@ shelly-manager scan --use-mdns
 shelly-manager device status 192.168.1.100
 shelly-manager device reboot 192.168.1.100
 shelly-manager device actions list 192.168.1.100
+
+# Firmware updates
+shelly-manager device update -t 192.168.1.100
+shelly-manager device update -t 192.168.1.100 --channel beta
+
+# ...or serve the firmware from this host, for a device with no internet access
+shelly-manager device update -t 192.168.1.100 --source local
 
 # Bulk operations
 shelly-manager bulk reboot --target 192.168.1.100-110

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,10 @@ services:
       # Defaults shown; set SHELLY_BACKUP_SCHEDULER_ENABLED=false to disable.
       SHELLY_BACKUP_SCHEDULER_ENABLED: "${SHELLY_BACKUP_SCHEDULER_ENABLED:-true}"
       SHELLY_BACKUP_POLL_INTERVAL_SECONDS: "${SHELLY_BACKUP_POLL_INTERVAL_SECONDS:-60}"
+      # Set to a URL your devices can reach to update a device that has no
+      # internet access, e.g. http://192.168.1.50:8000. Unset, only the
+      # internet update source works.
+      SHELLY_FIRMWARE_ADVERTISED_BASE_URL: "${SHELLY_FIRMWARE_ADVERTISED_BASE_URL:-}"
     volumes:
       - ./packages/api/src:/app/packages/api/src:rw
       - ./packages/core/src:/app/packages/core/src:rw

--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -62,7 +62,10 @@ GET /api/devices/scan              # Scan network for devices
 GET /api/devices/{ip}/status       # Get device status
 
 POST /api/devices/{ip}/update      # Update device firmware
-  ?channel=stable                  # Update channel (stable/beta)
+  # Body: {"channel": "stable", "source": "internet"}
+  #   channel: stable (default) or beta
+  #   source:  internet (default) lets the device download from Shelly
+  #            local serves the firmware from this manager instead
 
 POST /api/devices/{ip}/reboot      # Reboot device
 
@@ -72,6 +75,18 @@ POST /api/devices/bulk/update      # Bulk firmware updates
 # Component Actions
 GET /api/devices/{ip}/components/actions           # Discover available actions
 POST /api/devices/{ip}/components/{id}/action      # Execute component action
+```
+
+### Firmware Store
+
+Bundles the manager has downloaded for local updates. Devices fetch the download
+route themselves and are not authenticated, so it must be reachable from the
+device network.
+
+```bash
+GET    /api/firmware                  # List cached bundles
+DELETE /api/firmware/{id}             # Delete a bundle and its file
+GET    /api/firmware/{id}/download    # The zip a device fetches
 ```
 
 ### Configuration Backup & Restore
@@ -208,7 +223,9 @@ curl "http://localhost:8000/api/devices/scan?targets=192.168.1.1-10"
 ### Device Update
 
 ```bash
-curl -X POST "http://localhost:8000/api/devices/192.168.1.100/update?channel=stable"
+curl -X POST http://localhost:8000/api/devices/192.168.1.100/update \
+  -H "Content-Type: application/json" \
+  -d '{"channel": "stable"}'
 ```
 
 **Response:**
@@ -217,9 +234,21 @@ curl -X POST "http://localhost:8000/api/devices/192.168.1.100/update?channel=sta
 {
   "ip": "192.168.1.100",
   "success": true,
-  "message": "Firmware update initiated",
-  "action_type": "firmware_update"
+  "message": "Update executed successfully on shelly",
+  "action_type": "shelly.Update",
+  "channel": "stable",
+  "source": "internet"
 }
+```
+
+For a device with no internet access, ask the manager to serve the firmware.
+It downloads the official bundle once, keeps it, and hands the device a URL on
+this host. Requires `SHELLY_FIRMWARE_ADVERTISED_BASE_URL`; stable channel only.
+
+```bash
+curl -X POST http://localhost:8000/api/devices/192.168.1.100/update \
+  -H "Content-Type: application/json" \
+  -d '{"source": "local"}'
 ```
 
 ### Component Actions Examples
@@ -413,6 +442,11 @@ curl -X POST "http://localhost:8000/api/backups/1/restore" \
 | `SHELLY_SECRET_KEY`  | (required)    | Fernet key for credential encryption. Generate with: `python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"` |
 | `SHELLY_BACKUP_SCHEDULER_ENABLED` | `true` | Run the in-process scheduled-backup poller |
 | `SHELLY_BACKUP_POLL_INTERVAL_SECONDS` | `60` | How often the scheduler checks for due backups |
+| `SHELLY_FIRMWARE_ADVERTISED_BASE_URL` | (none) | URL devices use to reach this API, e.g. `http://192.168.1.50:8000`. Required for local updates; it cannot be guessed |
+| `SHELLY_FIRMWARE_DIR` | `./data/firmware` | Where downloaded firmware bundles are kept |
+| `SHELLY_FIRMWARE_INDEX_URL` | `https://updates.shelly.cloud/update` | Where published firmware is looked up, by the app name a device reports |
+| `SHELLY_FIRMWARE_ALLOWED_DOWNLOAD_HOSTS` | `shelly.cloud` | Comma separated hosts firmware may be downloaded from, matched exactly or as a parent domain and re-checked on every redirect. `*` accepts any host |
+| `SHELLY_FIRMWARE_VERIFY_SSL` | `false` | Verify TLS when talking to the firmware index and CDN. Off by default because Shelly signs those hosts with a private CA absent from public trust stores; devices verify firmware signatures themselves |
 
 `SHELLY_SECRET_KEY` also encrypts configuration **backup snapshots** at rest. Backups are
 stored in the local database (`{data_dir}/data.db`); rotating the key makes existing snapshots

--- a/packages/api/src/api/controllers/devices.py
+++ b/packages/api/src/api/controllers/devices.py
@@ -6,6 +6,7 @@ from typing import TypeVar
 
 from core.domain.entities.exceptions import DeviceNotFoundError
 from core.domain.enums.enums import UpdateChannel
+from core.domain.value_objects.base_device_request import BaseDeviceRequest
 from core.domain.value_objects.check_device_status_request import (
     CheckDeviceStatusRequest,
 )
@@ -19,6 +20,7 @@ from core.use_cases.check_device_status import CheckDeviceStatusUseCase
 from core.use_cases.execute_component_action import ExecuteComponentActionUseCase
 from core.use_cases.get_component_actions import GetComponentActionsUseCase
 from core.use_cases.scan_devices import ScanDevicesUseCase
+from core.use_cases.update_device_from_local import UpdateDeviceFromLocal
 from litestar import Router, get, post
 from litestar.exceptions import HTTPException
 from litestar.params import Body
@@ -240,6 +242,7 @@ async def update_device(
     ip: str,
     data: dict = Body(),
     execute_component_action_interactor: ExecuteComponentActionUseCase | None = None,
+    update_device_from_local_interactor: UpdateDeviceFromLocal | None = None,
 ) -> dict:
     """
     Initiate firmware update for a device.
@@ -247,27 +250,51 @@ async def update_device(
     Updates the device firmware to the latest version from the specified channel.
     The device will download and install the update, which may take several minutes.
 
+    With source "local" the manager downloads and caches the bundle, and the
+    device fetches it from the manager over LAN instead of from the internet.
+
     Args:
         ip: Device IP address (e.g., "192.168.1.100")
         data: Update parameters with optional "channel" field (stable/beta)
+            and optional "source" field (internet/local, default internet)
 
     Returns:
         dict: Update operation result and status
     """
-    execute_component_action_interactor = _require(
-        "execute_component_action_interactor", execute_component_action_interactor
-    )
+    source = data.get("source", "internet")
+    if source not in ("internet", "local"):
+        raise HTTPException(
+            status_code=400,
+            detail=f"Unsupported source: {source}. Supported: internet, local",
+        )
 
     channel = UpdateChannel(data.get("channel", "stable"))
 
-    request = ComponentActionRequest(
-        device_ip=ip,
-        component_key="shelly",
-        action="Update",
-        parameters=channel.to_update_parameters(),
-    )
+    if source == "local":
+        update_device_from_local_interactor = _require(
+            "update_device_from_local_interactor", update_device_from_local_interactor
+        )
+        if channel is not UpdateChannel.STABLE:
+            raise HTTPException(
+                status_code=400,
+                detail="Local updates support the stable channel only",
+            )
+        result = await update_device_from_local_interactor.execute(
+            BaseDeviceRequest(device_ip=ip)
+        )
+    else:
+        execute_component_action_interactor = _require(
+            "execute_component_action_interactor", execute_component_action_interactor
+        )
 
-    result = await execute_component_action_interactor.execute(request)
+        request = ComponentActionRequest(
+            device_ip=ip,
+            component_key="shelly",
+            action="Update",
+            parameters=channel.to_update_parameters(),
+        )
+
+        result = await execute_component_action_interactor.execute(request)
 
     return {
         "ip": result.device_ip,
@@ -276,6 +303,7 @@ async def update_device(
         "error": result.error,
         "action_type": result.action_type,
         "channel": channel.value,
+        "source": source,
     }
 
 

--- a/packages/api/src/api/controllers/firmware.py
+++ b/packages/api/src/api/controllers/firmware.py
@@ -1,0 +1,123 @@
+"""
+Firmware store API routes for local device updates.
+"""
+
+import os
+from typing import TypeVar
+
+from core.use_cases.manage_firmware import ManageFirmware
+from litestar import Router, delete, get
+from litestar.exceptions import HTTPException, NotFoundException
+from litestar.response import File
+
+T = TypeVar("T")
+
+
+@get("/", tags=["Firmware"], summary="List Cached Firmware Bundles")
+async def list_firmware(
+    manage_firmware_use_case: ManageFirmware | None = None,
+) -> list[dict]:
+    """
+    List firmware bundles cached in the local store.
+
+    Each bundle was downloaded once from Shelly's CDN and can be served to any
+    number of devices of the same app over LAN.
+
+    Returns:
+        list[dict]: Cached bundle metadata, newest first
+    """
+    manage_firmware_use_case = _require(
+        "manage_firmware_use_case", manage_firmware_use_case
+    )
+
+    bundles = await manage_firmware_use_case.list_bundles()
+    return [
+        {
+            "id": bundle.id,
+            "app_name": bundle.app_name,
+            "version": bundle.version,
+            "build_id": bundle.build_id,
+            "file_name": bundle.file_name,
+            "size_bytes": bundle.size_bytes,
+            "sha256": bundle.sha256,
+            "downloaded_at": bundle.downloaded_at,
+        }
+        for bundle in bundles
+    ]
+
+
+@delete("/{bundle_id:int}", tags=["Firmware"], summary="Delete Cached Firmware Bundle")
+async def delete_firmware(
+    bundle_id: int,
+    manage_firmware_use_case: ManageFirmware | None = None,
+) -> None:
+    """
+    Delete a cached firmware bundle, removing its metadata and its zip on disk.
+
+    Args:
+        bundle_id: ID of the cached bundle
+    """
+    manage_firmware_use_case = _require(
+        "manage_firmware_use_case", manage_firmware_use_case
+    )
+
+    if not await manage_firmware_use_case.delete_bundle(bundle_id):
+        raise NotFoundException(detail=f"Firmware bundle not found: {bundle_id}")
+
+
+@get(
+    "/{bundle_id:int}/download",
+    tags=["Firmware"],
+    summary="Download Cached Firmware Bundle",
+)
+async def download_firmware(
+    bundle_id: int,
+    manage_firmware_use_case: ManageFirmware | None = None,
+) -> File:
+    """
+    Serve a cached firmware zip.
+
+    Devices fetch this URL over LAN when an update is triggered with the local
+    source; it must stay reachable from the device network without auth.
+
+    Args:
+        bundle_id: ID of the cached bundle
+
+    Returns:
+        File: The firmware zip
+    """
+    manage_firmware_use_case = _require(
+        "manage_firmware_use_case", manage_firmware_use_case
+    )
+
+    bundle = await manage_firmware_use_case.get_bundle(bundle_id)
+    if bundle is None:
+        raise NotFoundException(detail=f"Firmware bundle not found: {bundle_id}")
+
+    path = manage_firmware_use_case.bundle_path(bundle)
+    if not os.path.isfile(path):
+        raise NotFoundException(
+            detail=f"Firmware bundle {bundle_id} has no file on disk"
+        )
+
+    return File(
+        path=path,
+        filename=bundle.file_name,
+        media_type="application/zip",
+    )
+
+
+firmware_router = Router(
+    path="/firmware",
+    route_handlers=[
+        list_firmware,
+        delete_firmware,
+        download_firmware,
+    ],
+)
+
+
+def _require(dep_name: str, dep: T | None) -> T:
+    if dep is None:
+        raise HTTPException(status_code=500, detail=f"Missing dependency: {dep_name}")
+    return dep

--- a/packages/api/src/api/dependencies/container.py
+++ b/packages/api/src/api/dependencies/container.py
@@ -78,4 +78,12 @@ def get_dependencies(container: APIContainer) -> dict:
             lambda: container.get_run_due_backups_interactor(),
             sync_to_thread=False,
         ),
+        "update_device_from_local_interactor": Provide(
+            lambda: container.get_update_device_from_local_interactor(),
+            sync_to_thread=False,
+        ),
+        "manage_firmware_use_case": Provide(
+            lambda: container.get_manage_firmware_interactor(),
+            sync_to_thread=False,
+        ),
     }

--- a/packages/api/src/api/main.py
+++ b/packages/api/src/api/main.py
@@ -17,6 +17,7 @@ from .controllers.backup_schedules import backup_schedules_router
 from .controllers.backups import backups_router
 from .controllers.credentials import credentials_router
 from .controllers.devices import devices_router
+from .controllers.firmware import firmware_router
 from .controllers.monitoring import (
     health_check,
 )
@@ -64,6 +65,10 @@ def create_app() -> Litestar:
                 name="Backup Schedules",
                 description="Automated scheduled backups and retention",
             ),
+            Tag(
+                name="Firmware",
+                description="Cached firmware bundles served to devices over LAN",
+            ),
         ],
         servers=[
             Server(url="http://localhost:8000", description="Development server"),
@@ -82,6 +87,7 @@ def create_app() -> Litestar:
             provisioning_router,
             backups_router,
             backup_schedules_router,
+            firmware_router,
             health_check,
         ],
     )

--- a/packages/api/src/api/presentation/handlers.py
+++ b/packages/api/src/api/presentation/handlers.py
@@ -15,6 +15,8 @@ from core.domain.entities.exceptions import (
     DeviceAuthenticationError,
     DeviceCommunicationError,
     DeviceNotFoundError,
+    FirmwareConfigurationError,
+    FirmwareError,
 )
 from core.domain.entities.exceptions import ValidationError as CoreValidationError
 from core.use_cases.backup_device_config import BackupError, BackupNotFoundError
@@ -96,6 +98,8 @@ EXCEPTION_HANDLERS: MutableMapping[int | type[Exception], ExceptionHandler] | No
     BackupNotFoundError: _typed_handler(404, "Backup Not Found"),
     BackupError: _typed_handler(422, "Backup Error"),
     DeviceMismatchError: _typed_handler(409, "Device Mismatch"),
+    FirmwareConfigurationError: _typed_handler(500, "Firmware Not Configured"),
+    FirmwareError: _typed_handler(422, "Firmware Error"),
     CredentialNotFoundError: _typed_handler(404, "Credential Not Found"),
     ProfileNotFoundError: _typed_handler(404, "Profile Not Found"),
     ProfileAlreadyExistsError: _typed_handler(409, "Profile Already Exists"),

--- a/packages/api/tests/unit/controllers/test_devices.py
+++ b/packages/api/tests/unit/controllers/test_devices.py
@@ -8,10 +8,12 @@ from api.controllers.devices import (
     get_component_actions,
     get_device_status,
     scan_devices,
+    update_device,
 )
 from api.presentation.handlers import EXCEPTION_HANDLERS
 from core.domain.entities.device_status import DeviceStatus
 from core.domain.entities.discovered_device import DiscoveredDevice
+from core.domain.entities.exceptions import FirmwareError
 from core.domain.enums.enums import Status
 from core.domain.value_objects.action_result import ActionResult
 from core.use_cases.bulk_operations import BulkOperationsUseCase
@@ -19,6 +21,7 @@ from core.use_cases.check_device_status import CheckDeviceStatusUseCase
 from core.use_cases.execute_component_action import ExecuteComponentActionUseCase
 from core.use_cases.get_component_actions import GetComponentActionsUseCase
 from core.use_cases.scan_devices import ScanDevicesUseCase
+from core.use_cases.update_device_from_local import UpdateDeviceFromLocal
 from litestar.di import Provide
 from litestar.testing import create_test_client
 
@@ -107,7 +110,7 @@ class TestDevicesController:
             },
         ) as client:
             response = client.post(
-                "/192.168.1.100/components/sys/actions/OTA", json={"channel": "beta"}
+                "/192.168.1.100/components/sys/actions/OTA", json={"stage": "beta"}
             )
 
             assert response.status_code == 200
@@ -117,6 +120,181 @@ class TestDevicesController:
             assert data["message"] == "Update started"
             assert data["component_key"] == "sys"
             assert data["action"] == "OTA"
+
+    def test_update_device_sends_stage_for_beta_channel(self):
+        captured = {}
+
+        class MockExecuteComponentActionUseCase(ExecuteComponentActionUseCase):
+            def __init__(self):
+                pass
+
+            async def execute(self, request):
+                captured["request"] = request
+                return ActionResult(
+                    device_ip=request.device_ip,
+                    success=True,
+                    message="Update started",
+                    action_type="shelly.Update",
+                )
+
+        with create_test_client(
+            route_handlers=[update_device],
+            dependencies={
+                "execute_component_action_interactor": Provide(
+                    lambda: MockExecuteComponentActionUseCase(), sync_to_thread=False
+                )
+            },
+        ) as client:
+            response = client.post("/192.168.1.100/update", json={"channel": "beta"})
+
+            assert response.status_code == 200
+            assert response.json()["channel"] == "beta"
+            assert captured["request"].parameters == {"stage": "beta"}
+
+    def test_update_device_sends_no_parameters_for_stable_channel(self):
+        captured = {}
+
+        class MockExecuteComponentActionUseCase(ExecuteComponentActionUseCase):
+            def __init__(self):
+                pass
+
+            async def execute(self, request):
+                captured["request"] = request
+                return ActionResult(
+                    device_ip=request.device_ip,
+                    success=True,
+                    message="Update started",
+                    action_type="shelly.Update",
+                )
+
+        with create_test_client(
+            route_handlers=[update_device],
+            dependencies={
+                "execute_component_action_interactor": Provide(
+                    lambda: MockExecuteComponentActionUseCase(), sync_to_thread=False
+                )
+            },
+        ) as client:
+            response = client.post("/192.168.1.100/update", json={})
+
+            assert response.status_code == 200
+            assert response.json()["channel"] == "stable"
+            assert captured["request"].parameters == {}
+
+    def test_update_device_from_local_source(self):
+        captured = {}
+
+        class MockUpdateDeviceFromLocal(UpdateDeviceFromLocal):
+            def __init__(self):
+                pass
+
+            async def execute(self, request):
+                captured["request"] = request
+                return ActionResult(
+                    device_ip=request.device_ip,
+                    success=True,
+                    message="Update executed successfully on shelly",
+                    action_type="shelly.Update",
+                )
+
+        with create_test_client(
+            route_handlers=[update_device],
+            dependencies={
+                "update_device_from_local_interactor": Provide(
+                    lambda: MockUpdateDeviceFromLocal(), sync_to_thread=False
+                )
+            },
+        ) as client:
+            response = client.post("/192.168.1.100/update", json={"source": "local"})
+
+            assert response.status_code == 200
+            data = response.json()
+            assert data["success"] is True
+            assert data["source"] == "local"
+            assert data["channel"] == "stable"
+            assert captured["request"].device_ip == "192.168.1.100"
+
+    def test_update_device_rejects_an_unknown_source(self):
+        with create_test_client(route_handlers=[update_device]) as client:
+            response = client.post("/192.168.1.100/update", json={"source": "usb"})
+
+            assert response.status_code == 400
+
+    def test_update_device_rejects_an_unknown_channel(self):
+        with create_test_client(
+            route_handlers=[update_device],
+            exception_handlers=EXCEPTION_HANDLERS,
+        ) as client:
+            response = client.post("/192.168.1.100/update", json={"channel": "nightly"})
+
+            assert response.status_code == 400
+
+    def test_update_device_rejects_a_beta_local_update(self):
+        class MockUpdateDeviceFromLocal(UpdateDeviceFromLocal):
+            def __init__(self):
+                pass
+
+        with create_test_client(
+            route_handlers=[update_device],
+            dependencies={
+                "update_device_from_local_interactor": Provide(
+                    lambda: MockUpdateDeviceFromLocal(), sync_to_thread=False
+                )
+            },
+        ) as client:
+            response = client.post(
+                "/192.168.1.100/update",
+                json={"source": "local", "channel": "beta"},
+            )
+
+            assert response.status_code == 400
+
+    def test_update_device_maps_firmware_misconfiguration_to_500(self):
+        from core.domain.entities.exceptions import FirmwareConfigurationError
+
+        class MockUpdateDeviceFromLocal(UpdateDeviceFromLocal):
+            def __init__(self):
+                pass
+
+            async def execute(self, request):
+                raise FirmwareConfigurationError(
+                    "Local updates need SHELLY_FIRMWARE_ADVERTISED_BASE_URL set"
+                )
+
+        with create_test_client(
+            route_handlers=[update_device],
+            dependencies={
+                "update_device_from_local_interactor": Provide(
+                    lambda: MockUpdateDeviceFromLocal(), sync_to_thread=False
+                )
+            },
+            exception_handlers=EXCEPTION_HANDLERS,
+        ) as client:
+            response = client.post("/192.168.1.100/update", json={"source": "local"})
+
+            assert response.status_code == 500
+            assert response.json()["error"] == "Firmware Not Configured"
+
+    def test_update_device_maps_firmware_errors_to_422(self):
+        class MockUpdateDeviceFromLocal(UpdateDeviceFromLocal):
+            def __init__(self):
+                pass
+
+            async def execute(self, request):
+                raise FirmwareError("No firmware published for app 'Plus2PM'")
+
+        with create_test_client(
+            route_handlers=[update_device],
+            dependencies={
+                "update_device_from_local_interactor": Provide(
+                    lambda: MockUpdateDeviceFromLocal(), sync_to_thread=False
+                )
+            },
+            exception_handlers=EXCEPTION_HANDLERS,
+        ) as client:
+            response = client.post("/192.168.1.100/update", json={"source": "local"})
+
+            assert response.status_code == 422
 
     def test_reboot_device_successfully(self):
         class MockExecuteComponentActionUseCase(ExecuteComponentActionUseCase):
@@ -288,6 +466,33 @@ class TestDevicesController:
             assert all(result["success"] for result in data)
             assert all(result["operation"] == "update" for result in data)
             assert all(result["channel"] == "beta" for result in data)
+
+    def test_bulk_operations_update_rejects_an_unknown_channel(self):
+        from core.use_cases.bulk_operations import BulkOperationsUseCase
+
+        class MockBulkOperationsUseCase(BulkOperationsUseCase):
+            def __init__(self):
+                pass
+
+        with create_test_client(
+            route_handlers=[execute_bulk_operations],
+            dependencies={
+                "bulk_operations_use_case": Provide(
+                    lambda: MockBulkOperationsUseCase(), sync_to_thread=False
+                )
+            },
+            exception_handlers=EXCEPTION_HANDLERS,
+        ) as client:
+            response = client.post(
+                "/bulk",
+                json={
+                    "device_ips": ["192.168.1.100"],
+                    "operation": "update",
+                    "channel": "nightly",
+                },
+            )
+
+            assert response.status_code == 400
 
     def test_bulk_operations_reboot_successfully(self):
         from core.use_cases.bulk_operations import BulkOperationsUseCase

--- a/packages/api/tests/unit/controllers/test_firmware.py
+++ b/packages/api/tests/unit/controllers/test_firmware.py
@@ -1,0 +1,135 @@
+from api.controllers.firmware import (
+    delete_firmware,
+    download_firmware,
+    list_firmware,
+)
+from core.domain.entities.firmware_bundle import FirmwareBundle
+from core.use_cases.manage_firmware import ManageFirmware
+from litestar.di import Provide
+from litestar.testing import create_test_client
+
+
+def _bundle(bundle_id=7, file_name="Plus2PM-1.7.5.zip"):
+    return FirmwareBundle(
+        id=bundle_id,
+        app_name="Plus2PM",
+        version="1.7.5",
+        build_id="20250611-100000/1.7.5-g1234567",
+        file_name=file_name,
+        size_bytes=2048,
+        sha256="ab" * 32,
+        downloaded_at=1753833600,
+    )
+
+
+def _client(route_handler, mock):
+    return create_test_client(
+        route_handlers=[route_handler],
+        dependencies={
+            "manage_firmware_use_case": Provide(lambda: mock, sync_to_thread=False)
+        },
+    )
+
+
+class TestFirmwareController:
+    def test_list_firmware_successfully(self):
+        class MockManageFirmware(ManageFirmware):
+            def __init__(self):
+                pass
+
+            async def list_bundles(self):
+                return [_bundle()]
+
+        with _client(list_firmware, MockManageFirmware()) as client:
+            response = client.get("/")
+
+            assert response.status_code == 200
+            data = response.json()
+            assert len(data) == 1
+            assert data[0]["id"] == 7
+            assert data[0]["app_name"] == "Plus2PM"
+            assert data[0]["version"] == "1.7.5"
+            assert data[0]["file_name"] == "Plus2PM-1.7.5.zip"
+            assert data[0]["size_bytes"] == 2048
+
+    def test_delete_firmware_successfully(self):
+        deleted = {}
+
+        class MockManageFirmware(ManageFirmware):
+            def __init__(self):
+                pass
+
+            async def delete_bundle(self, bundle_id):
+                deleted["id"] = bundle_id
+                return True
+
+        with _client(delete_firmware, MockManageFirmware()) as client:
+            response = client.delete("/7")
+
+            assert response.status_code == 204
+            assert deleted["id"] == 7
+
+    def test_delete_firmware_returns_404_for_a_missing_bundle(self):
+        class MockManageFirmware(ManageFirmware):
+            def __init__(self):
+                pass
+
+            async def delete_bundle(self, bundle_id):
+                return False
+
+        with _client(delete_firmware, MockManageFirmware()) as client:
+            response = client.delete("/7")
+
+            assert response.status_code == 404
+
+    def test_download_firmware_serves_the_zip(self, tmp_path):
+        payload = b"zip-bytes" * 100
+        zip_path = tmp_path / "Plus2PM-1.7.5.zip"
+        zip_path.write_bytes(payload)
+
+        class MockManageFirmware(ManageFirmware):
+            def __init__(self):
+                pass
+
+            async def get_bundle(self, bundle_id):
+                return _bundle(bundle_id=bundle_id)
+
+            def bundle_path(self, bundle):
+                return str(zip_path)
+
+        with _client(download_firmware, MockManageFirmware()) as client:
+            response = client.get("/7/download")
+
+            assert response.status_code == 200
+            assert response.content == payload
+            assert response.headers["content-type"] == "application/zip"
+            assert "Plus2PM-1.7.5.zip" in response.headers["content-disposition"]
+
+    def test_download_firmware_returns_404_for_a_missing_bundle(self):
+        class MockManageFirmware(ManageFirmware):
+            def __init__(self):
+                pass
+
+            async def get_bundle(self, bundle_id):
+                return None
+
+        with _client(download_firmware, MockManageFirmware()) as client:
+            response = client.get("/7/download")
+
+            assert response.status_code == 404
+
+    def test_download_firmware_returns_404_when_the_file_is_gone(self, tmp_path):
+        class MockManageFirmware(ManageFirmware):
+            def __init__(self):
+                pass
+
+            async def get_bundle(self, bundle_id):
+                return _bundle(bundle_id=bundle_id)
+
+            def bundle_path(self, bundle):
+                return str(tmp_path / "missing.zip")
+
+        with _client(download_firmware, MockManageFirmware()) as client:
+            response = client.get("/7/download")
+
+            assert response.status_code == 404

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -141,23 +141,27 @@ shelly-manager credentials delete AABBCCDDEEFF
 #### Update Commands
 
 ```bash
-# Check for available updates
-shelly-manager update check --all
-shelly-manager update check 192.168.1.100 192.168.1.101
+# Update one device, a range, or a whole subnet
+shelly-manager device update -t 192.168.1.100
+shelly-manager device update 192.168.1.0/24 --channel beta
 
-# Apply firmware updates
-shelly-manager update apply 192.168.1.100
-shelly-manager update apply 192.168.1.100 --channel beta
-
-# Check update status
-shelly-manager update status 192.168.1.100
+# Serve the firmware from this host, for devices with no internet access
+shelly-manager device update -t 192.168.1.100 --source local
 ```
 
 **Update Options:**
 
 - `--channel`: Update channel (stable, beta) - default: stable
+- `--source`: Where the device fetches firmware from (internet, local) - default: internet
 - `--force`: Skip confirmation prompts
-- `--timeout`: Update timeout (default: 30s)
+- `--timeout`: Request timeout in seconds
+- `--workers`: Maximum concurrent workers
+
+With `--source local` the manager downloads the official firmware once and the
+device fetches it from the manager, so only this host needs internet access.
+It reads the same firmware store as the API and requires
+`SHELLY_FIRMWARE_ADVERTISED_BASE_URL` to be set to a URL your devices can
+reach; the API must serve that URL. Stable channel only.
 
 ### Configuration Management
 

--- a/packages/cli/src/cli/commands/device_commands.py
+++ b/packages/cli/src/cli/commands/device_commands.py
@@ -15,7 +15,7 @@ from ..entities import (
     DeviceScanRequest,
     DeviceStatusRequest,
 )
-from ..exceptions import EXIT_VALIDATION
+from ..exceptions import EXIT_USAGE, EXIT_VALIDATION
 from ..presentation.styles import Messages
 from ..use_cases.device.component_actions import ComponentActionsUseCase
 from ..use_cases.device.device_status import DeviceStatusUseCase
@@ -309,6 +309,16 @@ async def reboot_devices(
     type=click.Choice([channel.value for channel in UpdateChannel]),
     default=UpdateChannel.STABLE.value,
 )
+@click.option(
+    "--source",
+    type=click.Choice(["internet", "local"]),
+    default="internet",
+    help=(
+        "Where the device fetches firmware from: internet (device downloads "
+        "from Shelly) or local (cached in this host's firmware store and "
+        "served to the device by the manager API, which must share it)"
+    ),
+)
 @click.option("--force", is_flag=True)
 @common_options
 @click.pass_context
@@ -318,6 +328,7 @@ async def update_firmware(
     targets: tuple[str, ...],
     targets_opt: tuple[str, ...],
     channel: str,
+    source: str,
     force: bool,
     timeout: int,
     workers: int,
@@ -327,7 +338,14 @@ async def update_firmware(
     Examples:
       shelly-manager device update -t 192.168.1.100
       shelly-manager device update 192.168.1.0/24 --channel beta
+      shelly-manager device update -t 192.168.1.100 --source local
     """
+    if source == "local" and channel != UpdateChannel.STABLE.value:
+        ctx.obj.console.print(
+            Messages.error("Local updates support the stable channel only")
+        )
+        sys.exit(EXIT_USAGE)
+
     request = ComponentActionRequest(
         targets=list(targets) + list(targets_opt),
         component_key="shelly",
@@ -343,6 +361,7 @@ async def update_firmware(
         request,
         "shelly-manager device update -t 192.168.1.100",
         "shelly-manager device update 192.168.1.0/24 --channel beta",
+        from_local_store=source == "local",
     )
 
 
@@ -396,11 +415,22 @@ async def _run_component_action(
     ctx: click.Context,
     request: ComponentActionRequest,
     *examples: str,
+    from_local_store: bool = False,
 ) -> None:
+    """Run one component action across every requested device.
+
+    ``from_local_store`` serves a firmware update out of this host's own
+    firmware store rather than leaving each device to fetch from the internet.
+    """
     console = ctx.obj.console
     actions_use_case = ComponentActionsUseCase(ctx.obj.container, console)
+    execute = (
+        actions_use_case.execute_local_update
+        if from_local_store
+        else actions_use_case.execute_action
+    )
     try:
-        results = await actions_use_case.execute_action(request)
+        results = await execute(request)
     except ValueError as e:
         _print_usage_error(console, e, *examples)
         sys.exit(EXIT_VALIDATION)

--- a/packages/cli/src/cli/use_cases/device/component_actions.py
+++ b/packages/cli/src/cli/use_cases/device/component_actions.py
@@ -5,6 +5,8 @@ Component actions CLI use case.
 import logging
 
 from core.domain.entities.discovered_device import DiscoveredDevice
+from core.domain.entities.exceptions import FirmwareConfigurationError
+from core.domain.value_objects.base_device_request import BaseDeviceRequest
 from core.domain.value_objects.component_action_request import (
     ComponentActionRequest as CoreActionRequest,
 )
@@ -121,6 +123,94 @@ class ComponentActionsUseCase:
                         action=request.action,
                         parameters=request.parameters,
                         message=f"Failed to execute {request.action}",
+                        error=str(e),
+                        action_successful=False,
+                    )
+                    results.append(result)
+
+                progress.advance()
+
+        return results
+
+    async def execute_local_update(
+        self, request: ComponentActionRequest
+    ) -> list[ComponentActionResult]:
+        """Update devices with firmware served from the manager's local store.
+
+        Same discovery, confirmation and progress flow as ``execute_action``,
+        but each device goes through the local-update interactor, which caches
+        the bundle on the manager host and points the device at it.
+        """
+        if not request.targets:
+            raise ValueError(
+                "No targets specified. Provide device IPs, ranges, or CIDR."
+            )
+
+        await self._container.initialize_database()
+
+        discovery_request = DeviceDiscoveryRequest(
+            targets=request.targets,
+            timeout=request.timeout,
+            workers=request.workers,
+        )
+        device_list: list[DiscoveredDevice] = (
+            await self._device_discovery.discover_devices(discovery_request)
+        )
+        device_ips = [d.ip for d in device_list]
+
+        if not device_ips:
+            return []
+
+        if not request.force:
+            devices = ", ".join(device_ips[:3]) + (
+                f" and {len(device_ips)-3} more" if len(device_ips) > 3 else ""
+            )
+
+            self._console.print(
+                "\n[yellow]About to execute:[/yellow] Update from local store"
+            )
+            self._console.print(f"[yellow]Target devices:[/yellow] {devices}")
+
+            if not self._console.input("\nContinue? [y/N]: ").lower().startswith("y"):
+                raise OperationCancelledError("Operation cancelled by user")
+
+        results = []
+        update_interactor = self._container.get_update_device_from_local_interactor()
+
+        async with self._progress_tracker.track_progress(
+            "Updating firmware from local store",
+            total=len(device_ips),
+        ) as progress:
+            for device_ip in device_ips:
+                try:
+                    action_result = await update_interactor.execute(
+                        BaseDeviceRequest(device_ip=device_ip)
+                    )
+
+                    result = ComponentActionResult(
+                        ip=device_ip,
+                        status="success" if action_result.success else "failed",
+                        component_key=request.component_key,
+                        action=request.action,
+                        parameters=request.parameters,
+                        message=action_result.message,
+                        error=action_result.error,
+                        action_successful=action_result.success,
+                        action_data=action_result.data,
+                    )
+                    results.append(result)
+
+                except FirmwareConfigurationError:
+                    raise
+
+                except Exception as e:
+                    result = ComponentActionResult(
+                        ip=device_ip,
+                        status="error",
+                        component_key=request.component_key,
+                        action=request.action,
+                        parameters=request.parameters,
+                        message="Failed to update from local store",
                         error=str(e),
                         action_successful=False,
                     )

--- a/packages/cli/tests/unit/commands/test_device_commands.py
+++ b/packages/cli/tests/unit/commands/test_device_commands.py
@@ -553,6 +553,58 @@ class TestActionsCommands:
 
         assert result.exit_code == 0
         assert "Update device firmware" in result.output
+        assert "--source" in result.output
+
+    def test_device_update_local_source(self, cli_context, sample_device):
+        """Test device update with the local source routes to the local interactor."""
+        from core.domain.value_objects.action_result import ActionResult
+
+        mock_scan_interactor = cli_context.container.get_scan_interactor.return_value
+        mock_scan_interactor.execute.return_value = [sample_device]
+        cli_context.container.initialize_database = AsyncMock()
+
+        mock_local_interactor = AsyncMock()
+        mock_local_interactor.execute.return_value = ActionResult(
+            device_ip=sample_device.ip,
+            action_type="shelly.Update",
+            success=True,
+            message="Update executed successfully on shelly",
+        )
+        cli_context.container.get_update_device_from_local_interactor.return_value = (
+            mock_local_interactor
+        )
+
+        runner = CliRunner()
+        result = runner.invoke(
+            device_commands,
+            ["update", "-t", sample_device.ip, "--source", "local", "--force"],
+            obj=cli_context,
+        )
+
+        assert result.exit_code == 0
+        mock_local_interactor.execute.assert_called_once()
+        request = mock_local_interactor.execute.call_args.args[0]
+        assert request.device_ip == sample_device.ip
+
+    def test_device_update_local_source_rejects_beta(self, cli_context):
+        """Test that a beta local update is refused."""
+        runner = CliRunner()
+        result = runner.invoke(
+            device_commands,
+            [
+                "update",
+                "-t",
+                "192.168.1.100",
+                "--source",
+                "local",
+                "--channel",
+                "beta",
+            ],
+            obj=cli_context,
+        )
+
+        assert result.exit_code != 0
+        cli_context.container.get_update_device_from_local_interactor.assert_not_called()
 
     def test_actions_execute_help(self, cli_context):
         """Test actions execute command help."""

--- a/packages/core/src/core/dependencies/container_base.py
+++ b/packages/core/src/core/dependencies/container_base.py
@@ -9,6 +9,7 @@ from core.gateways.device import LegacyDeviceGateway
 from core.gateways.device.ap_device_detector import APDeviceDetector
 from core.gateways.device.legacy_component_mapper import LegacyComponentMapper
 from core.gateways.device.shelly_device_gateway import ShellyDeviceGateway
+from core.gateways.firmware import ShellyCloudFirmwareGateway
 from core.gateways.network import (
     AsyncShellyRPCClient,
     LegacyHttpClient,
@@ -25,6 +26,9 @@ from core.repositories.sqlalchemy_backup_schedule_repository import (
 from core.repositories.sqlalchemy_credentials_repository import (
     SQLAlchemyCredentialsRepository,
 )
+from core.repositories.sqlalchemy_firmware_repository import (
+    SQLAlchemyFirmwareRepository,
+)
 from core.repositories.sqlalchemy_provisioning_profile_repository import (
     SQLAlchemyProvisioningProfileRepository,
 )
@@ -32,6 +36,7 @@ from core.services.auth_state_cache import AuthStateCache
 from core.services.authentication_service import AuthenticationService
 from core.services.encryption_service import EncryptionService
 from core.settings import settings as core_settings
+from core.use_cases.acquire_firmware import AcquireFirmware
 from core.use_cases.backup_device_config import BackupDeviceConfig
 from core.use_cases.bulk_operations import BulkOperationsUseCase
 from core.use_cases.capture_device_config import CaptureDeviceConfig
@@ -39,6 +44,7 @@ from core.use_cases.check_device_status import CheckDeviceStatusUseCase
 from core.use_cases.execute_component_action import ExecuteComponentActionUseCase
 from core.use_cases.get_component_actions import GetComponentActionsUseCase
 from core.use_cases.manage_backup_schedules import ManageBackupSchedulesUseCase
+from core.use_cases.manage_firmware import ManageFirmware
 from core.use_cases.manage_provisioning_profiles import (
     ManageProvisioningProfilesUseCase,
 )
@@ -46,6 +52,7 @@ from core.use_cases.provision_device import ProvisionDeviceUseCase
 from core.use_cases.restore_device_config import RestoreDeviceConfig
 from core.use_cases.run_due_backups import RunDueBackupsUseCase
 from core.use_cases.scan_devices import ScanDevicesUseCase
+from core.use_cases.update_device_from_local import UpdateDeviceFromLocal
 
 
 class BaseContainer:
@@ -72,6 +79,10 @@ class BaseContainer:
             ManageBackupSchedulesUseCase | None
         ) = None
         self._run_due_backups_interactor: RunDueBackupsUseCase | None = None
+        self._firmware_gateway: ShellyCloudFirmwareGateway | None = None
+        self._acquire_firmware_interactor: AcquireFirmware | None = None
+        self._update_device_from_local_interactor: UpdateDeviceFromLocal | None = None
+        self._manage_firmware_interactor: ManageFirmware | None = None
         # Every slot above is a device-scoped cache cleared by
         # _reset_device_caches(); slots below survive close().
         self._device_cache_slots: tuple[str, ...] = tuple(vars(self))
@@ -112,10 +123,28 @@ class BaseContainer:
             )
         return self._device_gateway
 
+    def get_firmware_gateway(self) -> ShellyCloudFirmwareGateway:
+        if self._firmware_gateway is None:
+            self._firmware_gateway = ShellyCloudFirmwareGateway(
+                index_url=core_settings.firmware.index_url,
+                verify=core_settings.firmware.verify_ssl,
+                allowed_download_hosts=(
+                    core_settings.firmware.download_host_allow_list()
+                ),
+            )
+        return self._firmware_gateway
+
     async def _aclose_legacy_http_client(self) -> None:
         if self._legacy_http_client is not None:
             try:
                 await self._legacy_http_client.close()
+            except Exception:
+                pass
+
+    async def _aclose_firmware_gateway(self) -> None:
+        if self._firmware_gateway is not None:
+            try:
+                await self._firmware_gateway.close()
             except Exception:
                 pass
 
@@ -181,6 +210,33 @@ class BaseContainer:
                 device_gateway=self.get_device_gateway()
             )
         return self._bulk_operations_interactor
+
+    def get_acquire_firmware_interactor(self) -> AcquireFirmware:
+        if self._acquire_firmware_interactor is None:
+            self._acquire_firmware_interactor = AcquireFirmware(
+                firmware_gateway=self.get_firmware_gateway(),
+                repository_factory=self.create_firmware_repository,
+                settings=core_settings.firmware,
+            )
+        return self._acquire_firmware_interactor
+
+    def get_update_device_from_local_interactor(self) -> UpdateDeviceFromLocal:
+        if self._update_device_from_local_interactor is None:
+            self._update_device_from_local_interactor = UpdateDeviceFromLocal(
+                device_gateway=self.get_device_gateway(),
+                firmware_gateway=self.get_firmware_gateway(),
+                acquire_firmware=self.get_acquire_firmware_interactor(),
+                settings=core_settings.firmware,
+            )
+        return self._update_device_from_local_interactor
+
+    def get_manage_firmware_interactor(self) -> ManageFirmware:
+        if self._manage_firmware_interactor is None:
+            self._manage_firmware_interactor = ManageFirmware(
+                repository_factory=self.create_firmware_repository,
+                settings=core_settings.firmware,
+            )
+        return self._manage_firmware_interactor
 
     def get_ap_device_detector(self) -> APDeviceDetector:
         if self._ap_device_detector is None:
@@ -281,6 +337,16 @@ class BaseContainer:
                 await session.close()
 
     @asynccontextmanager
+    async def create_firmware_repository(
+        self,
+    ) -> AsyncGenerator[SQLAlchemyFirmwareRepository, None]:
+        async with async_session_factory() as session:
+            try:
+                yield SQLAlchemyFirmwareRepository(session)
+            finally:
+                await session.close()
+
+    @asynccontextmanager
     async def create_backup_schedule_repository(
         self,
     ) -> AsyncGenerator[SQLAlchemyBackupScheduleRepository, None]:
@@ -304,6 +370,7 @@ class BaseContainer:
                 pass
 
         await self._aclose_legacy_http_client()
+        await self._aclose_firmware_gateway()
 
         self._rpc_client = None
         self._reset_device_caches()

--- a/packages/core/src/core/domain/entities/exceptions.py
+++ b/packages/core/src/core/domain/entities/exceptions.py
@@ -107,6 +107,20 @@ class LoggingError(ShellyManagerError):
         super().__init__(msg, {"operation": operation, "error": error})
 
 
+class FirmwareError(ShellyManagerError):
+
+    def __init__(self, message: str, details: dict[str, Any] | None = None):
+        super().__init__(message, details)
+
+
+class FirmwareConfigurationError(FirmwareError):
+    """Raised when the firmware feature itself is not set up on this server.
+
+    Separate from its parent so callers can tell an operator's missing
+    configuration apart from a request that cannot be satisfied.
+    """
+
+
 class DomainError(ShellyManagerError):
 
     def __init__(self, message: str, details: dict[str, Any] | None = None):

--- a/packages/core/src/core/domain/entities/firmware_bundle.py
+++ b/packages/core/src/core/domain/entities/firmware_bundle.py
@@ -1,0 +1,21 @@
+"""Cached firmware bundle domain entity."""
+
+from dataclasses import dataclass
+
+
+@dataclass
+class FirmwareBundle:
+    """A firmware zip cached on the manager host and served to devices over LAN.
+
+    The zip blob lives on disk under the configured firmware directory as
+    ``file_name``; only metadata is persisted in the database.
+    """
+
+    app_name: str
+    version: str
+    build_id: str
+    file_name: str
+    size_bytes: int = 0
+    sha256: str | None = None
+    id: int | None = None
+    downloaded_at: int | None = None

--- a/packages/core/src/core/domain/enums/enums.py
+++ b/packages/core/src/core/domain/enums/enums.py
@@ -25,8 +25,10 @@ class UpdateChannel(str, Enum):
     def to_update_parameters(self) -> dict[str, str]:
         """Parameters for a firmware Update action.
 
-        Stable is the device-side default, so it sends no channel at all.
+        Shelly.Update names this field stage. A device silently ignores an
+        unknown parameter, so sending channel installed stable no matter what
+        was asked for. Stable is the device-side default and sends nothing.
         """
         if self is UpdateChannel.STABLE:
             return {}
-        return {"channel": self.value}
+        return {"stage": self.value}

--- a/packages/core/src/core/domain/value_objects/firmware_release.py
+++ b/packages/core/src/core/domain/value_objects/firmware_release.py
@@ -1,0 +1,15 @@
+"""Firmware release value objects."""
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class FirmwareRelease(BaseModel):
+    """A downloadable firmware build published in the Shelly update index."""
+
+    model_config = ConfigDict(frozen=True)
+
+    app_name: str = Field(..., description="Device app name, e.g. 'Plus2PM'")
+    version: str = Field(..., description="Firmware version, e.g. '1.7.5'")
+    build_id: str = Field(..., description="Full build identifier")
+    download_url: str = Field(..., description="Direct download URL for the bundle")
+    channel: str = Field(default="stable", description="Release channel (stable/beta)")

--- a/packages/core/src/core/gateways/firmware/__init__.py
+++ b/packages/core/src/core/gateways/firmware/__init__.py
@@ -1,0 +1,9 @@
+"""Firmware gateway implementations."""
+
+from .firmware import FirmwareGateway
+from .shelly_cloud_firmware_gateway import ShellyCloudFirmwareGateway
+
+__all__ = [
+    "FirmwareGateway",
+    "ShellyCloudFirmwareGateway",
+]

--- a/packages/core/src/core/gateways/firmware/firmware.py
+++ b/packages/core/src/core/gateways/firmware/firmware.py
@@ -1,0 +1,19 @@
+"""Abstract gateway for firmware index queries and bundle downloads."""
+
+from abc import ABC, abstractmethod
+
+from core.domain.value_objects.firmware_release import FirmwareRelease
+
+
+class FirmwareGateway(ABC):
+    @abstractmethod
+    async def get_latest(self, app_name: str) -> FirmwareRelease | None:
+        """Latest stable release for an app, or ``None`` when the index has none."""
+        pass
+
+    @abstractmethod
+    async def download(
+        self, release: FirmwareRelease, dest_path: str
+    ) -> tuple[int, str]:
+        """Download a release to ``dest_path``. Returns (size_bytes, sha256)."""
+        pass

--- a/packages/core/src/core/gateways/firmware/shelly_cloud_firmware_gateway.py
+++ b/packages/core/src/core/gateways/firmware/shelly_cloud_firmware_gateway.py
@@ -1,0 +1,283 @@
+"""Firmware gateway backed by the official Shelly update index and CDN."""
+
+import hashlib
+import logging
+import os
+import re
+import uuid
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlparse
+
+import httpx
+
+from core.domain.entities.exceptions import FirmwareError
+from core.domain.value_objects.firmware_release import FirmwareRelease
+
+from .firmware import FirmwareGateway
+
+logger = logging.getLogger(__name__)
+
+_SAFE_APP_NAME = re.compile(r"[A-Za-z0-9._-]+")
+_MAX_BUNDLE_SIZE_BYTES = 100 * 1024 * 1024
+_MAX_DOWNLOAD_REDIRECTS = 5
+
+
+class ShellyCloudFirmwareGateway(FirmwareGateway):
+    """Fetches firmware metadata and bundles from Shelly's public endpoints.
+
+    The index endpoint is undocumented (the same dependency the community
+    tools take), so a missing or unexpected response means "no release",
+    never a crash.
+    """
+
+    def __init__(
+        self,
+        index_url: str,
+        session: httpx.AsyncClient | None = None,
+        timeout: float = 60.0,
+        connect_timeout: float = 5.0,
+        verify: bool = True,
+        allowed_download_hosts: list[str] | None = None,
+    ) -> None:
+        self._index_url = index_url.rstrip("/")
+        self._allowed_download_hosts = tuple(
+            normalised
+            for host in (
+                ["shelly.cloud"]
+                if allowed_download_hosts is None
+                else allowed_download_hosts
+            )
+            if (normalised := _normalise_host(host))
+        )
+        if session is not None:
+            self._session = session
+        else:
+            self._session = httpx.AsyncClient(
+                timeout=httpx.Timeout(timeout, connect=connect_timeout),
+                follow_redirects=True,
+                verify=verify,
+            )
+
+    async def get_latest(self, app_name: str) -> FirmwareRelease | None:
+        if not _is_safe_app_name(app_name):
+            raise FirmwareError(
+                f"Refusing firmware lookup for unsafe app name '{app_name}'",
+                {"app_name": app_name},
+            )
+
+        url = f"{self._index_url}/{app_name}"
+        logger.info("Querying Shelly firmware index: %s", url)
+        try:
+            response = await self._session.get(url)
+            if response.status_code == 404:
+                return None
+            response.raise_for_status()
+            data = response.json()
+        except (httpx.HTTPError, ValueError) as e:
+            raise FirmwareError(
+                f"Firmware index request failed for {app_name}: {e}",
+                {"app_name": app_name},
+            ) from e
+
+        return _release_from_index_entry(app_name, data)
+
+    async def download(
+        self, release: FirmwareRelease, dest_path: str
+    ) -> tuple[int, str]:
+        logger.info("Downloading firmware bundle: %s", release.download_url)
+        tmp_path = f"{dest_path}.{uuid.uuid4().hex}.part"
+        digest = hashlib.sha256()
+        size = 0
+        url = release.download_url
+        try:
+            for _ in range(_MAX_DOWNLOAD_REDIRECTS + 1):
+                self._reject_untrusted_download(url, release)
+                async with self._session.stream(
+                    "GET",
+                    url,
+                    headers={"Accept-Encoding": "identity"},
+                    follow_redirects=False,
+                ) as response:
+                    if response.is_redirect:
+                        url = _redirect_target(response, release)
+                        continue
+
+                    response.raise_for_status()
+                    _reject_compressed(response, release)
+                    _reject_oversized(response, release)
+                    with open(tmp_path, "wb") as handle:
+                        # Only safe because an encoded body was refused above:
+                        # httpx decodes a whole chunk before yielding it.
+                        async for chunk in response.aiter_bytes():
+                            size += len(chunk)
+                            if size > _MAX_BUNDLE_SIZE_BYTES:
+                                raise FirmwareError(
+                                    f"Firmware download for {release.app_name}"
+                                    f" {release.version} exceeded"
+                                    f" {_MAX_BUNDLE_SIZE_BYTES} bytes",
+                                    {
+                                        "app_name": release.app_name,
+                                        "version": release.version,
+                                    },
+                                )
+                            handle.write(chunk)
+                            digest.update(chunk)
+                    if size == 0:
+                        raise FirmwareError(
+                            f"Firmware download for {release.app_name}"
+                            f" {release.version} was empty",
+                            {
+                                "app_name": release.app_name,
+                                "version": release.version,
+                            },
+                        )
+                    break
+            else:
+                raise FirmwareError(
+                    f"Firmware download for {release.app_name} {release.version}"
+                    f" redirected more than {_MAX_DOWNLOAD_REDIRECTS} times",
+                    {"app_name": release.app_name, "version": release.version},
+                )
+            os.replace(tmp_path, dest_path)
+        except (httpx.HTTPError, httpx.InvalidURL, OSError, UnicodeError) as e:
+            raise FirmwareError(
+                f"Firmware download failed for {release.app_name}"
+                f" {release.version}: {e}",
+                {"app_name": release.app_name, "version": release.version},
+            ) from e
+        finally:
+            Path(tmp_path).unlink(missing_ok=True)
+        return size, digest.hexdigest()
+
+    async def close(self) -> None:
+        await self._session.aclose()
+
+    def _reject_untrusted_download(self, url: str, release: FirmwareRelease) -> None:
+        """Refuse a download address firmware should never come from.
+
+        The index response decides where a bundle lives, and TLS verification
+        is off by default because Shelly signs those endpoints privately. A
+        substituted response, or a redirect from a host that honours one,
+        could otherwise make the manager fetch any address it can reach and
+        hand the body back through the unauthenticated download route.
+        """
+        parsed = urlparse(url)
+        details = {"app_name": release.app_name, "version": release.version}
+
+        if parsed.scheme not in ("http", "https"):
+            raise FirmwareError(
+                f"Refusing firmware download over unsupported scheme"
+                f" '{parsed.scheme}'",
+                details,
+            )
+
+        host = _normalise_host(parsed.hostname or "")
+        if not host:
+            raise FirmwareError(
+                "Refusing firmware download from a URL with no host", details
+            )
+
+        if not self._allowed_download_hosts:
+            return
+
+        if not any(
+            host == allowed or host.endswith(f".{allowed}")
+            for allowed in self._allowed_download_hosts
+        ):
+            raise FirmwareError(
+                f"Refusing firmware download from untrusted host '{host}'",
+                details,
+            )
+
+
+def _normalise_host(value: str) -> str:
+    """A bare lowercase hostname, however the entry or URL spelled it.
+
+    Accepts the shapes an operator reasonably writes in the allow list, and
+    matches the trailing dot of an absolute name against the same entry.
+    """
+    host = value.strip().lower()
+    if "://" in host:
+        host = host.split("://", 1)[1]
+    host = host.split("/", 1)[0].split("@")[-1]
+    if host.startswith("*."):
+        host = host[2:]
+    return host.split(":", 1)[0].strip(".") if "]" not in host else host.strip(".")
+
+
+def _is_safe_app_name(value: str) -> bool:
+    """Whether the name is safe as a URL path segment.
+
+    "." and ".." satisfy the character class but resolve to a different index
+    path once the URL is normalized.
+    """
+    return value not in (".", "..") and bool(_SAFE_APP_NAME.fullmatch(value))
+
+
+def _redirect_target(response: httpx.Response, release: FirmwareRelease) -> str:
+    """The absolute address a redirect points at."""
+    location = response.headers.get("location", "").strip()
+    if not location:
+        raise FirmwareError(
+            f"Firmware download for {release.app_name} {release.version}"
+            f" was redirected without a target",
+            {"app_name": release.app_name, "version": release.version},
+        )
+    return str(response.url.join(location))
+
+
+def _reject_compressed(response: httpx.Response, release: FirmwareRelease) -> None:
+    """Refuse a body the client would have to decompress to read.
+
+    Firmware bundles are already zips, so a content encoding here is either a
+    broken server or an attempt to expand a small body into a large one.
+    """
+    encoding = response.headers.get("content-encoding", "").strip().lower()
+    if encoding and encoding != "identity":
+        raise FirmwareError(
+            f"Firmware download for {release.app_name} {release.version}"
+            f" arrived with unsupported content encoding '{encoding}'",
+            {"app_name": release.app_name, "version": release.version},
+        )
+
+
+def _reject_oversized(response: httpx.Response, release: FirmwareRelease) -> None:
+    """Refuse a body whose declared length already exceeds the cap."""
+    declared = response.headers.get("content-length", "")
+    if declared.isdigit() and int(declared) > _MAX_BUNDLE_SIZE_BYTES:
+        raise FirmwareError(
+            f"Firmware download for {release.app_name} {release.version}"
+            f" declares {declared} bytes, over the"
+            f" {_MAX_BUNDLE_SIZE_BYTES} byte limit",
+            {"app_name": release.app_name, "version": release.version},
+        )
+
+
+def _release_from_index_entry(app_name: str, data: Any) -> FirmwareRelease | None:
+    if not isinstance(data, dict):
+        return None
+    stable = data.get("stable")
+    if not isinstance(stable, dict):
+        return None
+
+    version = stable.get("version")
+    build_id = stable.get("build_id")
+    download_url = stable.get("url")
+    if not (
+        isinstance(version, str)
+        and version
+        and isinstance(build_id, str)
+        and build_id
+        and isinstance(download_url, str)
+        and download_url
+    ):
+        return None
+
+    return FirmwareRelease(
+        app_name=app_name,
+        version=version,
+        build_id=build_id,
+        download_url=download_url,
+        channel="stable",
+    )

--- a/packages/core/src/core/repositories/firmware_repository.py
+++ b/packages/core/src/core/repositories/firmware_repository.py
@@ -1,0 +1,44 @@
+"""Abstract repository for cached firmware bundles."""
+
+from abc import ABC, abstractmethod
+
+from core.domain.entities.firmware_bundle import FirmwareBundle
+
+
+class FirmwareRepository(ABC):
+    @abstractmethod
+    async def create(self, bundle: FirmwareBundle) -> FirmwareBundle:
+        """Persist a bundle. Returns the bundle with its assigned ID.
+
+        Storing a bundle that already exists (same app name, version and
+        build ID) returns the existing record instead of failing, so two
+        writers racing on one store converge on a single row.
+        """
+        pass
+
+    @abstractmethod
+    async def get(self, bundle_id: int) -> FirmwareBundle | None:
+        """Retrieve a bundle by ID."""
+        pass
+
+    @abstractmethod
+    async def find(
+        self, app_name: str, version: str, build_id: str
+    ) -> FirmwareBundle | None:
+        """Find the cached bundle for one exact release.
+
+        Matches the whole stored identity rather than app and version alone, so
+        a version republished under a new build is a miss and gets fetched
+        instead of serving the previous build's bytes.
+        """
+        pass
+
+    @abstractmethod
+    async def list(self) -> list[FirmwareBundle]:
+        """List every cached bundle, newest first."""
+        pass
+
+    @abstractmethod
+    async def delete(self, bundle_id: int) -> bool:
+        """Delete a bundle by ID. Returns ``True`` if a row was deleted."""
+        pass

--- a/packages/core/src/core/repositories/models.py
+++ b/packages/core/src/core/repositories/models.py
@@ -1,6 +1,6 @@
 from datetime import UTC, datetime
 
-from sqlalchemy import Boolean, Integer, String
+from sqlalchemy import Boolean, Integer, String, UniqueConstraint
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
 
 
@@ -80,6 +80,28 @@ class DeviceBackups(Base):
         return (
             f"<DeviceBackups(id={self.id}, device_mac='{self.device_mac}', "
             f"source='{self.source}')>"
+        )
+
+
+class FirmwareBundles(Base):
+    __tablename__ = "firmware_bundles"
+    __table_args__ = (UniqueConstraint("app_name", "version", "build_id"),)
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    app_name: Mapped[str] = mapped_column(String, nullable=False, index=True)
+    version: Mapped[str] = mapped_column(String, nullable=False)
+    build_id: Mapped[str] = mapped_column(String, nullable=False)
+    file_name: Mapped[str] = mapped_column(String, nullable=False)
+    size_bytes: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    sha256: Mapped[str | None] = mapped_column(String, nullable=True)
+    downloaded_at: Mapped[int] = mapped_column(
+        Integer, default=lambda: int(datetime.now(UTC).timestamp())
+    )
+
+    def __repr__(self) -> str:
+        return (
+            f"<FirmwareBundles(id={self.id}, app_name='{self.app_name}', "
+            f"version='{self.version}')>"
         )
 
 

--- a/packages/core/src/core/repositories/sqlalchemy_firmware_repository.py
+++ b/packages/core/src/core/repositories/sqlalchemy_firmware_repository.py
@@ -1,0 +1,88 @@
+"""SQLAlchemy implementation of the firmware bundle repository."""
+
+from core.domain.entities.firmware_bundle import FirmwareBundle
+from core.repositories.firmware_repository import FirmwareRepository
+from core.repositories.models import FirmwareBundles as FirmwareBundleModel
+from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+
+class SQLAlchemyFirmwareRepository(FirmwareRepository):
+    def __init__(self, session: AsyncSession):
+        self.session = session
+
+    async def create(self, bundle: FirmwareBundle) -> FirmwareBundle:
+        record = FirmwareBundleModel(
+            app_name=bundle.app_name,
+            version=bundle.version,
+            build_id=bundle.build_id,
+            file_name=bundle.file_name,
+            size_bytes=bundle.size_bytes,
+            sha256=bundle.sha256,
+        )
+        self.session.add(record)
+        try:
+            await self.session.commit()
+        except IntegrityError:
+            await self.session.rollback()
+            existing = await self.find(bundle.app_name, bundle.version, bundle.build_id)
+            if existing is not None:
+                return existing
+            raise
+        await self.session.refresh(record)
+
+        bundle.id = record.id
+        bundle.downloaded_at = record.downloaded_at
+        return bundle
+
+    async def get(self, bundle_id: int) -> FirmwareBundle | None:
+        stmt = select(FirmwareBundleModel).where(FirmwareBundleModel.id == bundle_id)
+        result = await self.session.execute(stmt)
+        record = result.scalar_one_or_none()
+        if record is None:
+            return None
+        return self._to_domain(record)
+
+    async def find(
+        self, app_name: str, version: str, build_id: str
+    ) -> FirmwareBundle | None:
+        stmt = select(FirmwareBundleModel).where(
+            FirmwareBundleModel.app_name == app_name,
+            FirmwareBundleModel.version == version,
+            FirmwareBundleModel.build_id == build_id,
+        )
+        result = await self.session.execute(stmt)
+        record = result.scalar_one_or_none()
+        if record is None:
+            return None
+        return self._to_domain(record)
+
+    async def list(self) -> list[FirmwareBundle]:
+        stmt = select(FirmwareBundleModel).order_by(
+            FirmwareBundleModel.downloaded_at.desc(), FirmwareBundleModel.id.desc()
+        )
+        result = await self.session.execute(stmt)
+        return [self._to_domain(record) for record in result.scalars().all()]
+
+    async def delete(self, bundle_id: int) -> bool:
+        stmt = select(FirmwareBundleModel).where(FirmwareBundleModel.id == bundle_id)
+        result = await self.session.execute(stmt)
+        record = result.scalar_one_or_none()
+        if record is None:
+            return False
+        await self.session.delete(record)
+        await self.session.commit()
+        return True
+
+    def _to_domain(self, record: FirmwareBundleModel) -> FirmwareBundle:
+        return FirmwareBundle(
+            id=record.id,
+            app_name=record.app_name,
+            version=record.version,
+            build_id=record.build_id,
+            file_name=record.file_name,
+            size_bytes=record.size_bytes,
+            sha256=record.sha256,
+            downloaded_at=record.downloaded_at,
+        )

--- a/packages/core/src/core/settings.py
+++ b/packages/core/src/core/settings.py
@@ -81,6 +81,75 @@ class BackupSettings(BaseSettings):
     )
 
 
+class FirmwareSettings(BaseSettings):
+    model_config = SettingsConfigDict(env_prefix="SHELLY_FIRMWARE_")
+
+    dir: str = Field(
+        default="./data/firmware",
+        description="Directory for cached firmware bundles",
+    )
+    advertised_base_url: str | None = Field(
+        default=None,
+        description=(
+            "Base URL devices use to reach this API over LAN, "
+            "e.g. http://192.168.40.252:8000. Required for local updates; "
+            "it cannot be guessed from the server side."
+        ),
+    )
+    index_url: str = Field(
+        default="https://updates.shelly.cloud/update",
+        description="Shelly firmware index base URL",
+    )
+    verify_ssl: bool = Field(
+        default=False,
+        description=(
+            "Verify TLS certificates for the firmware index and CDN. Off by "
+            "default because Shelly signs updates.shelly.cloud with a private "
+            "Allterco CA that no public trust store contains; firmware "
+            "integrity is enforced by the device's own signature check."
+        ),
+    )
+    allowed_download_hosts: str = Field(
+        default="shelly.cloud",
+        description=(
+            "Comma separated hosts a firmware bundle may be downloaded from, "
+            "matched exactly or as a parent domain, and re-checked on every "
+            "redirect. The index names the download URL, and with TLS "
+            "verification off that response is worth distrusting, so this "
+            "keeps it from pointing the manager at hosts it can reach but the "
+            "internet cannot. Set it to * to accept any host; an empty value "
+            "keeps the default rather than accepting any."
+        ),
+    )
+
+    @field_validator("allowed_download_hosts", mode="before")
+    @classmethod
+    def accept_a_list_of_hosts(cls, value: Any) -> Any:
+        """Take the JSON list shape a config file invites as well as a string."""
+        if isinstance(value, list | tuple):
+            return ",".join(str(host) for host in value)
+        return value
+
+    def download_host_allow_list(self) -> list[str]:
+        """The hosts firmware may come from, empty meaning any host.
+
+        Kept as a string because a list field can only be set from the
+        environment as JSON, and this is a knob operators are invited to set;
+        a comma separated value would otherwise stop the app at import. An
+        empty value falls back to the default instead of accepting any host,
+        so a blank entry in a deployment template cannot quietly turn the
+        check off; * is how that is asked for.
+        """
+        hosts = [
+            host.strip().lower()
+            for host in self.allowed_download_hosts.split(",")
+            if host.strip()
+        ]
+        if not hosts:
+            return ["shelly.cloud"]
+        return [] if "*" in hosts else hosts
+
+
 class APISettings(BaseSettings):
     model_config = SettingsConfigDict(env_prefix="API_")
 
@@ -103,6 +172,7 @@ class AppSettings(BaseSettings):
     network: NetworkSettings = Field(default_factory=NetworkSettings)
     api: APISettings = Field(default_factory=APISettings)
     backup: BackupSettings = Field(default_factory=BackupSettings)
+    firmware: FirmwareSettings = Field(default_factory=FirmwareSettings)
 
     config_file: str = Field(
         default="config.json", description="Configuration file path"
@@ -147,6 +217,8 @@ class AppSettings(BaseSettings):
                 self.api = APISettings(**raw["api"])
             if isinstance(raw.get("backup"), dict):
                 self.backup = BackupSettings(**raw["backup"])
+            if isinstance(raw.get("firmware"), dict):
+                self.firmware = FirmwareSettings(**raw["firmware"])
 
             for field_name in ["config_file", "data_dir", "cache_ttl"]:
                 if field_name in raw:
@@ -165,6 +237,7 @@ class AppSettings(BaseSettings):
                 "network": self.network.model_dump(),
                 "api": self.api.model_dump(),
                 "backup": self.backup.model_dump(),
+                "firmware": self.firmware.model_dump(),
                 "config_file": self.config_file,
                 "data_dir": self.data_dir,
                 "cache_ttl": self.cache_ttl,
@@ -185,6 +258,9 @@ class AppSettings(BaseSettings):
         try:
             data_path = Path(self.data_dir)
             data_path.mkdir(parents=True, exist_ok=True)
+
+            firmware_path = Path(self.firmware.dir)
+            firmware_path.mkdir(parents=True, exist_ok=True)
 
             if self.network.timeout <= 0:
                 raise ValidationError(

--- a/packages/core/src/core/use_cases/acquire_firmware.py
+++ b/packages/core/src/core/use_cases/acquire_firmware.py
@@ -1,0 +1,154 @@
+"""Use case for acquiring firmware bundles into the local store."""
+
+import asyncio
+import hashlib
+import logging
+import os
+import re
+from collections.abc import Callable
+from contextlib import AbstractAsyncContextManager
+
+from core.domain.entities.exceptions import FirmwareError
+from core.domain.entities.firmware_bundle import FirmwareBundle
+from core.domain.value_objects.firmware_release import FirmwareRelease
+from core.gateways.firmware import FirmwareGateway
+from core.repositories.firmware_repository import FirmwareRepository
+from core.settings import FirmwareSettings
+
+logger = logging.getLogger(__name__)
+
+_SAFE_NAME = re.compile(r"[A-Za-z0-9._-]+")
+
+
+class AcquireFirmware:
+    """Download the latest firmware for an app into the local store.
+
+    One download serves every device reporting the same app; a cached bundle
+    at the latest version skips the download entirely.
+    """
+
+    def __init__(
+        self,
+        firmware_gateway: FirmwareGateway,
+        repository_factory: Callable[
+            [], AbstractAsyncContextManager[FirmwareRepository]
+        ],
+        settings: FirmwareSettings,
+    ):
+        self._firmware_gateway = firmware_gateway
+        self._repository_factory = repository_factory
+        self._settings = settings
+        self._acquire_lock = asyncio.Lock()
+
+    async def execute(
+        self, app_name: str, release: FirmwareRelease | None = None
+    ) -> FirmwareBundle:
+        """Return the cached bundle at the latest version, downloading on a miss.
+
+        A caller that already resolved the release passes it in, so one update
+        never queries the index twice and cannot act on a release that changed
+        between the two reads.
+
+        Raises:
+            FirmwareError: If the app name is unsafe, the index has no release
+                for ``app_name``, or the download fails.
+        """
+        if not _is_safe_name(app_name):
+            raise FirmwareError(
+                f"Refusing firmware acquisition for unsafe app name '{app_name}'",
+                {"app_name": app_name},
+            )
+
+        if release is None:
+            release = await self._firmware_gateway.get_latest(app_name)
+        if release is None:
+            raise FirmwareError(
+                f"No firmware published for app '{app_name}'",
+                {"app_name": app_name},
+            )
+        if not _is_safe_name(release.version):
+            raise FirmwareError(
+                f"Refusing unsafe firmware version '{release.version}'"
+                f" from the index for app '{app_name}'",
+                {"app_name": app_name, "version": release.version},
+            )
+
+        async with self._acquire_lock:
+            os.makedirs(self._settings.dir, exist_ok=True)
+
+            async with self._repository_factory() as repository:
+                cached = await repository.find(
+                    app_name, release.version, release.build_id
+                )
+            if cached is not None:
+                return await self._ensure_on_disk(cached, release)
+
+            file_name = _file_name_for(app_name, release)
+            dest_path = os.path.join(self._settings.dir, file_name)
+            size_bytes, sha256 = await self._firmware_gateway.download(
+                release, dest_path
+            )
+
+            bundle = FirmwareBundle(
+                app_name=app_name,
+                version=release.version,
+                build_id=release.build_id,
+                file_name=file_name,
+                size_bytes=size_bytes,
+                sha256=sha256,
+            )
+            async with self._repository_factory() as repository:
+                return await repository.create(bundle)
+
+    async def _ensure_on_disk(
+        self, cached: FirmwareBundle, release: FirmwareRelease
+    ) -> FirmwareBundle:
+        """Return the cached bundle, restoring its zip if it left the disk."""
+        path = os.path.join(self._settings.dir, os.path.basename(cached.file_name))
+        if os.path.isfile(path):
+            logger.info(
+                "Firmware cache hit for %s %s (bundle %s)",
+                cached.app_name,
+                cached.version,
+                cached.id,
+            )
+            return cached
+
+        logger.warning(
+            "Firmware bundle %s (%s %s) has no file on disk; re-downloading",
+            cached.id,
+            cached.app_name,
+            cached.version,
+        )
+        _, sha256 = await self._firmware_gateway.download(release, path)
+        if cached.sha256 and sha256 != cached.sha256:
+            logger.warning(
+                "Re-downloaded firmware bundle %s differs from its stored"
+                " sha256; the index republished %s %s",
+                cached.id,
+                cached.app_name,
+                cached.version,
+            )
+        return cached
+
+
+def _is_safe_name(value: str) -> bool:
+    """Whether the name is safe as a path segment.
+
+    "." and ".." satisfy the character class but are traversal.
+    """
+    return value not in (".", "..") and bool(_SAFE_NAME.fullmatch(value))
+
+
+def _file_name_for(app_name: str, release: FirmwareRelease) -> str:
+    """A distinct file name per stored bundle identity.
+
+    Rows are unique on (app_name, version, build_id), so the file has to be too
+    or deleting one bundle would remove another's zip. The build id is not
+    path-safe, and the readable prefix alone is ambiguous ("a-b" with "c" and
+    "a" with "b-c" share it), so the hash covers the whole identity joined by a
+    byte that validation keeps out of every part.
+    """
+    identity = "\0".join((app_name, release.version, release.build_id))
+    digest = hashlib.sha256(identity.encode()).hexdigest()[:16]
+    return f"{app_name}-{release.version}-{digest}.zip"

--- a/packages/core/src/core/use_cases/manage_firmware.py
+++ b/packages/core/src/core/use_cases/manage_firmware.py
@@ -1,0 +1,56 @@
+"""Use case for browsing and pruning the local firmware store."""
+
+import logging
+import os
+from collections.abc import Callable
+from contextlib import AbstractAsyncContextManager
+from pathlib import Path
+
+from core.domain.entities.firmware_bundle import FirmwareBundle
+from core.repositories.firmware_repository import FirmwareRepository
+from core.settings import FirmwareSettings
+
+logger = logging.getLogger(__name__)
+
+
+class ManageFirmware:
+    """List cached firmware bundles, resolve their zips on disk, delete them."""
+
+    def __init__(
+        self,
+        repository_factory: Callable[
+            [], AbstractAsyncContextManager[FirmwareRepository]
+        ],
+        settings: FirmwareSettings,
+    ):
+        self._repository_factory = repository_factory
+        self._settings = settings
+
+    async def list_bundles(self) -> list[FirmwareBundle]:
+        async with self._repository_factory() as repository:
+            return await repository.list()
+
+    async def get_bundle(self, bundle_id: int) -> FirmwareBundle | None:
+        async with self._repository_factory() as repository:
+            return await repository.get(bundle_id)
+
+    async def delete_bundle(self, bundle_id: int) -> bool:
+        """Delete a bundle's metadata and its zip. Returns ``True`` if it existed."""
+        async with self._repository_factory() as repository:
+            bundle = await repository.get(bundle_id)
+            if bundle is None:
+                return False
+            deleted = await repository.delete(bundle_id)
+        if deleted:
+            Path(self.bundle_path(bundle)).unlink(missing_ok=True)
+            logger.info(
+                "Deleted firmware bundle %s (%s %s)",
+                bundle_id,
+                bundle.app_name,
+                bundle.version,
+            )
+        return deleted
+
+    def bundle_path(self, bundle: FirmwareBundle) -> str:
+        """Where a bundle's zip lives, always inside the firmware directory."""
+        return os.path.join(self._settings.dir, os.path.basename(bundle.file_name))

--- a/packages/core/src/core/use_cases/update_device_from_local.py
+++ b/packages/core/src/core/use_cases/update_device_from_local.py
@@ -1,0 +1,174 @@
+"""Use case for updating a device from the local firmware store."""
+
+import logging
+import re
+
+from core.domain.entities.exceptions import (
+    DeviceNotFoundError,
+    FirmwareConfigurationError,
+    FirmwareError,
+)
+from core.domain.value_objects.action_result import ActionResult
+from core.domain.value_objects.base_device_request import BaseDeviceRequest
+from core.domain.value_objects.firmware_release import FirmwareRelease
+from core.gateways.device import DeviceGateway
+from core.gateways.firmware import FirmwareGateway
+from core.settings import FirmwareSettings
+from core.use_cases.acquire_firmware import AcquireFirmware
+
+logger = logging.getLogger(__name__)
+
+
+class UpdateDeviceFromLocal:
+    """Update a Gen2+ device with firmware served from the manager host.
+
+    The device fetches the bundle over LAN from this API's firmware download
+    route, so the device itself needs no internet access.
+    """
+
+    def __init__(
+        self,
+        device_gateway: DeviceGateway,
+        firmware_gateway: FirmwareGateway,
+        acquire_firmware: AcquireFirmware,
+        settings: FirmwareSettings,
+    ):
+        self._device_gateway = device_gateway
+        self._firmware_gateway = firmware_gateway
+        self._acquire_firmware = acquire_firmware
+        self._settings = settings
+
+    async def execute(self, request: BaseDeviceRequest) -> ActionResult:
+        """Point the device at a locally cached copy of its latest firmware.
+
+        Raises:
+            DeviceNotFoundError: If the device is unreachable.
+            FirmwareError: If the advertised base URL is unset, the device is
+                Gen1 or reports no app name, or no release is published.
+        """
+        base_url = (self._settings.advertised_base_url or "").strip()
+        if not base_url:
+            raise FirmwareConfigurationError(
+                "Local updates need SHELLY_FIRMWARE_ADVERTISED_BASE_URL set to "
+                "a base URL devices can reach, e.g. http://192.168.40.252:8000"
+            )
+
+        ip = request.device_ip
+        status = await self._device_gateway.get_device_status(ip)
+        if status is None:
+            raise DeviceNotFoundError(ip)
+
+        if status.gen == 1:
+            raise FirmwareError(
+                f"Local updates support Gen2+ devices only; {ip} is Gen1",
+                {"device_ip": ip},
+            )
+
+        if not status.app_name:
+            raise FirmwareError(
+                f"Device {ip} did not report an app name to look firmware up by",
+                {"device_ip": ip},
+            )
+
+        release = await self._firmware_gateway.get_latest(status.app_name)
+        if release is None:
+            raise FirmwareError(
+                f"No firmware published for app '{status.app_name}'",
+                {"app_name": status.app_name},
+            )
+
+        installed = _installed_version(status.firmware_version)
+        if _already_runs(status.firmware_version, installed, release):
+            return ActionResult(
+                device_ip=ip,
+                action_type="shelly.Update",
+                success=True,
+                message=(
+                    f"Device already runs the latest firmware ({release.version})"
+                ),
+            )
+
+        downgrade = _downgrade_note(installed, release.version)
+        if downgrade is not None:
+            logger.warning("Local update for %s is a %s", ip, downgrade)
+
+        bundle = await self._acquire_firmware.execute(status.app_name, release)
+        url = f"{base_url.rstrip('/')}/api/firmware/{bundle.id}/download"
+        logger.info(
+            "Updating %s to %s %s from local bundle %s",
+            ip,
+            bundle.app_name,
+            bundle.version,
+            url,
+        )
+        result = await self._device_gateway.execute_component_action(
+            ip, "shelly", "Update", {"url": url}
+        )
+        if downgrade is None:
+            return result
+        return result.model_copy(
+            update={"message": f"{result.message} (this is a {downgrade})"}
+        )
+
+
+def _installed_version(firmware_version: str | None) -> str | None:
+    """Version a device reports running.
+
+    Reads the version out of a Gen2+ fw_id like
+    '20231219-133953/1.1.0-g34b5d4f', and takes a device that reports a bare
+    version at its word.
+    """
+    if not firmware_version:
+        return None
+    _, _, after_build_date = firmware_version.partition("/")
+    return (after_build_date or firmware_version).split("-g", 1)[0]
+
+
+def _already_runs(
+    firmware_version: str | None, installed: str | None, release: FirmwareRelease
+) -> bool:
+    """Whether the device already runs exactly what the index publishes.
+
+    A fw_id and the index's build id name one exact build, so they decide this
+    whenever the device reports one. Comparing versions instead would call a
+    device current when the same version has been republished under a new
+    build, which is how a reissued fix would never install. A device that
+    reports a bare version has no build to compare, so its version has to
+    settle it, otherwise it would be reflashed on every run.
+    """
+    if not firmware_version:
+        return False
+    if "/" in firmware_version:
+        return firmware_version == release.build_id
+    return installed is not None and installed == release.version
+
+
+def _version_key(version: str) -> tuple[int, ...] | None:
+    """Comparable form of a version, or ``None`` when it cannot be read."""
+    key = []
+    for component in version.split("."):
+        leading_digits = re.match(r"\d+", component)
+        if leading_digits is None:
+            return None
+        key.append(int(leading_digits.group()))
+    return tuple(key)
+
+
+def _downgrade_note(installed: str | None, candidate: str) -> str | None:
+    """How this update moves backwards, or ``None`` when it does not.
+
+    Installing an older build is allowed: pinning a device to a particular
+    published version is a legitimate thing to want, and an internet update
+    cannot express it at all. The note exists so nobody does it unaware, since
+    a device installs whatever URL it is handed without judging the version
+    itself. Versions that cannot be compared carry no note.
+    """
+    if installed is None:
+        return None
+    installed_key = _version_key(installed)
+    candidate_key = _version_key(candidate)
+    if installed_key is None or candidate_key is None:
+        return None
+    if installed_key > candidate_key:
+        return f"downgrade from {installed} to {candidate}"
+    return None

--- a/packages/core/tests/unit/dependencies/test_container_base.py
+++ b/packages/core/tests/unit/dependencies/test_container_base.py
@@ -15,6 +15,9 @@ from core.repositories.sqlalchemy_backup_schedule_repository import (
 from core.repositories.sqlalchemy_credentials_repository import (
     SQLAlchemyCredentialsRepository,
 )
+from core.repositories.sqlalchemy_firmware_repository import (
+    SQLAlchemyFirmwareRepository,
+)
 from core.repositories.sqlalchemy_provisioning_profile_repository import (
     SQLAlchemyProvisioningProfileRepository,
 )
@@ -87,6 +90,10 @@ class TestProviderWiring:
             "get_restore_device_config_interactor",
             "get_manage_backup_schedules_interactor",
             "get_run_due_backups_interactor",
+            "get_firmware_gateway",
+            "get_acquire_firmware_interactor",
+            "get_update_device_from_local_interactor",
+            "get_manage_firmware_interactor",
             "get_ap_device_detector",
             "get_mdns_client",
             "get_auth_state_cache",
@@ -115,6 +122,7 @@ class TestRepositoryFactories:
                 "create_backup_schedule_repository",
                 SQLAlchemyBackupScheduleRepository,
             ),
+            ("create_firmware_repository", SQLAlchemyFirmwareRepository),
         ],
     )
     async def test_it_yields_a_repository_per_session(
@@ -142,6 +150,16 @@ class TestClose:
         assert container.get_device_gateway() is not gateway
         assert container.get_authentication_service() is auth_service
         await container.close()
+
+    async def test_it_closes_the_firmware_gateway(self):
+        container = BaseContainer()
+        firmware_gateway = AsyncMock()
+        container._firmware_gateway = firmware_gateway
+
+        await container.close()
+
+        firmware_gateway.close.assert_awaited_once()
+        assert container._firmware_gateway is None
 
     async def test_it_swallows_client_close_errors(self):
         container = BaseContainer()

--- a/packages/core/tests/unit/domain/test_enums.py
+++ b/packages/core/tests/unit/domain/test_enums.py
@@ -8,8 +8,8 @@ class TestUpdateChannel:
     def test_it_sends_no_parameters_for_the_stable_channel(self):
         assert UpdateChannel.STABLE.to_update_parameters() == {}
 
-    def test_it_names_the_channel_for_beta(self):
-        assert UpdateChannel.BETA.to_update_parameters() == {"channel": "beta"}
+    def test_it_sends_beta_as_the_stage_the_device_reads(self):
+        assert UpdateChannel.BETA.to_update_parameters() == {"stage": "beta"}
 
     def test_it_rejects_an_unknown_channel(self):
         with pytest.raises(ValueError):

--- a/packages/core/tests/unit/gateways/device/test_shelly_device_gateway.py
+++ b/packages/core/tests/unit/gateways/device/test_shelly_device_gateway.py
@@ -573,6 +573,27 @@ class TestShellyDeviceGateway:
             "192.168.1.100", "Shelly.Update", params=None, timeout=10.0
         )
 
+    async def test_it_forwards_the_stage_to_the_update_action(
+        self, gateway, mock_rpc_client
+    ):
+
+        available_methods = ["Shelly.Update", "Shelly.Reboot", "Switch.Toggle"]
+        mock_rpc_client.make_rpc_request = AsyncMock(
+            side_effect=[
+                ({"methods": available_methods}, 0.1),
+                ({}, 0.1),
+            ]
+        )
+
+        result = await gateway.execute_component_action(
+            "192.168.1.100", "shelly", "Update", {"stage": "beta"}
+        )
+
+        assert result.success is True
+        mock_rpc_client.make_rpc_request.assert_any_call(
+            "192.168.1.100", "Shelly.Update", params={"stage": "beta"}, timeout=10.0
+        )
+
     async def test_it_executes_component_reboot_action_successfully(
         self, gateway, mock_rpc_client
     ):

--- a/packages/core/tests/unit/gateways/firmware/test_shelly_cloud_firmware_gateway.py
+++ b/packages/core/tests/unit/gateways/firmware/test_shelly_cloud_firmware_gateway.py
@@ -1,0 +1,440 @@
+"""Tests for the Shelly cloud firmware gateway."""
+
+import asyncio
+import hashlib
+
+import httpx
+import pytest
+from core.domain.entities.exceptions import FirmwareError
+from core.domain.value_objects.firmware_release import FirmwareRelease
+from core.gateways.firmware import ShellyCloudFirmwareGateway
+
+INDEX_URL = "https://updates.example.test/update"
+
+
+def _gateway(handler):
+    transport = httpx.MockTransport(handler)
+    return ShellyCloudFirmwareGateway(
+        index_url=INDEX_URL, session=httpx.AsyncClient(transport=transport)
+    )
+
+
+def _release(**kwargs):
+    base = {
+        "app_name": "Plus2PM",
+        "version": "1.7.5",
+        "build_id": "20250611-100000/1.7.5-g1234567",
+        "download_url": "https://fwcdn.shelly.cloud/Plus2PM.zip",
+        "channel": "stable",
+    }
+    base.update(kwargs)
+    return FirmwareRelease(**base)
+
+
+class TestGetLatest:
+    async def test_it_returns_the_stable_release(self):
+        def handler(request):
+            assert request.url == httpx.URL(f"{INDEX_URL}/Plus2PM")
+            return httpx.Response(
+                200,
+                json={
+                    "name": "Shelly Plus 2PM",
+                    "stable": {
+                        "version": "1.7.5",
+                        "build_id": "20250611-100000/1.7.5-g1234567",
+                        "url": "https://fwcdn.example.test/Plus2PM.zip",
+                    },
+                },
+            )
+
+        release = await _gateway(handler).get_latest("Plus2PM")
+
+        assert release is not None
+        assert release.app_name == "Plus2PM"
+        assert release.version == "1.7.5"
+        assert release.build_id == "20250611-100000/1.7.5-g1234567"
+        assert release.download_url == "https://fwcdn.example.test/Plus2PM.zip"
+        assert release.channel == "stable"
+
+    async def test_it_returns_none_when_the_index_has_no_entry(self):
+        def handler(request):
+            return httpx.Response(404)
+
+        assert (await _gateway(handler).get_latest("Unknown")) is None
+
+    async def test_it_returns_none_without_a_stable_block(self):
+        def handler(request):
+            return httpx.Response(200, json={"name": "Shelly Plus 2PM"})
+
+        assert (await _gateway(handler).get_latest("Plus2PM")) is None
+
+    async def test_it_returns_none_when_the_stable_block_is_incomplete(self):
+        def handler(request):
+            return httpx.Response(200, json={"stable": {"version": "1.7.5"}})
+
+        assert (await _gateway(handler).get_latest("Plus2PM")) is None
+
+    async def test_it_returns_none_for_non_string_metadata(self):
+        def handler(request):
+            return httpx.Response(
+                200,
+                json={
+                    "stable": {
+                        "version": {"unexpected": "object"},
+                        "build_id": "x",
+                        "url": "https://fwcdn.example.test/x.zip",
+                    }
+                },
+            )
+
+        assert (await _gateway(handler).get_latest("Plus2PM")) is None
+
+    async def test_it_raises_a_firmware_error_when_the_index_is_unreachable(self):
+        def handler(request):
+            raise httpx.ConnectError("connection refused")
+
+        with pytest.raises(FirmwareError, match="index request failed"):
+            await _gateway(handler).get_latest("Plus2PM")
+
+    async def test_it_raises_a_firmware_error_on_a_server_error(self):
+        def handler(request):
+            return httpx.Response(500)
+
+        with pytest.raises(FirmwareError, match="index request failed"):
+            await _gateway(handler).get_latest("Plus2PM")
+
+    async def test_it_raises_a_firmware_error_on_an_unparseable_response(self):
+        def handler(request):
+            return httpx.Response(200, content=b"not json")
+
+        with pytest.raises(FirmwareError, match="index request failed"):
+            await _gateway(handler).get_latest("Plus2PM")
+
+    async def test_it_refuses_an_unsafe_app_name(self):
+        def handler(request):
+            raise AssertionError("no request should be made")
+
+        with pytest.raises(FirmwareError, match="unsafe app name"):
+            await _gateway(handler).get_latest("Plus2PM/../evil")
+
+    @pytest.mark.parametrize("app_name", [".", ".."])
+    async def test_it_refuses_dot_segment_app_names(self, app_name):
+        def handler(request):
+            raise AssertionError("no request should be made")
+
+        with pytest.raises(FirmwareError, match="unsafe app name"):
+            await _gateway(handler).get_latest(app_name)
+
+
+class TestDownload:
+    async def test_it_streams_the_bundle_and_reports_size_and_sha256(self, tmp_path):
+        payload = b"zip-bytes" * 1000
+
+        def handler(request):
+            assert request.url == httpx.URL("https://fwcdn.shelly.cloud/Plus2PM.zip")
+            return httpx.Response(200, content=payload)
+
+        dest = tmp_path / "Plus2PM-1.7.5.zip"
+        size, sha256 = await _gateway(handler).download(_release(), str(dest))
+
+        assert dest.read_bytes() == payload
+        assert size == len(payload)
+        assert sha256 == hashlib.sha256(payload).hexdigest()
+        assert list(tmp_path.glob("*.part")) == []
+
+    async def test_it_cleans_up_the_partial_file_when_the_download_fails(
+        self, tmp_path
+    ):
+        def handler(request):
+            return httpx.Response(500)
+
+        dest = tmp_path / "Plus2PM-1.7.5.zip"
+        with pytest.raises(FirmwareError, match="download failed"):
+            await _gateway(handler).download(_release(), str(dest))
+
+        assert not dest.exists()
+        assert list(tmp_path.glob("*.part")) == []
+
+    async def test_it_wraps_a_disk_error_in_a_firmware_error(self, tmp_path):
+        def handler(request):
+            return httpx.Response(200, content=b"zip-bytes")
+
+        dest = tmp_path / "missing-dir" / "Plus2PM-1.7.5.zip"
+        with pytest.raises(FirmwareError, match="download failed"):
+            await _gateway(handler).download(_release(), str(dest))
+
+        assert list(tmp_path.rglob("*.part")) == []
+
+    async def test_it_cleans_up_the_partial_file_when_cancelled(self, tmp_path):
+        first_chunk_sent = asyncio.Event()
+        never = asyncio.Event()
+
+        class StallingStream(httpx.AsyncByteStream):
+            async def __aiter__(self):
+                yield b"zip-bytes"
+                first_chunk_sent.set()
+                await never.wait()
+                yield b"more"
+
+        def handler(request):
+            return httpx.Response(200, stream=StallingStream())
+
+        dest = tmp_path / "Plus2PM-1.7.5.zip"
+        task = asyncio.create_task(_gateway(handler).download(_release(), str(dest)))
+        await first_chunk_sent.wait()
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+        assert not dest.exists()
+        assert list(tmp_path.glob("*.part")) == []
+
+    @pytest.mark.parametrize(
+        "download_url",
+        [
+            "http://127.0.0.1:9200/_search",
+            "http://192.168.40.10/admin",
+            "https://attacker.example.test/Plus2PM.zip",
+            "file:///etc/passwd",
+        ],
+    )
+    async def test_it_refuses_a_download_outside_the_allowed_hosts(
+        self, tmp_path, download_url
+    ):
+        def handler(request):
+            raise AssertionError("no request should be made")
+
+        gateway = ShellyCloudFirmwareGateway(
+            index_url=INDEX_URL,
+            session=httpx.AsyncClient(transport=httpx.MockTransport(handler)),
+            allowed_download_hosts=["shelly.cloud"],
+        )
+        dest = tmp_path / "Plus2PM-1.7.5.zip"
+
+        with pytest.raises(FirmwareError, match="Refusing firmware download"):
+            await gateway.download(_release(download_url=download_url), str(dest))
+
+        assert not dest.exists()
+
+    async def test_it_refuses_a_redirect_off_the_allowed_hosts(self, tmp_path):
+        seen = []
+
+        def handler(request):
+            seen.append(str(request.url))
+            if request.url.host == "fwcdn.shelly.cloud":
+                return httpx.Response(
+                    302, headers={"Location": "http://127.0.0.1:9200/_search"}
+                )
+            return httpx.Response(200, content=b"INTERNAL-SECRET-BODY")
+
+        gateway = ShellyCloudFirmwareGateway(
+            index_url=INDEX_URL,
+            session=httpx.AsyncClient(transport=httpx.MockTransport(handler)),
+            allowed_download_hosts=["shelly.cloud"],
+        )
+        dest = tmp_path / "Plus2PM-1.7.5.zip"
+
+        with pytest.raises(FirmwareError, match="untrusted host '127.0.0.1'"):
+            await gateway.download(_release(), str(dest))
+
+        assert not dest.exists()
+        assert list(tmp_path.glob("*.part")) == []
+        assert not any("127.0.0.1" in url for url in seen)
+
+    async def test_it_follows_a_redirect_that_stays_on_an_allowed_host(self, tmp_path):
+        def handler(request):
+            if request.url.path == "/redirect":
+                return httpx.Response(
+                    302, headers={"Location": "https://fwcdn.shelly.cloud/real.zip"}
+                )
+            return httpx.Response(200, content=b"zip")
+
+        gateway = ShellyCloudFirmwareGateway(
+            index_url=INDEX_URL,
+            session=httpx.AsyncClient(transport=httpx.MockTransport(handler)),
+            allowed_download_hosts=["shelly.cloud"],
+        )
+        dest = tmp_path / "Plus2PM-1.7.5.zip"
+
+        size, _ = await gateway.download(
+            _release(download_url="https://updates.shelly.cloud/redirect"), str(dest)
+        )
+
+        assert size == 3
+        assert dest.read_bytes() == b"zip"
+
+    async def test_it_stops_a_redirect_loop(self, tmp_path):
+        def handler(request):
+            return httpx.Response(
+                302, headers={"Location": "https://fwcdn.shelly.cloud/again"}
+            )
+
+        gateway = ShellyCloudFirmwareGateway(
+            index_url=INDEX_URL,
+            session=httpx.AsyncClient(transport=httpx.MockTransport(handler)),
+            allowed_download_hosts=["shelly.cloud"],
+        )
+        dest = tmp_path / "Plus2PM-1.7.5.zip"
+
+        with pytest.raises(FirmwareError, match="redirected more than"):
+            await gateway.download(_release(), str(dest))
+
+        assert list(tmp_path.glob("*.part")) == []
+
+    @pytest.mark.parametrize(
+        "entry",
+        ["shelly.cloud", "*.shelly.cloud", "SHELLY.CLOUD:443", "https://shelly.cloud"],
+    )
+    async def test_it_reads_the_allow_list_however_it_is_written(self, tmp_path, entry):
+        def handler(request):
+            return httpx.Response(200, content=b"zip")
+
+        gateway = ShellyCloudFirmwareGateway(
+            index_url=INDEX_URL,
+            session=httpx.AsyncClient(transport=httpx.MockTransport(handler)),
+            allowed_download_hosts=[entry],
+        )
+        dest = tmp_path / "Plus2PM-1.7.5.zip"
+
+        size, _ = await gateway.download(_release(), str(dest))
+
+        assert size == 3
+
+    async def test_it_allows_an_absolute_form_of_the_host(self, tmp_path):
+        def handler(request):
+            return httpx.Response(200, content=b"zip")
+
+        gateway = ShellyCloudFirmwareGateway(
+            index_url=INDEX_URL,
+            session=httpx.AsyncClient(transport=httpx.MockTransport(handler)),
+            allowed_download_hosts=["shelly.cloud"],
+        )
+        dest = tmp_path / "Plus2PM-1.7.5.zip"
+
+        size, _ = await gateway.download(
+            _release(download_url="https://fwcdn.shelly.cloud./Plus2PM.zip"), str(dest)
+        )
+
+        assert size == 3
+
+    async def test_it_refuses_an_empty_bundle(self, tmp_path):
+        def handler(request):
+            return httpx.Response(200, content=b"")
+
+        dest = tmp_path / "Plus2PM-1.7.5.zip"
+        with pytest.raises(FirmwareError, match="was empty"):
+            await _gateway(handler).download(_release(), str(dest))
+
+        assert not dest.exists()
+        assert list(tmp_path.glob("*.part")) == []
+
+    @pytest.mark.parametrize(
+        "download_url",
+        [
+            "https://fwcdn.shelly.cloud/" + "x" * 70000,
+            "https://xn--a.shelly.cloud/x.zip",
+        ],
+    )
+    async def test_it_wraps_an_unusable_url_in_a_firmware_error(
+        self, tmp_path, download_url
+    ):
+        def handler(request):
+            return httpx.Response(200, content=b"zip")
+
+        dest = tmp_path / "Plus2PM-1.7.5.zip"
+        with pytest.raises(FirmwareError, match="download failed"):
+            await _gateway(handler).download(
+                _release(download_url=download_url), str(dest)
+            )
+
+        assert list(tmp_path.glob("*.part")) == []
+
+    async def test_it_allows_a_subdomain_of_an_allowed_host(self, tmp_path):
+        def handler(request):
+            return httpx.Response(200, content=b"zip")
+
+        gateway = ShellyCloudFirmwareGateway(
+            index_url=INDEX_URL,
+            session=httpx.AsyncClient(transport=httpx.MockTransport(handler)),
+            allowed_download_hosts=["shelly.cloud"],
+        )
+        dest = tmp_path / "Plus2PM-1.7.5.zip"
+
+        size, _ = await gateway.download(
+            _release(download_url="https://fwcdn.shelly.cloud/Plus2PM.zip"), str(dest)
+        )
+
+        assert size == 3
+
+    async def test_it_allows_any_host_when_the_allow_list_is_empty(self, tmp_path):
+        def handler(request):
+            return httpx.Response(200, content=b"zip")
+
+        gateway = ShellyCloudFirmwareGateway(
+            index_url=INDEX_URL,
+            session=httpx.AsyncClient(transport=httpx.MockTransport(handler)),
+            allowed_download_hosts=[],
+        )
+        dest = tmp_path / "Plus2PM-1.7.5.zip"
+
+        size, _ = await gateway.download(
+            _release(download_url="https://mirror.example.test/Plus2PM.zip"), str(dest)
+        )
+
+        assert size == 3
+
+    async def test_it_rejects_a_compressed_body(self, tmp_path):
+        class GzipStream(httpx.AsyncByteStream):
+            async def __aiter__(self):
+                raise AssertionError("body must not be read")
+                yield b""
+
+        def handler(request):
+            return httpx.Response(
+                200,
+                stream=GzipStream(),
+                headers={"Content-Encoding": "gzip"},
+            )
+
+        dest = tmp_path / "Plus2PM-1.7.5.zip"
+        with pytest.raises(FirmwareError, match="content encoding"):
+            await _gateway(handler).download(_release(), str(dest))
+
+        assert not dest.exists()
+        assert list(tmp_path.glob("*.part")) == []
+
+    async def test_it_rejects_a_declared_length_over_the_cap(
+        self, tmp_path, monkeypatch
+    ):
+        from core.gateways.firmware import shelly_cloud_firmware_gateway
+
+        monkeypatch.setattr(shelly_cloud_firmware_gateway, "_MAX_BUNDLE_SIZE_BYTES", 10)
+
+        def handler(request):
+            return httpx.Response(200, content=b"zip-bytes" * 10)
+
+        dest = tmp_path / "Plus2PM-1.7.5.zip"
+        with pytest.raises(FirmwareError, match="over the"):
+            await _gateway(handler).download(_release(), str(dest))
+
+        assert not dest.exists()
+
+    async def test_it_rejects_a_bundle_over_the_size_cap(self, tmp_path, monkeypatch):
+        from core.gateways.firmware import shelly_cloud_firmware_gateway
+
+        monkeypatch.setattr(shelly_cloud_firmware_gateway, "_MAX_BUNDLE_SIZE_BYTES", 10)
+
+        class UndeclaredLengthStream(httpx.AsyncByteStream):
+            async def __aiter__(self):
+                for _ in range(5):
+                    yield b"zip-bytes"
+
+        def handler(request):
+            return httpx.Response(200, stream=UndeclaredLengthStream())
+
+        dest = tmp_path / "Plus2PM-1.7.5.zip"
+        with pytest.raises(FirmwareError, match="exceeded"):
+            await _gateway(handler).download(_release(), str(dest))
+
+        assert not dest.exists()
+        assert list(tmp_path.glob("*.part")) == []

--- a/packages/core/tests/unit/repositories/test_sqlalchemy_firmware_repository.py
+++ b/packages/core/tests/unit/repositories/test_sqlalchemy_firmware_repository.py
@@ -1,0 +1,122 @@
+"""Tests for the SQLAlchemy firmware bundle repository."""
+
+import pytest
+from core.domain.entities.firmware_bundle import FirmwareBundle
+from core.repositories.models import Base
+from core.repositories.sqlalchemy_firmware_repository import (
+    SQLAlchemyFirmwareRepository,
+)
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+from sqlalchemy.pool import StaticPool
+
+
+@pytest.fixture
+async def session_factory():
+    engine = create_async_engine(
+        "sqlite+aiosqlite://",
+        poolclass=StaticPool,
+        connect_args={"check_same_thread": False},
+    )
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    factory = async_sessionmaker(engine, expire_on_commit=False)
+    yield factory
+    await engine.dispose()
+
+
+def _bundle(app_name="Plus2PM", version="1.7.5", **kwargs):
+    base = {
+        "app_name": app_name,
+        "version": version,
+        "build_id": f"20250611-100000/{version}-g1234567",
+        "file_name": f"{app_name}-{version}.zip",
+        "size_bytes": 2048,
+        "sha256": "ab" * 32,
+    }
+    base.update(kwargs)
+    return FirmwareBundle(**base)
+
+
+class TestFirmwareRepository:
+    async def test_it_round_trips_a_bundle(self, session_factory):
+        async with session_factory() as session:
+            repo = SQLAlchemyFirmwareRepository(session)
+            created = await repo.create(_bundle())
+
+            assert created.id is not None
+            assert created.downloaded_at is not None
+
+            fetched = await repo.get(created.id)
+            assert fetched is not None
+            assert fetched.app_name == "Plus2PM"
+            assert fetched.version == "1.7.5"
+            assert fetched.build_id == "20250611-100000/1.7.5-g1234567"
+            assert fetched.file_name == "Plus2PM-1.7.5.zip"
+            assert fetched.size_bytes == 2048
+            assert fetched.sha256 == "ab" * 32
+
+    async def test_it_returns_none_for_a_missing_bundle(self, session_factory):
+        async with session_factory() as session:
+            repo = SQLAlchemyFirmwareRepository(session)
+
+            assert (await repo.get(12345)) is None
+
+    async def test_it_finds_a_bundle_by_its_full_identity(self, session_factory):
+        async with session_factory() as session:
+            repo = SQLAlchemyFirmwareRepository(session)
+            await repo.create(_bundle(app_name="Plus2PM", version="1.7.5"))
+            await repo.create(_bundle(app_name="Mini1PMG4", version="2.0.0"))
+
+            found = await repo.find(
+                "Mini1PMG4", "2.0.0", "20250611-100000/2.0.0-g1234567"
+            )
+            assert found is not None
+            assert found.app_name == "Mini1PMG4"
+            assert found.version == "2.0.0"
+
+            assert (
+                await repo.find("Plus2PM", "9.9.9", "20250611-100000/9.9.9-g1234567")
+            ) is None
+
+    async def test_it_misses_a_republished_version_under_a_new_build(
+        self, session_factory
+    ):
+        async with session_factory() as session:
+            repo = SQLAlchemyFirmwareRepository(session)
+            await repo.create(_bundle(app_name="Plus2PM", version="1.7.5"))
+
+            assert (
+                await repo.find("Plus2PM", "1.7.5", "20260101-000000/1.7.5-gdeadbee")
+            ) is None
+
+    async def test_it_lists_bundles_newest_first(self, session_factory):
+        async with session_factory() as session:
+            repo = SQLAlchemyFirmwareRepository(session)
+            first = await repo.create(_bundle(version="1.7.3"))
+            second = await repo.create(_bundle(version="1.7.4"))
+            third = await repo.create(_bundle(version="1.7.5"))
+
+            bundles = await repo.list()
+
+            assert [b.id for b in bundles] == [third.id, second.id, first.id]
+
+    async def test_it_deletes_a_bundle(self, session_factory):
+        async with session_factory() as session:
+            repo = SQLAlchemyFirmwareRepository(session)
+            created = await repo.create(_bundle())
+
+            assert (await repo.delete(created.id)) is True
+            assert (await repo.get(created.id)) is None
+            assert (await repo.delete(created.id)) is False
+
+    async def test_it_returns_the_existing_row_for_a_duplicate_bundle(
+        self, session_factory
+    ):
+        async with session_factory() as session:
+            repo = SQLAlchemyFirmwareRepository(session)
+            first = await repo.create(_bundle())
+
+            second = await repo.create(_bundle())
+
+            assert second.id == first.id
+            assert len(await repo.list()) == 1

--- a/packages/core/tests/unit/test_settings.py
+++ b/packages/core/tests/unit/test_settings.py
@@ -43,3 +43,99 @@ def test_it_saves_backup_settings_to_config_file(tmp_path, monkeypatch):
         "scheduler_enabled": False,
         "poll_interval_seconds": 300,
     }
+
+
+def test_it_loads_firmware_settings_from_config_file(tmp_path, monkeypatch):
+    config_path = tmp_path / "config.json"
+    config_path.write_text(
+        json.dumps(
+            {
+                "firmware": {
+                    "dir": str(tmp_path / "fw"),
+                    "advertised_base_url": "http://192.168.40.252:8000",
+                }
+            }
+        )
+    )
+
+    monkeypatch.setenv(
+        "SHELLY_SECRET_KEY", "0N6fK7YkEmvA0I4d1sD4v15uvB94H4A1N1nMG8vLMOg="
+    )
+
+    settings = AppSettings(config_file=str(config_path))
+
+    assert settings.firmware.dir == str(tmp_path / "fw")
+    assert settings.firmware.advertised_base_url == "http://192.168.40.252:8000"
+    assert settings.firmware.index_url == "https://updates.shelly.cloud/update"
+
+
+def test_it_saves_firmware_settings_to_config_file(tmp_path, monkeypatch):
+    config_path = tmp_path / "config.json"
+
+    monkeypatch.setenv(
+        "SHELLY_SECRET_KEY", "0N6fK7YkEmvA0I4d1sD4v15uvB94H4A1N1nMG8vLMOg="
+    )
+
+    settings = AppSettings(config_file=str(config_path))
+    settings.firmware.advertised_base_url = "http://192.168.40.252:8000"
+    settings.save_config()
+
+    saved = json.loads(config_path.read_text())
+    assert saved["firmware"] == {
+        "dir": "./data/firmware",
+        "advertised_base_url": "http://192.168.40.252:8000",
+        "index_url": "https://updates.shelly.cloud/update",
+        "verify_ssl": False,
+        "allowed_download_hosts": "shelly.cloud",
+    }
+
+
+def test_it_reads_a_comma_separated_download_allow_list(monkeypatch):
+    monkeypatch.setenv(
+        "SHELLY_SECRET_KEY", "0N6fK7YkEmvA0I4d1sD4v15uvB94H4A1N1nMG8vLMOg="
+    )
+    monkeypatch.setenv(
+        "SHELLY_FIRMWARE_ALLOWED_DOWNLOAD_HOSTS", "shelly.cloud, Mirror.Example.com "
+    )
+
+    settings = AppSettings(config_file="does-not-exist.json")
+
+    assert settings.firmware.download_host_allow_list() == [
+        "shelly.cloud",
+        "mirror.example.com",
+    ]
+
+
+def test_it_keeps_the_default_when_the_download_allow_list_is_blank(monkeypatch):
+    monkeypatch.setenv(
+        "SHELLY_SECRET_KEY", "0N6fK7YkEmvA0I4d1sD4v15uvB94H4A1N1nMG8vLMOg="
+    )
+    monkeypatch.setenv("SHELLY_FIRMWARE_ALLOWED_DOWNLOAD_HOSTS", "  , ")
+
+    settings = AppSettings(config_file="does-not-exist.json")
+
+    assert settings.firmware.download_host_allow_list() == ["shelly.cloud"]
+
+
+def test_it_accepts_any_download_host_only_when_asked_explicitly(monkeypatch):
+    monkeypatch.setenv(
+        "SHELLY_SECRET_KEY", "0N6fK7YkEmvA0I4d1sD4v15uvB94H4A1N1nMG8vLMOg="
+    )
+    monkeypatch.setenv("SHELLY_FIRMWARE_ALLOWED_DOWNLOAD_HOSTS", "*")
+
+    settings = AppSettings(config_file="does-not-exist.json")
+
+    assert settings.firmware.download_host_allow_list() == []
+
+
+def test_it_creates_the_firmware_dir_on_validate(tmp_path, monkeypatch):
+    monkeypatch.setenv(
+        "SHELLY_SECRET_KEY", "0N6fK7YkEmvA0I4d1sD4v15uvB94H4A1N1nMG8vLMOg="
+    )
+
+    settings = AppSettings(config_file=str(tmp_path / "config.json"))
+    settings.data_dir = str(tmp_path / "data")
+    settings.firmware.dir = str(tmp_path / "data" / "firmware")
+    settings.validate_settings()
+
+    assert (tmp_path / "data" / "firmware").is_dir()

--- a/packages/core/tests/unit/use_cases/test_acquire_firmware.py
+++ b/packages/core/tests/unit/use_cases/test_acquire_firmware.py
@@ -1,0 +1,210 @@
+"""Tests for the acquire firmware use case."""
+
+import asyncio
+import hashlib
+from contextlib import asynccontextmanager
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+import pytest
+from core.domain.entities.exceptions import FirmwareError
+from core.domain.entities.firmware_bundle import FirmwareBundle
+from core.domain.value_objects.firmware_release import FirmwareRelease
+from core.settings import FirmwareSettings
+from core.use_cases.acquire_firmware import AcquireFirmware
+
+
+def _build_id(version="1.7.5"):
+    return f"20250611-100000/{version}-g1234567"
+
+
+def _release(version="1.7.5"):
+    return FirmwareRelease(
+        app_name="Plus2PM",
+        version=version,
+        build_id=_build_id(version),
+        download_url="https://fwcdn.example.test/Plus2PM.zip",
+        channel="stable",
+    )
+
+
+def _expected_file_name(version="1.7.5"):
+    identity = "\0".join(("Plus2PM", version, _build_id(version)))
+    digest = hashlib.sha256(identity.encode()).hexdigest()[:16]
+    return f"Plus2PM-{version}-{digest}.zip"
+
+
+def _bundle(version="1.7.5", bundle_id=7):
+    return FirmwareBundle(
+        id=bundle_id,
+        app_name="Plus2PM",
+        version=version,
+        build_id=f"20250611-100000/{version}-g1234567",
+        file_name=f"Plus2PM-{version}.zip",
+        size_bytes=2048,
+        sha256="ab" * 32,
+    )
+
+
+class TestAcquireFirmware:
+    @pytest.fixture
+    def mock_firmware_gateway(self):
+        gateway = AsyncMock()
+        gateway.get_latest = AsyncMock(return_value=_release())
+        gateway.download = AsyncMock(return_value=(2048, "ab" * 32))
+        return gateway
+
+    @pytest.fixture
+    def mock_repository(self):
+        repository = AsyncMock()
+        repository.find = AsyncMock(return_value=None)
+        repository.create = AsyncMock(side_effect=lambda bundle: bundle)
+        return repository
+
+    @pytest.fixture
+    def use_case(self, mock_firmware_gateway, mock_repository, tmp_path):
+        @asynccontextmanager
+        async def repository_factory():
+            yield mock_repository
+
+        return AcquireFirmware(
+            firmware_gateway=mock_firmware_gateway,
+            repository_factory=repository_factory,
+            settings=FirmwareSettings(dir=str(tmp_path)),
+        )
+
+    async def test_it_returns_the_cached_bundle_without_downloading(
+        self, use_case, mock_firmware_gateway, mock_repository, tmp_path
+    ):
+        (tmp_path / "Plus2PM-1.7.5.zip").write_bytes(b"zip")
+        cached = _bundle()
+        mock_repository.find = AsyncMock(return_value=cached)
+
+        result = await use_case.execute("Plus2PM")
+
+        assert result is cached
+        mock_repository.find.assert_awaited_once_with("Plus2PM", "1.7.5", _build_id())
+        mock_firmware_gateway.download.assert_not_awaited()
+        mock_repository.create.assert_not_awaited()
+
+    async def test_it_restores_a_cached_bundle_whose_file_left_the_disk(
+        self, use_case, mock_firmware_gateway, mock_repository, tmp_path
+    ):
+        cached = _bundle()
+        mock_repository.find = AsyncMock(return_value=cached)
+
+        result = await use_case.execute("Plus2PM")
+
+        assert result is cached
+        mock_firmware_gateway.download.assert_awaited_once_with(
+            _release(), str(tmp_path / "Plus2PM-1.7.5.zip")
+        )
+        mock_repository.create.assert_not_awaited()
+
+    async def test_it_downloads_and_stores_on_a_cache_miss(
+        self, use_case, mock_firmware_gateway, mock_repository, tmp_path
+    ):
+        result = await use_case.execute("Plus2PM")
+
+        mock_firmware_gateway.download.assert_awaited_once_with(
+            _release(), str(tmp_path / _expected_file_name())
+        )
+        mock_repository.create.assert_awaited_once()
+        assert result.app_name == "Plus2PM"
+        assert result.version == "1.7.5"
+        assert result.build_id == "20250611-100000/1.7.5-g1234567"
+        assert result.file_name == _expected_file_name()
+        assert result.size_bytes == 2048
+        assert result.sha256 == "ab" * 32
+
+    async def test_it_raises_when_the_index_has_no_release(
+        self, use_case, mock_firmware_gateway
+    ):
+        mock_firmware_gateway.get_latest = AsyncMock(return_value=None)
+
+        with pytest.raises(FirmwareError, match="No firmware published"):
+            await use_case.execute("Unknown")
+
+        mock_firmware_gateway.download.assert_not_awaited()
+
+    async def test_it_refuses_an_unsafe_app_name(self, use_case, mock_firmware_gateway):
+        with pytest.raises(FirmwareError, match="unsafe app name"):
+            await use_case.execute("Plus2PM/../evil")
+
+        mock_firmware_gateway.get_latest.assert_not_awaited()
+        mock_firmware_gateway.download.assert_not_awaited()
+
+    @pytest.mark.parametrize("app_name", [".", ".."])
+    async def test_it_refuses_dot_segment_app_names(
+        self, use_case, mock_firmware_gateway, app_name
+    ):
+        with pytest.raises(FirmwareError, match="unsafe app name"):
+            await use_case.execute(app_name)
+
+        mock_firmware_gateway.get_latest.assert_not_awaited()
+
+    async def test_it_uses_a_supplied_release_without_re_querying_the_index(
+        self, use_case, mock_firmware_gateway, mock_repository, tmp_path
+    ):
+        release = _release()
+
+        result = await use_case.execute("Plus2PM", release)
+
+        mock_firmware_gateway.get_latest.assert_not_awaited()
+        mock_firmware_gateway.download.assert_awaited_once_with(
+            release, str(tmp_path / _expected_file_name())
+        )
+        assert result.version == "1.7.5"
+
+    async def test_it_refuses_an_unsafe_version_from_the_index(
+        self, use_case, mock_firmware_gateway
+    ):
+        mock_firmware_gateway.get_latest = AsyncMock(
+            return_value=_release(version="../../evil")
+        )
+
+        with pytest.raises(FirmwareError, match="unsafe firmware version"):
+            await use_case.execute("Plus2PM")
+
+        mock_firmware_gateway.download.assert_not_awaited()
+
+    async def test_it_downloads_once_for_concurrent_requests(
+        self, mock_firmware_gateway, tmp_path
+    ):
+        stored: dict[tuple[str, str, str], FirmwareBundle] = {}
+
+        async def find(app_name, version, build_id):
+            return stored.get((app_name, version, build_id))
+
+        async def create(bundle):
+            bundle.id = len(stored) + 1
+            stored[(bundle.app_name, bundle.version, bundle.build_id)] = bundle
+            return bundle
+
+        async def download(release, dest_path):
+            await asyncio.sleep(0)
+            Path(dest_path).write_bytes(b"zip")
+            return 2048, "ab" * 32
+
+        repository = AsyncMock()
+        repository.find = AsyncMock(side_effect=find)
+        repository.create = AsyncMock(side_effect=create)
+        mock_firmware_gateway.download = AsyncMock(side_effect=download)
+
+        @asynccontextmanager
+        async def repository_factory():
+            yield repository
+
+        use_case = AcquireFirmware(
+            firmware_gateway=mock_firmware_gateway,
+            repository_factory=repository_factory,
+            settings=FirmwareSettings(dir=str(tmp_path)),
+        )
+
+        first, second = await asyncio.gather(
+            use_case.execute("Plus2PM"), use_case.execute("Plus2PM")
+        )
+
+        assert first.id == second.id
+        mock_firmware_gateway.download.assert_awaited_once()
+        repository.create.assert_awaited_once()

--- a/packages/core/tests/unit/use_cases/test_bulk_operations.py
+++ b/packages/core/tests/unit/use_cases/test_bulk_operations.py
@@ -69,7 +69,7 @@ class TestBulkOperationsUseCase:
         assert len(results) == 1
         assert results[0].success is True
         mock_device_gateway.execute_bulk_action.assert_called_once_with(
-            device_ips, "shelly", "Update", {"channel": "beta"}
+            device_ips, "shelly", "Update", {"stage": "beta"}
         )
 
     async def test_it_raises_bulk_operation_error_on_update_failure(

--- a/packages/core/tests/unit/use_cases/test_manage_firmware.py
+++ b/packages/core/tests/unit/use_cases/test_manage_firmware.py
@@ -1,0 +1,72 @@
+"""Tests for the manage firmware use case."""
+
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock
+
+import pytest
+from core.domain.entities.firmware_bundle import FirmwareBundle
+from core.settings import FirmwareSettings
+from core.use_cases.manage_firmware import ManageFirmware
+
+
+def _bundle(bundle_id=7, file_name="Plus2PM-1.7.5.zip"):
+    return FirmwareBundle(
+        id=bundle_id,
+        app_name="Plus2PM",
+        version="1.7.5",
+        build_id="20250611-100000/1.7.5-g1234567",
+        file_name=file_name,
+    )
+
+
+class TestManageFirmware:
+    @pytest.fixture
+    def mock_repository(self):
+        repository = AsyncMock()
+        repository.get = AsyncMock(return_value=_bundle())
+        repository.delete = AsyncMock(return_value=True)
+        repository.list = AsyncMock(return_value=[_bundle()])
+        return repository
+
+    @pytest.fixture
+    def use_case(self, mock_repository, tmp_path):
+        @asynccontextmanager
+        async def repository_factory():
+            yield mock_repository
+
+        return ManageFirmware(
+            repository_factory=repository_factory,
+            settings=FirmwareSettings(dir=str(tmp_path)),
+        )
+
+    async def test_it_lists_bundles(self, use_case):
+        bundles = await use_case.list_bundles()
+
+        assert len(bundles) == 1
+        assert bundles[0].app_name == "Plus2PM"
+
+    async def test_it_deletes_the_bundle_and_its_file(
+        self, use_case, mock_repository, tmp_path
+    ):
+        zip_path = tmp_path / "Plus2PM-1.7.5.zip"
+        zip_path.write_bytes(b"zip")
+
+        assert (await use_case.delete_bundle(7)) is True
+
+        mock_repository.delete.assert_awaited_once_with(7)
+        assert not zip_path.exists()
+
+    async def test_it_returns_false_for_a_missing_bundle(
+        self, use_case, mock_repository
+    ):
+        mock_repository.get = AsyncMock(return_value=None)
+
+        assert (await use_case.delete_bundle(7)) is False
+        mock_repository.delete.assert_not_awaited()
+
+    async def test_it_keeps_a_hostile_file_name_inside_the_store(
+        self, use_case, tmp_path
+    ):
+        path = use_case.bundle_path(_bundle(file_name="../evil.zip"))
+
+        assert path == str(tmp_path / "evil.zip")

--- a/packages/core/tests/unit/use_cases/test_update_device_from_local.py
+++ b/packages/core/tests/unit/use_cases/test_update_device_from_local.py
@@ -1,0 +1,314 @@
+"""Tests for the update device from local use case."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+from core.domain.entities.exceptions import (
+    DeviceNotFoundError,
+    FirmwareConfigurationError,
+    FirmwareError,
+)
+from core.domain.entities.firmware_bundle import FirmwareBundle
+from core.domain.value_objects.action_result import ActionResult
+from core.domain.value_objects.base_device_request import BaseDeviceRequest
+from core.domain.value_objects.firmware_release import FirmwareRelease
+from core.settings import FirmwareSettings
+from core.use_cases.update_device_from_local import UpdateDeviceFromLocal
+
+IP = "192.168.1.100"
+BASE_URL = "http://192.168.40.252:8000"
+
+
+def _status(gen=2, app_name="Plus2PM", firmware_version="20240101-000000/1.7.5-gabc"):
+    return SimpleNamespace(
+        gen=gen,
+        app_name=app_name,
+        firmware_version=firmware_version,
+    )
+
+
+def _release(version="1.8.0"):
+    return FirmwareRelease(
+        app_name="Plus2PM",
+        version=version,
+        build_id=f"20250611-100000/{version}-g1234567",
+        download_url="https://fwcdn.example.test/Plus2PM.zip",
+        channel="stable",
+    )
+
+
+def _bundle(bundle_id=7, version="1.8.0"):
+    return FirmwareBundle(
+        id=bundle_id,
+        app_name="Plus2PM",
+        version=version,
+        build_id=f"20250611-100000/{version}-g1234567",
+        file_name=f"Plus2PM-{version}.zip",
+    )
+
+
+def _use_case(
+    mock_device_gateway,
+    mock_firmware_gateway,
+    mock_acquire,
+    advertised_base_url=BASE_URL,
+):
+    return UpdateDeviceFromLocal(
+        device_gateway=mock_device_gateway,
+        firmware_gateway=mock_firmware_gateway,
+        acquire_firmware=mock_acquire,
+        settings=FirmwareSettings(advertised_base_url=advertised_base_url),
+    )
+
+
+class TestUpdateDeviceFromLocal:
+    @pytest.fixture
+    def mock_firmware_gateway(self):
+        gateway = AsyncMock()
+        gateway.get_latest = AsyncMock(return_value=_release())
+        return gateway
+
+    @pytest.fixture
+    def mock_acquire(self):
+        acquire = AsyncMock()
+        acquire.execute = AsyncMock(return_value=_bundle())
+        return acquire
+
+    @pytest.fixture
+    def use_case(self, mock_device_gateway, mock_firmware_gateway, mock_acquire):
+        mock_device_gateway.get_device_status = AsyncMock(return_value=_status())
+        mock_device_gateway.execute_component_action = AsyncMock(
+            return_value=ActionResult(
+                device_ip=IP,
+                action_type="shelly.Update",
+                success=True,
+                message="Update executed successfully on shelly",
+            )
+        )
+        return _use_case(mock_device_gateway, mock_firmware_gateway, mock_acquire)
+
+    async def test_it_sends_the_local_url_to_the_device(
+        self, use_case, mock_device_gateway, mock_firmware_gateway, mock_acquire
+    ):
+        result = await use_case.execute(BaseDeviceRequest(device_ip=IP))
+
+        assert result.success is True
+        mock_device_gateway.execute_component_action.assert_awaited_once_with(
+            IP,
+            "shelly",
+            "Update",
+            {"url": f"{BASE_URL}/api/firmware/7/download"},
+        )
+        mock_firmware_gateway.get_latest.assert_awaited_once()
+        mock_acquire.execute.assert_awaited_once_with(
+            "Plus2PM", mock_firmware_gateway.get_latest.return_value
+        )
+
+    async def test_it_normalizes_a_trailing_slash_in_the_base_url(
+        self, mock_device_gateway, mock_firmware_gateway, mock_acquire
+    ):
+        mock_device_gateway.get_device_status = AsyncMock(return_value=_status())
+        mock_device_gateway.execute_component_action = AsyncMock(
+            return_value=ActionResult(
+                device_ip=IP, action_type="shelly.Update", success=True, message="ok"
+            )
+        )
+        use_case = _use_case(
+            mock_device_gateway,
+            mock_firmware_gateway,
+            mock_acquire,
+            advertised_base_url=f"{BASE_URL}/",
+        )
+
+        await use_case.execute(BaseDeviceRequest(device_ip=IP))
+
+        mock_device_gateway.execute_component_action.assert_awaited_once_with(
+            IP,
+            "shelly",
+            "Update",
+            {"url": f"{BASE_URL}/api/firmware/7/download"},
+        )
+
+    async def test_it_rejects_an_unset_advertised_base_url(
+        self, mock_device_gateway, mock_firmware_gateway, mock_acquire
+    ):
+        mock_device_gateway.get_device_status = AsyncMock()
+        use_case = _use_case(
+            mock_device_gateway,
+            mock_firmware_gateway,
+            mock_acquire,
+            advertised_base_url=None,
+        )
+
+        with pytest.raises(FirmwareConfigurationError, match="ADVERTISED_BASE_URL"):
+            await use_case.execute(BaseDeviceRequest(device_ip=IP))
+
+        mock_device_gateway.get_device_status.assert_not_awaited()
+
+    async def test_it_raises_when_the_device_is_unreachable(
+        self, use_case, mock_device_gateway
+    ):
+        mock_device_gateway.get_device_status = AsyncMock(return_value=None)
+
+        with pytest.raises(DeviceNotFoundError):
+            await use_case.execute(BaseDeviceRequest(device_ip=IP))
+
+    async def test_it_rejects_a_gen1_device(self, use_case, mock_device_gateway):
+        mock_device_gateway.get_device_status = AsyncMock(
+            return_value=_status(gen=1, firmware_version="v1.14.0-gcb84623")
+        )
+
+        with pytest.raises(FirmwareError, match="Gen1"):
+            await use_case.execute(BaseDeviceRequest(device_ip=IP))
+
+        mock_device_gateway.execute_component_action.assert_not_awaited()
+
+    async def test_it_rejects_a_device_without_an_app_name(
+        self, use_case, mock_device_gateway
+    ):
+        mock_device_gateway.get_device_status = AsyncMock(
+            return_value=_status(app_name=None)
+        )
+
+        with pytest.raises(FirmwareError, match="app name"):
+            await use_case.execute(BaseDeviceRequest(device_ip=IP))
+
+    async def test_it_raises_when_no_release_is_published(
+        self, use_case, mock_firmware_gateway, mock_device_gateway
+    ):
+        mock_firmware_gateway.get_latest = AsyncMock(return_value=None)
+
+        with pytest.raises(FirmwareError, match="No firmware published"):
+            await use_case.execute(BaseDeviceRequest(device_ip=IP))
+
+        mock_device_gateway.execute_component_action.assert_not_awaited()
+
+    async def test_it_short_circuits_when_already_up_to_date(
+        self, use_case, mock_device_gateway, mock_firmware_gateway, mock_acquire
+    ):
+        published = _release("1.7.5")
+        mock_device_gateway.get_device_status = AsyncMock(
+            return_value=_status(firmware_version=published.build_id)
+        )
+        mock_firmware_gateway.get_latest = AsyncMock(return_value=published)
+
+        result = await use_case.execute(BaseDeviceRequest(device_ip=IP))
+
+        assert result.success is True
+        assert "already" in result.message
+        mock_acquire.execute.assert_not_awaited()
+        mock_device_gateway.execute_component_action.assert_not_awaited()
+
+    async def test_it_trusts_a_bare_version_a_device_reports(
+        self, use_case, mock_device_gateway, mock_firmware_gateway, mock_acquire
+    ):
+        mock_device_gateway.get_device_status = AsyncMock(
+            return_value=_status(firmware_version="1.7.5")
+        )
+        mock_firmware_gateway.get_latest = AsyncMock(return_value=_release("1.7.5"))
+
+        result = await use_case.execute(BaseDeviceRequest(device_ip=IP))
+
+        assert "already" in result.message
+        mock_acquire.execute.assert_not_awaited()
+        mock_device_gateway.execute_component_action.assert_not_awaited()
+
+    async def test_it_reports_a_downgrade_from_a_bare_version(
+        self, use_case, mock_device_gateway, mock_firmware_gateway
+    ):
+        mock_device_gateway.get_device_status = AsyncMock(
+            return_value=_status(firmware_version="2.0.0")
+        )
+        mock_firmware_gateway.get_latest = AsyncMock(return_value=_release("1.8.0"))
+
+        result = await use_case.execute(BaseDeviceRequest(device_ip=IP))
+
+        assert "downgrade from 2.0.0 to 1.8.0" in result.message
+
+    async def test_it_updates_a_version_republished_under_a_new_build(
+        self, use_case, mock_device_gateway, mock_firmware_gateway
+    ):
+        mock_device_gateway.get_device_status = AsyncMock(
+            return_value=_status(firmware_version="20240101-000000/1.7.5-gold")
+        )
+        mock_firmware_gateway.get_latest = AsyncMock(return_value=_release("1.7.5"))
+
+        await use_case.execute(BaseDeviceRequest(device_ip=IP))
+
+        mock_device_gateway.execute_component_action.assert_awaited_once()
+
+    async def test_it_installs_an_older_build_and_says_so(
+        self, use_case, mock_device_gateway, mock_firmware_gateway
+    ):
+        mock_device_gateway.get_device_status = AsyncMock(
+            return_value=_status(firmware_version="20260101-000000/1.9.0-gabc")
+        )
+        mock_firmware_gateway.get_latest = AsyncMock(return_value=_release("1.8.0"))
+
+        result = await use_case.execute(BaseDeviceRequest(device_ip=IP))
+
+        assert result.success is True
+        assert "downgrade from 1.9.0 to 1.8.0" in result.message
+        mock_device_gateway.execute_component_action.assert_awaited_once()
+
+    async def test_it_reports_a_downgrade_from_a_prerelease(
+        self, use_case, mock_device_gateway, mock_firmware_gateway
+    ):
+        mock_device_gateway.get_device_status = AsyncMock(
+            return_value=_status(firmware_version="20260101-000000/1.9.0-beta1-gabc")
+        )
+        mock_firmware_gateway.get_latest = AsyncMock(return_value=_release("1.8.0"))
+
+        result = await use_case.execute(BaseDeviceRequest(device_ip=IP))
+
+        assert "downgrade from 1.9.0-beta1 to 1.8.0" in result.message
+        mock_device_gateway.execute_component_action.assert_awaited_once()
+
+    async def test_it_says_nothing_extra_when_moving_forward(
+        self, use_case, mock_device_gateway, mock_firmware_gateway
+    ):
+        mock_device_gateway.get_device_status = AsyncMock(
+            return_value=_status(firmware_version="20240101-000000/1.7.5-gabc")
+        )
+        mock_firmware_gateway.get_latest = AsyncMock(return_value=_release("1.8.0"))
+
+        result = await use_case.execute(BaseDeviceRequest(device_ip=IP))
+
+        assert "downgrade" not in result.message
+
+    async def test_it_updates_a_device_running_an_older_version(
+        self, use_case, mock_device_gateway, mock_firmware_gateway
+    ):
+        mock_device_gateway.get_device_status = AsyncMock(
+            return_value=_status(firmware_version="20240101-000000/1.7.5-gabc")
+        )
+        mock_firmware_gateway.get_latest = AsyncMock(return_value=_release("1.8.0"))
+
+        await use_case.execute(BaseDeviceRequest(device_ip=IP))
+
+        mock_device_gateway.execute_component_action.assert_awaited_once()
+
+    async def test_it_updates_when_the_versions_cannot_be_compared(
+        self, use_case, mock_device_gateway, mock_firmware_gateway
+    ):
+        mock_device_gateway.get_device_status = AsyncMock(
+            return_value=_status(firmware_version="20240101-000000/experimental-gabc")
+        )
+        mock_firmware_gateway.get_latest = AsyncMock(return_value=_release("1.8.0"))
+
+        await use_case.execute(BaseDeviceRequest(device_ip=IP))
+
+        mock_device_gateway.execute_component_action.assert_awaited_once()
+
+    async def test_it_updates_when_the_installed_version_is_a_prefix(
+        self, use_case, mock_device_gateway, mock_firmware_gateway
+    ):
+        mock_device_gateway.get_device_status = AsyncMock(
+            return_value=_status(firmware_version="20240101-000000/1.7.5-gabc")
+        )
+        mock_firmware_gateway.get_latest = AsyncMock(return_value=_release("1.7.55"))
+
+        await use_case.execute(BaseDeviceRequest(device_ip=IP))
+
+        mock_device_gateway.execute_component_action.assert_awaited_once()

--- a/packages/web/src/components/device-detail/component-actions.tsx
+++ b/packages/web/src/components/device-detail/component-actions.tsx
@@ -302,11 +302,11 @@ export function ComponentActions({
         return (
           <div className="space-y-4">
             <div>
-              <Label htmlFor="channel">Update Channel</Label>
+              <Label htmlFor="stage">Update Channel</Label>
               <Select
-                value={(actionParameters.channel as string) || "stable"}
+                value={(actionParameters.stage as string) || "stable"}
                 onValueChange={(value) =>
-                  setActionParameters({ ...actionParameters, channel: value })
+                  setActionParameters({ ...actionParameters, stage: value })
                 }
               >
                 <SelectTrigger>

--- a/packages/web/src/components/device-detail/device-actions.tsx
+++ b/packages/web/src/components/device-detail/device-actions.tsx
@@ -35,7 +35,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { deviceApi, handleApiError } from "@/lib/api";
-import type { DeviceStatus } from "@/types/api";
+import type { DeviceStatus, UpdateSource } from "@/types/api";
 
 interface DeviceActionsProps {
   ip: string;
@@ -54,13 +54,24 @@ export function DeviceActions({
   const [updateChannel, setUpdateChannel] = useState<"stable" | "beta">(
     "stable",
   );
+  const [updateSource, setUpdateSource] = useState<UpdateSource>("internet");
   const [rebootDialogOpen, setRebootDialogOpen] = useState(false);
   const [updateDialogOpen, setUpdateDialogOpen] = useState(false);
   const [factoryResetDialogOpen, setFactoryResetDialogOpen] = useState(false);
 
   const updateMutation = useMutation({
-    mutationFn: (channel: "stable" | "beta") =>
-      deviceApi.updateDevice(ip, channel),
+    mutationFn: ({
+      channel,
+      source,
+    }: {
+      channel: "stable" | "beta";
+      source: UpdateSource;
+    }) =>
+      deviceApi.updateDevice(
+        ip,
+        source === "local" ? "stable" : channel,
+        source,
+      ),
     onSuccess: (result) => {
       if (result.success) {
         toast.success(
@@ -145,7 +156,6 @@ export function DeviceActions({
             <DialogTrigger asChild>
               <Button
                 variant={hasUpdates ? "default" : "outline"}
-                disabled={!hasUpdates}
                 className="flex items-center space-x-2"
               >
                 <Download className="h-4 w-4" />
@@ -163,64 +173,114 @@ export function DeviceActions({
                 </DialogDescription>
               </DialogHeader>
 
-              <div className="space-y-4">
-                <div className="space-y-2">
-                  <label className="text-sm font-medium">
-                    {t("deviceDetail.dialogs.updateFirmware.updateChannel")}
+              <div className="space-y-5">
+                <div className="space-y-3">
+                  <label className="block text-sm font-medium">
+                    {t("deviceDetail.dialogs.updateFirmware.updateSource")}
                   </label>
                   <Select
-                    value={updateChannel}
-                    onValueChange={(value: "stable" | "beta") =>
-                      setUpdateChannel(value)
+                    value={updateSource}
+                    onValueChange={(value: UpdateSource) =>
+                      setUpdateSource(value)
                     }
                   >
                     <SelectTrigger>
                       <SelectValue />
                     </SelectTrigger>
                     <SelectContent>
-                      <SelectItem value="stable">
-                        <div className="space-y-1">
-                          <div>{t("bulkActions.stable")}</div>
-                          {availableUpdates.stable && (
-                            <div className="text-xs text-muted-foreground">
-                              {t("deviceDetail.dialogs.updateFirmware.version")}{" "}
-                              {availableUpdates.stable.version}
-                            </div>
-                          )}
-                        </div>
+                      <SelectItem value="internet">
+                        {t(
+                          "deviceDetail.dialogs.updateFirmware.sourceInternet",
+                        )}
                       </SelectItem>
-                      <SelectItem value="beta">
-                        <div className="space-y-1">
-                          <div>{t("bulkActions.beta")}</div>
-                          {availableUpdates.beta && (
-                            <div className="text-xs text-muted-foreground">
-                              {t("deviceDetail.dialogs.updateFirmware.version")}{" "}
-                              {availableUpdates.beta.version}
-                            </div>
-                          )}
-                        </div>
+                      <SelectItem value="local">
+                        {t("deviceDetail.dialogs.updateFirmware.sourceLocal")}
                       </SelectItem>
                     </SelectContent>
                   </Select>
+                  <ol className="text-xs text-muted-foreground space-y-1 pt-2">
+                    {(updateSource === "local"
+                      ? ["localStep1", "localStep2", "localStep3"]
+                      : ["internetStep1", "internetStep2"]
+                    ).map((step, index) => (
+                      <li key={step} className="flex gap-2">
+                        <span className="text-muted-foreground/60">
+                          {index + 1}.
+                        </span>
+                        <span>
+                          {t(`deviceDetail.dialogs.updateFirmware.${step}`)}
+                        </span>
+                      </li>
+                    ))}
+                  </ol>
                 </div>
 
-                {availableUpdates[updateChannel] && (
-                  <div className="p-3 bg-muted rounded-lg space-y-2">
-                    <div className="text-sm font-medium">
-                      {availableUpdates[updateChannel].name ||
-                        t("deviceDetail.dialogs.updateFirmware.firmwareUpdate")}
-                    </div>
-                    <div className="text-sm text-muted-foreground">
-                      {t("deviceDetail.dialogs.updateFirmware.version")}:{" "}
-                      {availableUpdates[updateChannel].version}
-                    </div>
-                    {availableUpdates[updateChannel].desc && (
-                      <div className="text-xs text-muted-foreground">
-                        {availableUpdates[updateChannel].desc}
-                      </div>
-                    )}
+                {updateSource === "internet" && (
+                  <div className="space-y-3">
+                    <label className="block text-sm font-medium">
+                      {t("deviceDetail.dialogs.updateFirmware.updateChannel")}
+                    </label>
+                    <Select
+                      value={updateChannel}
+                      onValueChange={(value: "stable" | "beta") =>
+                        setUpdateChannel(value)
+                      }
+                    >
+                      <SelectTrigger>
+                        <SelectValue />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="stable">
+                          <div className="space-y-1">
+                            <div>{t("bulkActions.stable")}</div>
+                            {availableUpdates.stable && (
+                              <div className="text-xs text-muted-foreground">
+                                {t(
+                                  "deviceDetail.dialogs.updateFirmware.version",
+                                )}{" "}
+                                {availableUpdates.stable.version}
+                              </div>
+                            )}
+                          </div>
+                        </SelectItem>
+                        <SelectItem value="beta">
+                          <div className="space-y-1">
+                            <div>{t("bulkActions.beta")}</div>
+                            {availableUpdates.beta && (
+                              <div className="text-xs text-muted-foreground">
+                                {t(
+                                  "deviceDetail.dialogs.updateFirmware.version",
+                                )}{" "}
+                                {availableUpdates.beta.version}
+                              </div>
+                            )}
+                          </div>
+                        </SelectItem>
+                      </SelectContent>
+                    </Select>
                   </div>
                 )}
+
+                {updateSource === "internet" &&
+                  availableUpdates[updateChannel] && (
+                    <div className="p-3 bg-muted rounded-lg space-y-2">
+                      <div className="text-sm font-medium">
+                        {availableUpdates[updateChannel].name ||
+                          t(
+                            "deviceDetail.dialogs.updateFirmware.firmwareUpdate",
+                          )}
+                      </div>
+                      <div className="text-sm text-muted-foreground">
+                        {t("deviceDetail.dialogs.updateFirmware.version")}:{" "}
+                        {availableUpdates[updateChannel].version}
+                      </div>
+                      {availableUpdates[updateChannel].desc && (
+                        <div className="text-xs text-muted-foreground">
+                          {availableUpdates[updateChannel].desc}
+                        </div>
+                      )}
+                    </div>
+                  )}
               </div>
 
               <DialogFooter>
@@ -231,8 +291,16 @@ export function DeviceActions({
                   {t("common.cancel")}
                 </Button>
                 <Button
-                  onClick={() => updateMutation.mutate(updateChannel)}
-                  disabled={updateMutation.isPending}
+                  onClick={() =>
+                    updateMutation.mutate({
+                      channel: updateChannel,
+                      source: updateSource,
+                    })
+                  }
+                  disabled={
+                    updateMutation.isPending ||
+                    (updateSource === "internet" && !hasUpdates)
+                  }
                 >
                   {updateMutation.isPending
                     ? t("deviceDetail.dialogs.updateFirmware.startingUpdate")

--- a/packages/web/src/i18n/en.json
+++ b/packages/web/src/i18n/en.json
@@ -395,8 +395,17 @@
     "dialogs": {
       "updateFirmware": {
         "title": "Update Firmware",
-        "description": "Select the update channel and confirm to start the firmware update process.",
+        "description": "Select the update source and confirm to start the firmware update process.",
         "updateChannel": "Update Channel",
+        "updateSource": "Update Source",
+        "sourceInternet": "Internet",
+        "sourceLocal": "Via manager",
+        "sourceLocalHint": "The manager downloads the official firmware once and serves it to the device over the local network. Useful for devices without internet access. Stable channel only.",
+        "internetStep1": "The device is told to update itself",
+        "internetStep2": "It downloads the firmware from Shelly and installs it",
+        "localStep1": "The manager asks Shelly which version is current",
+        "localStep2": "It downloads that firmware, unless it already has it (first time takes a moment)",
+        "localStep3": "The device downloads from the manager and installs it",
         "version": "Version",
         "firmwareUpdate": "Firmware Update",
         "startingUpdate": "Starting Update...",

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -23,6 +23,7 @@ import type {
   CreateBackupScheduleRequest,
   UpdateBackupScheduleRequest,
   ScheduleRunResult,
+  UpdateSource,
 } from "@/types/api";
 import { loadAppSettings } from "./settings";
 import { parseResponse } from "./schemas/parse";
@@ -163,8 +164,13 @@ export const deviceApi = {
   updateDevice: async (
     ip: string,
     channel: "stable" | "beta" = "stable",
+    source: UpdateSource = "internet",
   ): Promise<ActionResult> => {
-    const response = await apiClient.post(`/devices/${ip}/update`, { channel });
+    const response = await apiClient.post(
+      `/devices/${ip}/update`,
+      { channel, source },
+      source === "local" ? { timeout: 120000 } : undefined,
+    );
     return response.data;
   },
 

--- a/packages/web/src/types/api.ts
+++ b/packages/web/src/types/api.ts
@@ -324,12 +324,16 @@ export interface DeviceStatusError {
   error: string;
 }
 
+export type UpdateSource = "internet" | "local";
+
 export interface ActionResult {
   ip: string;
   success: boolean;
   message?: string;
   error?: string | null;
   action_type?: string;
+  channel?: string;
+  source?: UpdateSource;
 }
 
 export interface BulkActionResult {


### PR DESCRIPTION
## Purpose

Update Shelly devices that have no internet access, by having the manager fetch the firmware and serve it to them over the LAN.

## Context

Closes the ask in #4. The manager downloads the official bundle from Shelly's published index once, caches it, and points `Shelly.Update` at its own copy, so one download serves every identical device and the devices themselves never need to reach the internet. Opt-in per update via a new `source` field; the existing internet path is untouched.

The first commit is an independent bug fix worth reading on its own: `Shelly.Update` names the channel field `stage`, and we were sending `channel`. Devices ignore an unknown parameter, so asking for beta silently installed stable and reported success. That bug is live on `main` today.

Because the index response chooses the download URL and Shelly signs its endpoints with a CA no public trust store carries, TLS verification is off for those two hosts and the download is instead constrained by a host allow list re-checked on every redirect hop. Firmware integrity itself rests on the device's own signature check.

Gen1, bulk local updates, picking a specific version, and manual upload are all out of scope here. Only the index's current stable release is installable, because Shelly publishes no history for Gen2+.

## Local Setup

Set `SHELLY_FIRMWARE_ADVERTISED_BASE_URL` to a URL your devices can reach (for example `http://192.168.40.252:8000`) — local updates fail fast without it, since the manager cannot guess its own device-facing address.
