### PR TITLE
The compose cli service mounts nothing and runs nothing

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -17,6 +17,9 @@ Development setup guide for Shelly Manager, covering backend (Core/API/CLI) and 
 git clone https://github.com/jfmlima/shelly-manager.git
 cd shelly-manager
 
+# Every compose service needs this. Put it in a .env file to keep it.
+export SHELLY_SECRET_KEY=$(python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())")
+
 # Start development environment
 docker-compose up -d
 
@@ -31,8 +34,10 @@ The CLI ships as an opt-in profile, so `docker-compose up -d` does not start it.
 ```bash
 docker compose --profile cli up -d cli
 docker compose exec cli shelly-manager scan 192.168.1.0/24
-docker compose --profile cli down
+docker compose down cli
 ```
+
+`down cli` stops only that container. A bare `docker compose down` takes the whole stack with it, profile flag or not.
 
 Both source trees are bind-mounted into that container, so edits on the host take effect without a rebuild.
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -26,6 +26,16 @@ docker-compose up -d
 # - API Docs: http://localhost:8000/docs
 ```
 
+The CLI ships as an opt-in profile, so `docker-compose up -d` does not start it. Its entrypoint keeps the container idle, which means you drive it with `exec` rather than `run`:
+
+```bash
+docker compose --profile cli up -d cli
+docker compose exec cli shelly-manager scan 192.168.1.0/24
+docker compose --profile cli down
+```
+
+Both source trees are bind-mounted into that container, so edits on the host take effect without a rebuild.
+
 ### Option 2: Local Development
 
 1. **Install uv:**

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -58,6 +58,8 @@ services:
       context: .
       dockerfile: packages/cli/dev.Dockerfile
     environment:
+      SHELLY_SECRET_KEY: "${SHELLY_SECRET_KEY:?SHELLY_SECRET_KEY must be set - generate with: python -c \"from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())\"}"
+    volumes:
       - ./packages/cli/src:/app/packages/cli/src:rw
       - ./packages/core/src:/app/packages/core/src:rw
     profiles:


### PR DESCRIPTION
## Purpose

The compose `cli` service mounted nothing and could not run a single command. Both are fixed, and the profile is documented for the first time.

## Context

Its two source mounts sat under the service's `environment:` key rather than a `volumes:` key. That is legal YAML, so compose accepted it and read each mount string as an environment variable name with no value: the rendered service had two variables literally called `./packages/cli/src:/app/packages/cli/src:rw` and `./packages/core/src:/app/packages/core/src:rw`, and no volumes at all. `d936c88` removed the legacy config file and deleted the `volumes:` key line along with `SHELLY_CONFIG_FILE` and the `config.json` mount, stranding the two survivors one key too high.

The service also passed no `SHELLY_SECRET_KEY`, and core builds its settings singleton at import with that field required, so every command in the container died on a validation error before doing any work. It takes the key the same way the api service does now.

Restoring the mounts is worth doing rather than deleting them: the image installs both workspace packages editable, pointed at exactly those two paths, so edits on the host take effect with no rebuild.

## Notes

Nothing in the repo described this profile, which is the likeliest reason the breakage went unnoticed. The documentation added here covers the two things that are not guessable: it is opt-in, so a plain `docker-compose up -d` does not start it, and its idle entrypoint means you drive it with `exec`, not `run`. A `docker compose run cli <args>` appends the arguments to `tail -f /dev/null` and hangs.

The teardown line is `docker compose down cli` rather than `docker compose --profile cli down`. The profile flag selects which services a command activates; it does not narrow what `down` destroys, so the profile form removes the whole stack. Checked with the api service running alongside.

Quick Start now exports `SHELLY_SECRET_KEY`. Every service in the compose file interpolates it as a required variable, so none of the commands in this guide ran from a clean shell and nothing said so. That predates this change; the new section would have added a second instance of it.

Not addressed here: neither service mounts anything for `./data`, so a container-local database is discarded on teardown. That is a broader problem across every deployment surface and wants its own change.
