### PR TITLE
Tidy the channel selector and stop serving a stale UI

### DIFF
--- a/packages/web/nginx.conf
+++ b/packages/web/nginx.conf
@@ -28,8 +28,18 @@ server {
         application/json;
 
     # Handle React Router (SPA routing)
+    # Revalidate the document: it names the hashed asset files, so a cached
+    # copy keeps loading an earlier build's bundle. expires rather than
+    # add_header, which would drop the inherited security headers.
     location / {
         try_files $uri $uri/ /index.html;
+        expires -1;
+    }
+
+    # Rewritten at container start with the API URL, so it cannot be cached as
+    # a build artefact. Exact match, which the extension rule below cannot beat.
+    location = /config.js {
+        expires -1;
     }
 
     # Cache static assets

--- a/packages/web/src/components/device-detail/device-actions.tsx
+++ b/packages/web/src/components/device-detail/device-actions.tsx
@@ -231,30 +231,10 @@ export function DeviceActions({
                       </SelectTrigger>
                       <SelectContent>
                         <SelectItem value="stable">
-                          <div className="space-y-1">
-                            <div>{t("bulkActions.stable")}</div>
-                            {availableUpdates.stable && (
-                              <div className="text-xs text-muted-foreground">
-                                {t(
-                                  "deviceDetail.dialogs.updateFirmware.version",
-                                )}{" "}
-                                {availableUpdates.stable.version}
-                              </div>
-                            )}
-                          </div>
+                          {t("bulkActions.stable")}
                         </SelectItem>
                         <SelectItem value="beta">
-                          <div className="space-y-1">
-                            <div>{t("bulkActions.beta")}</div>
-                            {availableUpdates.beta && (
-                              <div className="text-xs text-muted-foreground">
-                                {t(
-                                  "deviceDetail.dialogs.updateFirmware.version",
-                                )}{" "}
-                                {availableUpdates.beta.version}
-                              </div>
-                            )}
-                          </div>
+                          {t("bulkActions.beta")}
                         </SelectItem>
                       </SelectContent>
                     </Select>


### PR DESCRIPTION
## Purpose

Two small fixes to the web UI: the update channel selector no longer overflows its box, and a new build actually reaches the browser.

## Context

Each channel option carried the firmware version under the channel name, and the collapsed trigger renders the selected option's contents, so it stacked two lines into a control sized for one. The release panel directly below already names the version for the selected channel, so the options only need to say which channel they are.

Separately, the hashed asset filenames were cached for a year, correctly, but the document naming them carried no caching rules at all. A browser is free to hold it on heuristics alone, and a held copy keeps requesting the previous build's bundle, so a deployed change can stay invisible until someone clears their cache by hand. This is not hypothetical: it is what made a current deployment keep serving an older UI.

`expires` rather than `add_header Cache-Control`, because nginx only inherits `add_header` when a level defines none of its own, so the obvious spelling would have dropped the four security headers from the one response that most needs them.

## Notes

Verified against a build of the image: the document answers `Cache-Control: no-cache`, keeps all four security headers, hashed assets keep `max-age=31536000`, and a conditional request answers 304.

The channel change is a layout fix that has not been looked at in a browser, only reasoned about from how the component composes. Worth a glance at the dropdown before merging.
