### PR TITLE
The bulk dialogs offer every component type the API accepts

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,7 @@ The REST API provides complete device management capabilities:
 ```bash
 # Health and status
 GET  /api/health                                              # Service health check
+GET  /api/metadata/component-types                            # Component types the config endpoints accept
 GET  /api/devices/scan                                        # Discover devices on network
 GET  /api/devices/{ip}/status                                 # Get device status
 

--- a/packages/api/src/api/controllers/metadata.py
+++ b/packages/api/src/api/controllers/metadata.py
@@ -15,9 +15,7 @@ async def list_component_types() -> dict[str, list[str]]:
     """
     List the component types the configuration endpoints accept.
 
-    The same sets the bulk export and bulk apply request validators enforce,
-    so a client can offer exactly what will be accepted instead of keeping its
-    own copy that drifts as component types are added.
+    The same sets the bulk export and bulk apply validators enforce.
 
     Returns:
         dict: Sorted type lists, keyed exportable, configurable and network

--- a/packages/api/src/api/controllers/metadata.py
+++ b/packages/api/src/api/controllers/metadata.py
@@ -1,0 +1,35 @@
+"""
+Metadata API routes describing what the API itself accepts.
+"""
+
+from core.domain.entities.config_snapshot import (
+    CONFIGURABLE_COMPONENT_TYPES,
+    EXPORTABLE_COMPONENT_TYPES,
+    NETWORK_TYPES,
+)
+from litestar import Router, get
+
+
+@get("/component-types", tags=["Metadata"], summary="List Component Type Vocabulary")
+async def list_component_types() -> dict[str, list[str]]:
+    """
+    List the component types the configuration endpoints accept.
+
+    The same sets the bulk export and bulk apply request validators enforce,
+    so a client can offer exactly what will be accepted instead of keeping its
+    own copy that drifts as component types are added.
+
+    Returns:
+        dict: Sorted type lists, keyed exportable, configurable and network
+    """
+    return {
+        "exportable": sorted(EXPORTABLE_COMPONENT_TYPES),
+        "configurable": sorted(CONFIGURABLE_COMPONENT_TYPES),
+        "network": sorted(NETWORK_TYPES),
+    }
+
+
+metadata_router = Router(
+    path="/metadata",
+    route_handlers=[list_component_types],
+)

--- a/packages/api/src/api/main.py
+++ b/packages/api/src/api/main.py
@@ -18,6 +18,7 @@ from .controllers.backups import backups_router
 from .controllers.credentials import credentials_router
 from .controllers.devices import devices_router
 from .controllers.firmware import firmware_router
+from .controllers.metadata import metadata_router
 from .controllers.monitoring import (
     health_check,
 )
@@ -69,6 +70,10 @@ def create_app() -> Litestar:
                 name="Firmware",
                 description="Cached firmware bundles served to devices over LAN",
             ),
+            Tag(
+                name="Metadata",
+                description="Vocabularies the API's own endpoints accept",
+            ),
         ],
         servers=[
             Server(url="http://localhost:8000", description="Development server"),
@@ -88,6 +93,7 @@ def create_app() -> Litestar:
             backups_router,
             backup_schedules_router,
             firmware_router,
+            metadata_router,
             health_check,
         ],
     )

--- a/packages/api/tests/unit/controllers/test_metadata.py
+++ b/packages/api/tests/unit/controllers/test_metadata.py
@@ -1,0 +1,46 @@
+from api.controllers.metadata import list_component_types
+from core.domain.entities.config_snapshot import (
+    CONFIGURABLE_COMPONENT_TYPES,
+    EXPORTABLE_COMPONENT_TYPES,
+    NETWORK_TYPES,
+)
+from litestar.testing import create_test_client
+
+
+def _get():
+    with create_test_client(route_handlers=[list_component_types]) as client:
+        return client.get("/component-types")
+
+
+class TestMetadataController:
+    def test_it_returns_all_three_vocabularies(self):
+        response = _get()
+
+        assert response.status_code == 200
+        data = response.json()
+        assert set(data) == {"exportable", "configurable", "network"}
+
+    def test_it_serves_the_sets_core_validates_against(self):
+        data = _get().json()
+
+        assert set(data["exportable"]) == EXPORTABLE_COMPONENT_TYPES
+        assert set(data["configurable"]) == CONFIGURABLE_COMPONENT_TYPES
+        assert set(data["network"]) == NETWORK_TYPES
+
+    def test_it_offers_the_types_the_web_selector_used_to_omit(self):
+        data = _get().json()
+
+        for component_type in ("light", "em", "eth", "rgbw", "bthome"):
+            assert component_type in data["configurable"]
+        assert "schedules" in data["exportable"]
+
+    def test_it_sorts_every_list_so_the_selector_order_is_stable(self):
+        data = _get().json()
+
+        for key, types in data.items():
+            assert types == sorted(types), key
+
+    def test_it_is_mounted_on_the_app(self, app):
+        assert any(
+            route.path == "/api/metadata/component-types" for route in app.routes
+        )

--- a/packages/core/src/core/domain/entities/config_snapshot.py
+++ b/packages/core/src/core/domain/entities/config_snapshot.py
@@ -37,6 +37,11 @@ CONFIGURABLE_COMPONENT_TYPES: frozenset[str] = EXPORTABLE_COMPONENT_TYPES - {
     "em1data",
 }
 
+# Component types that can drop the device off the network if restored. A
+# curated subset rather than a registry projection: it is about the blast
+# radius of a restore, not about which types exist.
+NETWORK_TYPES: frozenset[str] = frozenset({"wifi", "eth", "mqtt", "ws", "cloud"})
+
 
 @dataclass(frozen=True)
 class SnapshotDeviceInfo:

--- a/packages/core/src/core/domain/entities/config_snapshot.py
+++ b/packages/core/src/core/domain/entities/config_snapshot.py
@@ -37,9 +37,6 @@ CONFIGURABLE_COMPONENT_TYPES: frozenset[str] = EXPORTABLE_COMPONENT_TYPES - {
     "em1data",
 }
 
-# Component types that can drop the device off the network if restored. A
-# curated subset rather than a registry projection: it is about the blast
-# radius of a restore, not about which types exist.
 NETWORK_TYPES: frozenset[str] = frozenset({"wifi", "eth", "mqtt", "ws", "cloud"})
 
 

--- a/packages/core/src/core/use_cases/restore_device_config.py
+++ b/packages/core/src/core/use_cases/restore_device_config.py
@@ -6,6 +6,7 @@ from contextlib import AbstractAsyncContextManager
 
 from core.domain.entities.config_snapshot import (
     LEGACY_SETTINGS_KEY,
+    NETWORK_TYPES,
     ComponentSnapshot,
     DeviceSnapshot,
 )
@@ -24,10 +25,6 @@ from core.use_cases.restore_strategies.gen2 import Gen2RestoreStrategy
 from core.utils.validation import normalize_mac
 
 logger = logging.getLogger(__name__)
-
-# Component types that can drop the device off the network if restored.
-# Excluded from the default selection; applied LAST when explicitly included.
-NETWORK_TYPES = {"wifi", "eth", "mqtt", "ws", "cloud"}
 
 
 class DeviceMismatchError(Exception):

--- a/packages/core/tests/unit/domain/entities/test_config_snapshot.py
+++ b/packages/core/tests/unit/domain/entities/test_config_snapshot.py
@@ -2,6 +2,7 @@ import pytest
 from core.domain.entities.config_snapshot import (
     CONFIGURABLE_COMPONENT_TYPES,
     EXPORTABLE_COMPONENT_TYPES,
+    NETWORK_TYPES,
     SCHEDULES_KEY,
     ComponentSnapshot,
     DeviceSnapshot,
@@ -215,3 +216,13 @@ class TestComponentTypeVocabulary:
             "emdata",
             "em1data",
         }
+
+    def test_it_treats_exactly_the_connectivity_types_as_network(self):
+        assert NETWORK_TYPES == {"wifi", "eth", "mqtt", "ws", "cloud"}
+
+    def test_it_leaves_the_restore_use_case_without_its_own_copy(self):
+        from core.use_cases.restore_device_config import (
+            NETWORK_TYPES as RESTORE_NETWORK_TYPES,
+        )
+
+        assert RESTORE_NETWORK_TYPES is NETWORK_TYPES

--- a/packages/web/src/components/dashboard/bulk-actions-dialog/components/action-configurations/apply-config-config.tsx
+++ b/packages/web/src/components/dashboard/bulk-actions-dialog/components/action-configurations/apply-config-config.tsx
@@ -13,7 +13,8 @@ import {
   useConfiguration,
 } from "@/components/shared/configuration";
 import type { ApplyConfigActionProps } from "../../types";
-import { CONFIGURABLE_COMPONENT_TYPES, BULK_ACTION_STYLES } from "../../types";
+import { BULK_ACTION_STYLES } from "../../types";
+import { useComponentTypes } from "@/hooks/useComponentTypes";
 
 export function ApplyConfigConfig({
   selectedComponentType,
@@ -24,6 +25,7 @@ export function ApplyConfigConfig({
   onCancel,
 }: ApplyConfigActionProps) {
   const { t } = useTranslation();
+  const { componentTypes } = useComponentTypes();
 
   const configuration = useConfiguration({
     initialValue: configurationJson,
@@ -63,7 +65,7 @@ export function ApplyConfigConfig({
               <SelectValue placeholder="Select component type" />
             </SelectTrigger>
             <SelectContent>
-              {CONFIGURABLE_COMPONENT_TYPES.map((componentType) => (
+              {componentTypes.configurable.map((componentType) => (
                 <SelectItem key={componentType} value={componentType}>
                   <span className="capitalize">{componentType}</span>
                 </SelectItem>

--- a/packages/web/src/components/dashboard/bulk-actions-dialog/components/action-configurations/apply-config-config.tsx
+++ b/packages/web/src/components/dashboard/bulk-actions-dialog/components/action-configurations/apply-config-config.tsx
@@ -25,7 +25,7 @@ export function ApplyConfigConfig({
   onCancel,
 }: ApplyConfigActionProps) {
   const { t } = useTranslation();
-  const { componentTypes, isError } = useComponentTypes();
+  const { componentTypes, usingFallback } = useComponentTypes();
 
   const configuration = useConfiguration({
     initialValue: configurationJson,
@@ -57,7 +57,7 @@ export function ApplyConfigConfig({
           <p className="text-sm text-muted-foreground">
             {t("bulkActions.selectSingleComponentType")}
           </p>
-          {isError && (
+          {usingFallback && (
             <p className="text-sm text-amber-600">
               {t("bulkActions.componentTypesUnavailable")}
             </p>

--- a/packages/web/src/components/dashboard/bulk-actions-dialog/components/action-configurations/apply-config-config.tsx
+++ b/packages/web/src/components/dashboard/bulk-actions-dialog/components/action-configurations/apply-config-config.tsx
@@ -25,7 +25,7 @@ export function ApplyConfigConfig({
   onCancel,
 }: ApplyConfigActionProps) {
   const { t } = useTranslation();
-  const { componentTypes } = useComponentTypes();
+  const { componentTypes, isError } = useComponentTypes();
 
   const configuration = useConfiguration({
     initialValue: configurationJson,
@@ -57,6 +57,11 @@ export function ApplyConfigConfig({
           <p className="text-sm text-muted-foreground">
             {t("bulkActions.selectSingleComponentType")}
           </p>
+          {isError && (
+            <p className="text-sm text-amber-600">
+              {t("bulkActions.componentTypesUnavailable")}
+            </p>
+          )}
           <Select
             value={selectedComponentType}
             onValueChange={onSelectedComponentTypeChange}

--- a/packages/web/src/components/dashboard/bulk-actions-dialog/components/action-configurations/export-config-config.tsx
+++ b/packages/web/src/components/dashboard/bulk-actions-dialog/components/action-configurations/export-config-config.tsx
@@ -13,7 +13,7 @@ export function ExportConfigConfig({
   onCancel,
 }: ExportConfigActionProps) {
   const { t } = useTranslation();
-  const { componentTypes, isError } = useComponentTypes();
+  const { componentTypes, usingFallback } = useComponentTypes();
 
   const handleComponentTypeToggle = (
     componentType: string,
@@ -47,7 +47,7 @@ export function ExportConfigConfig({
           <p className="text-sm text-muted-foreground">
             {t("bulkActions.selectComponentTypes")}
           </p>
-          {isError && (
+          {usingFallback && (
             <p className="text-sm text-amber-600">
               {t("bulkActions.componentTypesUnavailable")}
             </p>

--- a/packages/web/src/components/dashboard/bulk-actions-dialog/components/action-configurations/export-config-config.tsx
+++ b/packages/web/src/components/dashboard/bulk-actions-dialog/components/action-configurations/export-config-config.tsx
@@ -13,7 +13,7 @@ export function ExportConfigConfig({
   onCancel,
 }: ExportConfigActionProps) {
   const { t } = useTranslation();
-  const { componentTypes } = useComponentTypes();
+  const { componentTypes, isError } = useComponentTypes();
 
   const handleComponentTypeToggle = (
     componentType: string,
@@ -47,6 +47,11 @@ export function ExportConfigConfig({
           <p className="text-sm text-muted-foreground">
             {t("bulkActions.selectComponentTypes")}
           </p>
+          {isError && (
+            <p className="text-sm text-amber-600">
+              {t("bulkActions.componentTypesUnavailable")}
+            </p>
+          )}
           <div className={BULK_ACTION_STYLES.componentGrid}>
             {componentTypes.exportable.map((componentType) => (
               <div key={componentType} className="flex items-center space-x-2">

--- a/packages/web/src/components/dashboard/bulk-actions-dialog/components/action-configurations/export-config-config.tsx
+++ b/packages/web/src/components/dashboard/bulk-actions-dialog/components/action-configurations/export-config-config.tsx
@@ -3,7 +3,8 @@ import { Upload } from "lucide-react";
 import { Checkbox } from "@/components/ui/checkbox";
 import { ActionConfigWrapper } from "./action-config-wrapper";
 import type { ExportConfigActionProps } from "../../types";
-import { CONFIGURABLE_COMPONENT_TYPES, BULK_ACTION_STYLES } from "../../types";
+import { BULK_ACTION_STYLES } from "../../types";
+import { useComponentTypes } from "@/hooks/useComponentTypes";
 
 export function ExportConfigConfig({
   selectedComponentTypes,
@@ -12,6 +13,7 @@ export function ExportConfigConfig({
   onCancel,
 }: ExportConfigActionProps) {
   const { t } = useTranslation();
+  const { componentTypes } = useComponentTypes();
 
   const handleComponentTypeToggle = (
     componentType: string,
@@ -46,7 +48,7 @@ export function ExportConfigConfig({
             {t("bulkActions.selectComponentTypes")}
           </p>
           <div className={BULK_ACTION_STYLES.componentGrid}>
-            {CONFIGURABLE_COMPONENT_TYPES.map((componentType) => (
+            {componentTypes.exportable.map((componentType) => (
               <div key={componentType} className="flex items-center space-x-2">
                 <Checkbox
                   id={`component-${componentType}`}

--- a/packages/web/src/components/dashboard/bulk-actions-dialog/types.ts
+++ b/packages/web/src/components/dashboard/bulk-actions-dialog/types.ts
@@ -61,22 +61,6 @@ export interface DevicePreviewProps {
   selectedDevices: Device[];
 }
 
-export const CONFIGURABLE_COMPONENT_TYPES = [
-  "switch",
-  "input",
-  "cover",
-  "sys",
-  "cloud",
-  "wifi",
-  "ble",
-  "mqtt",
-  "ws",
-  "script",
-  "knx",
-  "modbus",
-  "zigbee",
-] as const;
-
 export const BULK_ACTION_STYLES = {
   actionCard: "transition-shadow cursor-pointer hover:shadow-md",
   dangerCard: "border-destructive/20 hover:border-destructive/40",

--- a/packages/web/src/components/device-detail/backups-section.tsx
+++ b/packages/web/src/components/device-detail/backups-section.tsx
@@ -212,7 +212,7 @@ function RestoreDialog({
   const {
     componentTypes: vocabulary,
     isLoading: vocabularyLoading,
-    isError: vocabularyFailed,
+    usingFallback,
   } = useComponentTypes();
 
   const networkTypes = useMemo(
@@ -280,7 +280,7 @@ function RestoreDialog({
                 {detail ? " Showing the components last loaded." : ""}
               </p>
             )}
-            {vocabularyFailed && (
+            {usingFallback && (
               <p className="text-sm text-amber-600">
                 Could not load the network component list from the server, so
                 the defaults below come from a built-in list. Check the network

--- a/packages/web/src/components/device-detail/backups-section.tsx
+++ b/packages/web/src/components/device-detail/backups-section.tsx
@@ -35,11 +35,10 @@ import {
   useDeleteBackup,
   useRestoreBackup,
 } from "@/hooks/useBackups";
+import { useComponentTypes } from "@/hooks/useComponentTypes";
 import { PAGE_SIZE, useRewindEmptyPage } from "@/hooks/useOffsetPagination";
 import { OffsetPager } from "@/components/shared/offset-pager";
 import type { BackupSummary } from "@/types/api";
-
-const NETWORK_TYPES = new Set(["wifi", "eth", "mqtt", "ws", "cloud"]);
 
 interface BackupsSectionProps {
   deviceIp: string;
@@ -210,14 +209,20 @@ function RestoreDialog({
 }) {
   const restore = useRestoreBackup();
   const { data: detail, isLoading, error } = useBackup(backup.id);
+  const { componentTypes: vocabulary } = useComponentTypes();
+
+  const networkTypes = useMemo(
+    () => new Set(vocabulary.network),
+    [vocabulary.network],
+  );
 
   const componentTypes = useMemo(() => {
     const components = detail?.snapshot.components ?? {};
     return Object.entries(components).map(([key, value]) => ({
       key,
-      network: isNetworkComponent(key, value.type),
+      network: isNetworkComponent(key, value.type, networkTypes),
     }));
-  }, [detail]);
+  }, [detail, networkTypes]);
 
   const [selected, setSelected] = useState<Set<string> | null>(null);
   const [reboot, setReboot] = useState(false);
@@ -327,9 +332,13 @@ function RestoreDialog({
 // Either signal is enough to treat a component as network: an entry can reach
 // the store untyped, and a type the device spells differently would otherwise
 // win over the key and leave wifi selected for restore.
-function isNetworkComponent(key: string, type: string | null | undefined) {
+function isNetworkComponent(
+  key: string,
+  type: string | null | undefined,
+  networkTypes: Set<string>,
+) {
   const keyType = key.split(":")[0].toLowerCase();
   return (
-    NETWORK_TYPES.has((type ?? "").toLowerCase()) || NETWORK_TYPES.has(keyType)
+    networkTypes.has((type ?? "").toLowerCase()) || networkTypes.has(keyType)
   );
 }

--- a/packages/web/src/components/device-detail/backups-section.tsx
+++ b/packages/web/src/components/device-detail/backups-section.tsx
@@ -209,7 +209,11 @@ function RestoreDialog({
 }) {
   const restore = useRestoreBackup();
   const { data: detail, isLoading, error } = useBackup(backup.id);
-  const { componentTypes: vocabulary } = useComponentTypes();
+  const {
+    componentTypes: vocabulary,
+    isPending: vocabularyPending,
+    isError: vocabularyFailed,
+  } = useComponentTypes();
 
   const networkTypes = useMemo(
     () => new Set(vocabulary.network),
@@ -266,7 +270,7 @@ function RestoreDialog({
           </DialogDescription>
         </DialogHeader>
 
-        {isLoading ? (
+        {isLoading || vocabularyPending ? (
           <p className="text-sm text-muted-foreground">Loading components...</p>
         ) : (
           <>
@@ -274,6 +278,13 @@ function RestoreDialog({
               <p className="text-sm text-destructive">
                 Failed to load this backup: {handleApiError(error)}
                 {detail ? " Showing the components last loaded." : ""}
+              </p>
+            )}
+            {vocabularyFailed && (
+              <p className="text-sm text-amber-600">
+                Could not load the network component list from the server, so
+                the defaults below come from a built-in list. Check the network
+                marks before restoring.
               </p>
             )}
             <div className="max-h-72 overflow-y-auto space-y-2">

--- a/packages/web/src/components/device-detail/backups-section.tsx
+++ b/packages/web/src/components/device-detail/backups-section.tsx
@@ -211,7 +211,7 @@ function RestoreDialog({
   const { data: detail, isLoading, error } = useBackup(backup.id);
   const {
     componentTypes: vocabulary,
-    isPending: vocabularyPending,
+    isLoading: vocabularyLoading,
     isError: vocabularyFailed,
   } = useComponentTypes();
 
@@ -270,7 +270,7 @@ function RestoreDialog({
           </DialogDescription>
         </DialogHeader>
 
-        {isLoading || vocabularyPending ? (
+        {isLoading || vocabularyLoading ? (
           <p className="text-sm text-muted-foreground">Loading components...</p>
         ) : (
           <>

--- a/packages/web/src/hooks/useComponentTypes.ts
+++ b/packages/web/src/hooks/useComponentTypes.ts
@@ -5,10 +5,6 @@ import { metadataApi } from "@/lib/api";
 import { queryKeys } from "@/lib/query-keys";
 import type { ComponentTypeVocabulary } from "@/lib/schemas/component-types";
 
-// The list the web hardcoded for both dialogs before the API served this
-// vocabulary. It survives for two jobs, neither of which is deciding what a
-// user may pick: the order the selectors read in, and the bridge for the
-// render before the query resolves.
 const PREFERRED_ORDER = [
   "switch",
   "input",
@@ -35,9 +31,6 @@ export function useComponentTypes() {
   const query = useQuery({
     queryKey: queryKeys.metadata.componentTypes(),
     queryFn: metadataApi.getComponentTypes,
-    // The vocabulary moves only when the API is redeployed. Long rather than
-    // infinite so a tab left open across a deploy picks the new one up on the
-    // next dialog open instead of holding the old list until a reload.
     staleTime: 60 * 60 * 1000,
   });
 
@@ -55,10 +48,6 @@ export function useComponentTypes() {
   return { ...query, componentTypes };
 }
 
-// The API sorts alphabetically so its own output stays stable, which buries
-// switch below two dozen types most devices do not have. Ordering is the
-// selector's problem, so the everyday types lead and the rest follow
-// alphabetically behind them.
 function forDisplay(types: string[]): string[] {
   const rank = (type: string) => {
     const index = PREFERRED_ORDER.indexOf(type);

--- a/packages/web/src/hooks/useComponentTypes.ts
+++ b/packages/web/src/hooks/useComponentTypes.ts
@@ -45,7 +45,7 @@ export function useComponentTypes() {
     [vocabulary],
   );
 
-  return { ...query, componentTypes };
+  return { ...query, componentTypes, usingFallback: query.data === undefined };
 }
 
 function forDisplay(types: string[]): string[] {

--- a/packages/web/src/hooks/useComponentTypes.ts
+++ b/packages/web/src/hooks/useComponentTypes.ts
@@ -45,7 +45,11 @@ export function useComponentTypes() {
     [vocabulary],
   );
 
-  return { ...query, componentTypes, usingFallback: query.data === undefined };
+  return {
+    ...query,
+    componentTypes,
+    usingFallback: query.data === undefined && !query.isLoading,
+  };
 }
 
 function forDisplay(types: string[]): string[] {

--- a/packages/web/src/hooks/useComponentTypes.ts
+++ b/packages/web/src/hooks/useComponentTypes.ts
@@ -1,0 +1,47 @@
+import { useQuery } from "@tanstack/react-query";
+
+import { metadataApi } from "@/lib/api";
+import { queryKeys } from "@/lib/query-keys";
+import type { ComponentTypeVocabulary } from "@/lib/schemas/component-types";
+
+// The single list the web hardcoded for both dialogs before the API served
+// this vocabulary. It covers only the types that shipped first, so it is a
+// bridge for the render before the query resolves, never the answer: the API
+// is the source of truth and knows about types this list never heard of.
+const TYPES_THE_WEB_ONCE_HARDCODED = [
+  "switch",
+  "input",
+  "cover",
+  "sys",
+  "cloud",
+  "wifi",
+  "ble",
+  "mqtt",
+  "ws",
+  "script",
+  "knx",
+  "modbus",
+  "zigbee",
+];
+
+const FALLBACK_VOCABULARY: ComponentTypeVocabulary = {
+  exportable: TYPES_THE_WEB_ONCE_HARDCODED,
+  configurable: TYPES_THE_WEB_ONCE_HARDCODED,
+  network: ["wifi", "eth", "mqtt", "ws", "cloud"],
+};
+
+export function useComponentTypes() {
+  const query = useQuery({
+    queryKey: queryKeys.metadata.componentTypes(),
+    queryFn: metadataApi.getComponentTypes,
+    // The vocabulary moves only when the API is redeployed, so refetching it
+    // per dialog open buys a request for an answer that cannot have changed.
+    staleTime: Infinity,
+    gcTime: Infinity,
+  });
+
+  return {
+    ...query,
+    componentTypes: query.data ?? FALLBACK_VOCABULARY,
+  };
+}

--- a/packages/web/src/hooks/useComponentTypes.ts
+++ b/packages/web/src/hooks/useComponentTypes.ts
@@ -1,14 +1,15 @@
+import { useMemo } from "react";
 import { useQuery } from "@tanstack/react-query";
 
 import { metadataApi } from "@/lib/api";
 import { queryKeys } from "@/lib/query-keys";
 import type { ComponentTypeVocabulary } from "@/lib/schemas/component-types";
 
-// The single list the web hardcoded for both dialogs before the API served
-// this vocabulary. It covers only the types that shipped first, so it is a
-// bridge for the render before the query resolves, never the answer: the API
-// is the source of truth and knows about types this list never heard of.
-const TYPES_THE_WEB_ONCE_HARDCODED = [
+// The list the web hardcoded for both dialogs before the API served this
+// vocabulary. It survives for two jobs, neither of which is deciding what a
+// user may pick: the order the selectors read in, and the bridge for the
+// render before the query resolves.
+const PREFERRED_ORDER = [
   "switch",
   "input",
   "cover",
@@ -25,8 +26,8 @@ const TYPES_THE_WEB_ONCE_HARDCODED = [
 ];
 
 const FALLBACK_VOCABULARY: ComponentTypeVocabulary = {
-  exportable: TYPES_THE_WEB_ONCE_HARDCODED,
-  configurable: TYPES_THE_WEB_ONCE_HARDCODED,
+  exportable: PREFERRED_ORDER,
+  configurable: PREFERRED_ORDER,
   network: ["wifi", "eth", "mqtt", "ws", "cloud"],
 };
 
@@ -34,14 +35,36 @@ export function useComponentTypes() {
   const query = useQuery({
     queryKey: queryKeys.metadata.componentTypes(),
     queryFn: metadataApi.getComponentTypes,
-    // The vocabulary moves only when the API is redeployed, so refetching it
-    // per dialog open buys a request for an answer that cannot have changed.
-    staleTime: Infinity,
-    gcTime: Infinity,
+    // The vocabulary moves only when the API is redeployed. Long rather than
+    // infinite so a tab left open across a deploy picks the new one up on the
+    // next dialog open instead of holding the old list until a reload.
+    staleTime: 60 * 60 * 1000,
   });
 
-  return {
-    ...query,
-    componentTypes: query.data ?? FALLBACK_VOCABULARY,
+  const vocabulary = query.data ?? FALLBACK_VOCABULARY;
+
+  const componentTypes = useMemo(
+    () => ({
+      exportable: forDisplay(vocabulary.exportable),
+      configurable: forDisplay(vocabulary.configurable),
+      network: vocabulary.network,
+    }),
+    [vocabulary],
+  );
+
+  return { ...query, componentTypes };
+}
+
+// The API sorts alphabetically so its own output stays stable, which buries
+// switch below two dozen types most devices do not have. Ordering is the
+// selector's problem, so the everyday types lead and the rest follow
+// alphabetically behind them.
+function forDisplay(types: string[]): string[] {
+  const rank = (type: string) => {
+    const index = PREFERRED_ORDER.indexOf(type);
+    return index === -1 ? PREFERRED_ORDER.length : index;
   };
+  return [...types].sort(
+    (a, b) => rank(a) - rank(b) || a.localeCompare(b, "en"),
+  );
 }

--- a/packages/web/src/i18n/en.json
+++ b/packages/web/src/i18n/en.json
@@ -141,6 +141,7 @@
     },
     "componentSelection": "Component Selection",
     "selectComponentTypes": "Select component types to export configurations from",
+    "componentTypesUnavailable": "Could not load the component type list from the server. Showing the built-in list, which may be missing types this device supports.",
     "selectSingleComponentType": "Select a single component type to apply configuration to",
     "configurationEditor": "Configuration Editor",
     "pasteJsonConfig": "Paste your JSON configuration here",

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -32,6 +32,8 @@ import {
   paginatedBackupsSchema,
   restoreResultSchema,
 } from "./schemas/backups";
+import { componentTypeVocabularySchema } from "./schemas/component-types";
+import type { ComponentTypeVocabulary } from "./schemas/component-types";
 
 declare global {
   interface Window {
@@ -448,6 +450,17 @@ export const backupScheduleApi = {
       { timeout: 120000 },
     );
     return response.data;
+  },
+};
+
+export const metadataApi = {
+  getComponentTypes: async (): Promise<ComponentTypeVocabulary> => {
+    const response = await apiClient.get("/metadata/component-types");
+    return parseResponse(
+      componentTypeVocabularySchema,
+      response.data,
+      "GET /metadata/component-types",
+    );
   },
 };
 

--- a/packages/web/src/lib/query-keys.ts
+++ b/packages/web/src/lib/query-keys.ts
@@ -29,4 +29,7 @@ export const queryKeys = {
   provisioning: {
     profiles: () => ["provisioning", "profiles"] as const,
   },
+  metadata: {
+    componentTypes: () => ["metadata", "component-types"] as const,
+  },
 };

--- a/packages/web/src/lib/schemas/component-types.ts
+++ b/packages/web/src/lib/schemas/component-types.ts
@@ -1,0 +1,14 @@
+import { z } from "zod";
+
+// No defaults: an empty list here would render as a selector offering nothing
+// and read as "this device supports no component types" rather than as a
+// failed request, so a missing key has to surface as a parse error.
+export const componentTypeVocabularySchema = z.object({
+  exportable: z.array(z.string()),
+  configurable: z.array(z.string()),
+  network: z.array(z.string()),
+});
+
+export type ComponentTypeVocabulary = z.infer<
+  typeof componentTypeVocabularySchema
+>;

--- a/packages/web/src/lib/schemas/component-types.ts
+++ b/packages/web/src/lib/schemas/component-types.ts
@@ -1,8 +1,5 @@
 import { z } from "zod";
 
-// No defaults: an empty list here would render as a selector offering nothing
-// and read as "this device supports no component types" rather than as a
-// failed request, so a missing key has to surface as a parse error.
 export const componentTypeVocabularySchema = z.object({
   exportable: z.array(z.string()),
   configurable: z.array(z.string()),


### PR DESCRIPTION
## Purpose

Serve the component type vocabulary from core so the bulk and restore dialogs offer what the API actually accepts.

## Context

The web hardcoded a single 13 entry list and fed it to both bulk dialogs, but bulk export validates against `EXPORTABLE_COMPONENT_TYPES` (39) and bulk apply against `CONFIGURABLE_COMPONENT_TYPES` (36). Twenty six and twenty three types respectively were unselectable despite the API accepting them, `light`, `em`, `eth`, `rgbw` and `bthome` among them, and `schedules` could not be bulk exported even though the validator has accepted it since #65. `NETWORK_TYPES` was duplicated the same way, and it decides which components the restore dialog leaves unchecked because restoring them can drop a device off the network.

Each dialog now reads the set its own endpoint enforces, over a new `GET /api/metadata/component-types`. The old list survives only as the pre resolution fallback; it is a strict subset of both server sets, so a request built from it can never fail validation.

## Notes

The API sorts alphabetically, which would put `switch` 28th of 36 in a Select with no search box, so the web orders the previously offered thirteen first and the rest alphabetically behind them.

`configurable` includes types with no practical bulk `SetConfig` (`devicepower`, `group`, `boolean`, `enum`, `number`, `text`, `matter`, `bthome`). Filtering those in the web would recreate the drift this removes, so if that set should be narrower it belongs in core.

Verified through the API, the test suites and the web build. Not exercised manually in a browser, and there is no web test infrastructure, so the restore dialog's new wait on the vocabulary query is the piece most worth a click through.
