### PR TITLE
Stop requiring an encryption key to print help

### DIFF
--- a/packages/api/src/api/main.py
+++ b/packages/api/src/api/main.py
@@ -3,8 +3,10 @@ from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
 
 import uvicorn
+from core.domain.entities.exceptions import ConfigurationError
 from core.repositories.db import engine
 from core.repositories.models import Base
+from core.settings import MISSING_SECRET_KEY_MESSAGE
 from core.settings import settings as core_settings
 from litestar import Litestar, Router
 from litestar.config.cors import CORSConfig
@@ -94,6 +96,12 @@ def create_app() -> Litestar:
 
     @asynccontextmanager
     async def lifespan(app: Litestar) -> AsyncGenerator[None, None]:
+        # Credential and backup requests need this key. Without the check the
+        # server would boot and only fail deep inside a request, where the 500
+        # body redacts the cause.
+        if core_settings.secret_key is None:
+            raise ConfigurationError("startup", MISSING_SECRET_KEY_MESSAGE)
+
         async with engine.begin() as conn:
             await conn.run_sync(Base.metadata.create_all)
             # create_all adds new indexes only to tables it creates fresh, not

--- a/packages/api/src/api/main.py
+++ b/packages/api/src/api/main.py
@@ -3,10 +3,8 @@ from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
 
 import uvicorn
-from core.domain.entities.exceptions import ConfigurationError
 from core.repositories.db import engine
 from core.repositories.models import Base
-from core.settings import MISSING_SECRET_KEY_MESSAGE
 from core.settings import settings as core_settings
 from litestar import Litestar, Router
 from litestar.config.cors import CORSConfig
@@ -96,11 +94,7 @@ def create_app() -> Litestar:
 
     @asynccontextmanager
     async def lifespan(app: Litestar) -> AsyncGenerator[None, None]:
-        # Credential and backup requests need this key. Without the check the
-        # server would boot and only fail deep inside a request, where the 500
-        # body redacts the cause.
-        if core_settings.secret_key is None:
-            raise ConfigurationError("startup", MISSING_SECRET_KEY_MESSAGE)
+        _container.get_encryption_service()
 
         async with engine.begin() as conn:
             await conn.run_sync(Base.metadata.create_all)

--- a/packages/api/src/api/presentation/handlers.py
+++ b/packages/api/src/api/presentation/handlers.py
@@ -12,6 +12,7 @@ from typing import Any
 
 from core.domain.entities.exceptions import (
     BulkOperationError,
+    ConfigurationError,
     DeviceAuthenticationError,
     DeviceCommunicationError,
     DeviceNotFoundError,
@@ -106,6 +107,7 @@ EXCEPTION_HANDLERS: MutableMapping[int | type[Exception], ExceptionHandler] | No
     ScheduleNotFoundError: _typed_handler(404, "Schedule Not Found"),
     ScheduleAlreadyExistsError: _typed_handler(409, "Schedule Already Exists"),
     CoreValidationError: _typed_handler(400, "Validation Error"),
+    ConfigurationError: _typed_handler(500, "Configuration Error"),
     ValueError: handle_value_error,
     HTTPException: handle_http_exception,
     Exception: handle_generic_exception,

--- a/packages/api/tests/unit/test_main.py
+++ b/packages/api/tests/unit/test_main.py
@@ -1,7 +1,9 @@
 from datetime import datetime
 
+import pytest
 from api.controllers.monitoring import health_check
 from api.main import app_factory
+from core.domain.entities.exceptions import ConfigurationError
 from litestar import Litestar
 from litestar.config.cors import CORSConfig
 from litestar.testing import create_test_client
@@ -61,3 +63,28 @@ class TestMainApp:
             response = client.get("/unknown/route")
 
             assert response.status_code == 404
+
+
+class TestSecretKeyAtStartup:
+
+    async def test_it_refuses_to_start_without_a_secret_key(self, monkeypatch):
+        import core.settings
+
+        monkeypatch.setattr(core.settings.settings, "secret_key", None)
+
+        with pytest.raises(BaseExceptionGroup) as excinfo:
+            async with app_factory().lifespan():
+                pass
+
+        assert excinfo.group_contains(ConfigurationError, match="SHELLY_SECRET_KEY")
+
+    async def test_it_refuses_to_start_on_a_malformed_secret_key(self, monkeypatch):
+        import core.settings
+
+        monkeypatch.setattr(core.settings.settings, "secret_key", "not-a-fernet-key")
+
+        with pytest.raises(BaseExceptionGroup) as excinfo:
+            async with app_factory().lifespan():
+                pass
+
+        assert excinfo.group_contains(ConfigurationError, match="SHELLY_SECRET_KEY")

--- a/packages/core/src/core/services/authentication_service.py
+++ b/packages/core/src/core/services/authentication_service.py
@@ -3,6 +3,7 @@ from collections.abc import Callable
 from contextlib import AbstractAsyncContextManager
 
 from core.domain.credentials import Credential
+from core.domain.entities.exceptions import ConfigurationError
 from core.repositories.credentials_repository import CredentialsRepository
 from core.utils.validation import normalize_mac
 
@@ -47,6 +48,8 @@ class AuthenticationService:
                     return creds
 
                 return await repository.get_global()
+        except ConfigurationError:
+            raise
         except Exception as e:
             logger.error("Failed to resolve credentials for MAC %s: %s", mac, e)
             return None

--- a/packages/core/src/core/services/encryption_service.py
+++ b/packages/core/src/core/services/encryption_service.py
@@ -1,5 +1,9 @@
 from core.domain.entities.exceptions import ConfigurationError
-from core.settings import MISSING_SECRET_KEY_MESSAGE, settings
+from core.settings import (
+    INVALID_SECRET_KEY_MESSAGE,
+    MISSING_SECRET_KEY_MESSAGE,
+    settings,
+)
 from cryptography.fernet import Fernet
 
 
@@ -7,9 +11,14 @@ class EncryptionService:
     def __init__(self, key: str | None = None):
         # Allow key injection for testing, default to settings
         resolved = key or settings.secret_key
-        if resolved is None:
+        if not resolved:
             raise ConfigurationError("encryption", MISSING_SECRET_KEY_MESSAGE)
-        self._fernet = Fernet(resolved.encode())
+        try:
+            self._fernet = Fernet(resolved.encode())
+        except Exception as e:
+            raise ConfigurationError(
+                "encryption", f"{INVALID_SECRET_KEY_MESSAGE} {e}"
+            ) from e
 
     def encrypt(self, plaintext: str) -> str:
         """Encrypt a plaintext string."""

--- a/packages/core/src/core/services/encryption_service.py
+++ b/packages/core/src/core/services/encryption_service.py
@@ -1,12 +1,15 @@
-from core.settings import settings
+from core.domain.entities.exceptions import ConfigurationError
+from core.settings import MISSING_SECRET_KEY_MESSAGE, settings
 from cryptography.fernet import Fernet
 
 
 class EncryptionService:
     def __init__(self, key: str | None = None):
         # Allow key injection for testing, default to settings
-        key_bytes = (key or settings.secret_key).encode()
-        self._fernet = Fernet(key_bytes)
+        resolved = key or settings.secret_key
+        if resolved is None:
+            raise ConfigurationError("encryption", MISSING_SECRET_KEY_MESSAGE)
+        self._fernet = Fernet(resolved.encode())
 
     def encrypt(self, plaintext: str) -> str:
         """Encrypt a plaintext string."""

--- a/packages/core/src/core/settings.py
+++ b/packages/core/src/core/settings.py
@@ -12,6 +12,12 @@ from pydantic_settings import BaseSettings, SettingsConfigDict
 
 from core.domain.entities.exceptions import ConfigurationError, ValidationError
 
+MISSING_SECRET_KEY_MESSAGE = (
+    "SHELLY_SECRET_KEY is not set. Generate one with: "
+    'python -c "from cryptography.fernet import Fernet; '
+    'print(Fernet.generate_key().decode())"'
+)
+
 
 class DatabaseSettings(BaseSettings):
     model_config = SettingsConfigDict(env_prefix="DB_")
@@ -180,8 +186,8 @@ class AppSettings(BaseSettings):
     data_dir: str = Field(default="./data", description="Data directory")
     cache_ttl: int = Field(default=300, ge=0, description="Cache TTL in seconds")
 
-    secret_key: str = Field(
-        ...,
+    secret_key: str | None = Field(
+        default=None,
         description="Secret key for encryption. Must be a valid Fernet key.",
         exclude=True,  # Prevent secret from being logged
     )
@@ -277,6 +283,13 @@ class AppSettings(BaseSettings):
             if self.api.port < 1 or self.api.port > 65535:
                 raise ValidationError(
                     "port", self.api.port, "Port must be between 1 and 65535"
+                )
+
+            if self.secret_key is None:
+                raise ValidationError(
+                    "secret_key",
+                    None,
+                    MISSING_SECRET_KEY_MESSAGE,
                 )
 
             # Validate secret key format (Fernet)

--- a/packages/core/src/core/settings.py
+++ b/packages/core/src/core/settings.py
@@ -18,6 +18,12 @@ MISSING_SECRET_KEY_MESSAGE = (
     'print(Fernet.generate_key().decode())"'
 )
 
+INVALID_SECRET_KEY_MESSAGE = (
+    "SHELLY_SECRET_KEY is not a valid Fernet key. Generate one with: "
+    'python -c "from cryptography.fernet import Fernet; '
+    'print(Fernet.generate_key().decode())".'
+)
+
 
 class DatabaseSettings(BaseSettings):
     model_config = SettingsConfigDict(env_prefix="DB_")

--- a/packages/core/tests/unit/services/test_encryption_service.py
+++ b/packages/core/tests/unit/services/test_encryption_service.py
@@ -14,7 +14,6 @@ def test_it_round_trips_with_an_injected_key():
 
 
 def test_it_falls_back_to_the_configured_key(monkeypatch):
-    monkeypatch.setenv("SHELLY_SECRET_KEY", VALID_KEY)
     settings_module = importlib.import_module("core.settings")
     monkeypatch.setattr(settings_module.settings, "secret_key", VALID_KEY)
 
@@ -23,9 +22,10 @@ def test_it_falls_back_to_the_configured_key(monkeypatch):
     assert service.decrypt(service.encrypt("hunter2")) == "hunter2"
 
 
-def test_it_names_the_env_var_when_no_key_is_configured(monkeypatch):
+@pytest.mark.parametrize("configured", [None, "", "not-a-fernet-key"])
+def test_it_names_the_env_var_when_the_key_is_unusable(monkeypatch, configured):
     settings_module = importlib.import_module("core.settings")
-    monkeypatch.setattr(settings_module.settings, "secret_key", None)
+    monkeypatch.setattr(settings_module.settings, "secret_key", configured)
 
     with pytest.raises(ConfigurationError) as excinfo:
         EncryptionService()

--- a/packages/core/tests/unit/services/test_encryption_service.py
+++ b/packages/core/tests/unit/services/test_encryption_service.py
@@ -1,0 +1,33 @@
+import importlib
+
+import pytest
+from core.domain.entities.exceptions import ConfigurationError
+from core.services.encryption_service import EncryptionService
+
+VALID_KEY = "0N6fK7YkEmvA0I4d1sD4v15uvB94H4A1N1nMG8vLMOg="
+
+
+def test_it_round_trips_with_an_injected_key():
+    service = EncryptionService(VALID_KEY)
+
+    assert service.decrypt(service.encrypt("hunter2")) == "hunter2"
+
+
+def test_it_falls_back_to_the_configured_key(monkeypatch):
+    monkeypatch.setenv("SHELLY_SECRET_KEY", VALID_KEY)
+    settings_module = importlib.import_module("core.settings")
+    monkeypatch.setattr(settings_module.settings, "secret_key", VALID_KEY)
+
+    service = EncryptionService()
+
+    assert service.decrypt(service.encrypt("hunter2")) == "hunter2"
+
+
+def test_it_names_the_env_var_when_no_key_is_configured(monkeypatch):
+    settings_module = importlib.import_module("core.settings")
+    monkeypatch.setattr(settings_module.settings, "secret_key", None)
+
+    with pytest.raises(ConfigurationError) as excinfo:
+        EncryptionService()
+
+    assert "SHELLY_SECRET_KEY" in str(excinfo.value)

--- a/packages/core/tests/unit/test_settings.py
+++ b/packages/core/tests/unit/test_settings.py
@@ -1,5 +1,7 @@
 import json
 
+import pytest
+from core.domain.entities.exceptions import ValidationError
 from core.settings import AppSettings
 
 
@@ -139,3 +141,24 @@ def test_it_creates_the_firmware_dir_on_validate(tmp_path, monkeypatch):
     settings.validate_settings()
 
     assert (tmp_path / "data" / "firmware").is_dir()
+
+
+def test_it_builds_without_a_secret_key(monkeypatch):
+    monkeypatch.delenv("SHELLY_SECRET_KEY", raising=False)
+
+    settings = AppSettings(config_file="does-not-exist.json")
+
+    assert settings.secret_key is None
+
+
+def test_it_rejects_a_missing_secret_key_on_validate(tmp_path, monkeypatch):
+    monkeypatch.delenv("SHELLY_SECRET_KEY", raising=False)
+
+    settings = AppSettings(config_file=str(tmp_path / "config.json"))
+    settings.data_dir = str(tmp_path / "data")
+    settings.firmware.dir = str(tmp_path / "data" / "firmware")
+
+    with pytest.raises(ValidationError) as excinfo:
+        settings.validate_settings()
+
+    assert "SHELLY_SECRET_KEY" in str(excinfo.value)

--- a/packages/core/tests/unit/test_settings.py
+++ b/packages/core/tests/unit/test_settings.py
@@ -146,7 +146,7 @@ def test_it_creates_the_firmware_dir_on_validate(tmp_path, monkeypatch):
 def test_it_builds_without_a_secret_key(monkeypatch):
     monkeypatch.delenv("SHELLY_SECRET_KEY", raising=False)
 
-    settings = AppSettings(config_file="does-not-exist.json")
+    settings = AppSettings(config_file="does-not-exist.json", _env_file=None)
 
     assert settings.secret_key is None
 
@@ -154,7 +154,7 @@ def test_it_builds_without_a_secret_key(monkeypatch):
 def test_it_rejects_a_missing_secret_key_on_validate(tmp_path, monkeypatch):
     monkeypatch.delenv("SHELLY_SECRET_KEY", raising=False)
 
-    settings = AppSettings(config_file=str(tmp_path / "config.json"))
+    settings = AppSettings(config_file=str(tmp_path / "config.json"), _env_file=None)
     settings.data_dir = str(tmp_path / "data")
     settings.firmware.dir = str(tmp_path / "data" / "firmware")
 


### PR DESCRIPTION
## Purpose

`shelly-manager --help` died on a pydantic traceback with no `SHELLY_SECRET_KEY` set. Printing usage has no use for an encryption key, so the requirement moves to the point where encryption actually happens.

## Context

`secret_key` was declared required and `settings = AppSettings()` runs at module import, so importing anything under `core` needed the variable whether or not the caller ever encrypted anything. That made the first command a new user runs fail with a stack trace. Outside the settings module there is exactly one reader of the field, so making it optional is a small change with a narrow blast radius.

Deferring the singleton instead was the obvious alternative and does not work: `from core.settings import settings` binds at the importer's import time, so a lazy module attribute defers nothing for `repositories/db.py` or anything downstream. That approach only pays off after rewriting every call site.

The API keeps failing fast. Left alone it would have booted happily and failed on the first credential or backup request, where the response redacts the cause and the message reaches the log alone. It builds the encryption service during startup instead of inspecting the field, so an empty or truncated key fails there too rather than only a missing one. That distinction matters more than it looks: with a merely non-None check, a blank value passed startup, the scheduler then started, and every scheduled backup failed inside a counter-incrementing `except` while health stayed green.

Credential resolution used to catch every exception and return `None`. A misconfigured key therefore read as "no credentials stored" and made each password-protected device look unreachable, with one log line per device. It re-raises configuration errors now.

## Notes

The CLI needed no error boundary added. One already exists and turns these into a single styled line with exit code 1. Verified for a missing, empty, and malformed key.

Configuration errors now map to a response that names the problem rather than the generic redacted 500. The message carries a variable name, never its value.

The startup check is covered by tests that enter the real lifespan. It is worth saying why: before those existed, deleting the check outright left the entire api suite passing.

Two settings tests pass `_env_file=None`. `AppSettings` reads a `.env` from the working directory, which the development guide now suggests creating, and without that a developer who has one would see those tests fail locally and pass in CI.

Still open, and unchanged here: importing a repository module creates `./data` as an import-time side effect. Same family of problem, its own change.
