### PR TITLE
Refuse local updates the device would silently discard

### DIFF
--- a/packages/core/src/core/use_cases/update_device_from_local.py
+++ b/packages/core/src/core/use_cases/update_device_from_local.py
@@ -18,6 +18,9 @@ from core.use_cases.acquire_firmware import AcquireFirmware
 
 logger = logging.getLogger(__name__)
 
+# Changelog: "1.3.3 is a mandatory update before 1.4.0."
+_MANDATORY_STEPS = (((1, 3, 3), (1, 4, 0)),)
+
 
 class UpdateDeviceFromLocal:
     """Update a Gen2+ device with firmware served from the manager host.
@@ -44,7 +47,8 @@ class UpdateDeviceFromLocal:
         Raises:
             DeviceNotFoundError: If the device is unreachable.
             FirmwareError: If the advertised base URL is unset, the device is
-                Gen1 or reports no app name, or no release is published.
+                Gen1 or reports no app name, no release is published, or a
+                mandatory intermediate update is missing.
         """
         base_url = (self._settings.advertised_base_url or "").strip()
         if not base_url:
@@ -86,6 +90,15 @@ class UpdateDeviceFromLocal:
                 message=(
                     f"Device already runs the latest firmware ({release.version})"
                 ),
+            )
+
+        step = _blocking_step(installed, release.version)
+        if step is not None:
+            raise FirmwareError(
+                f"Device {ip} runs {installed}; Shelly requires {step} before"
+                f" {release.version} can install. Update once with internet"
+                f" access, then local updates work.",
+                {"device_ip": ip, "installed": installed, "target": release.version},
             )
 
         downgrade = _downgrade_note(installed, release.version)
@@ -152,6 +165,20 @@ def _version_key(version: str) -> tuple[int, ...] | None:
             return None
         key.append(int(leading_digits.group()))
     return tuple(key)
+
+
+def _blocking_step(installed: str | None, candidate: str) -> str | None:
+    """The version the device must run before ``candidate``, or ``None``."""
+    if installed is None:
+        return None
+    installed_key = _version_key(installed)
+    candidate_key = _version_key(candidate)
+    if installed_key is None or candidate_key is None:
+        return None
+    for step, gated_from in _MANDATORY_STEPS:
+        if installed_key < step and candidate_key >= gated_from:
+            return ".".join(str(part) for part in step)
+    return None
 
 
 def _downgrade_note(installed: str | None, candidate: str) -> str | None:

--- a/packages/core/tests/unit/use_cases/test_update_device_from_local.py
+++ b/packages/core/tests/unit/use_cases/test_update_device_from_local.py
@@ -277,6 +277,55 @@ class TestUpdateDeviceFromLocal:
 
         assert "downgrade" not in result.message
 
+    async def test_it_refuses_an_update_the_device_would_discard(
+        self, use_case, mock_device_gateway, mock_firmware_gateway, mock_acquire
+    ):
+        mock_device_gateway.get_device_status = AsyncMock(
+            return_value=_status(firmware_version="20231031-152228/1.0.7-g5db02bd")
+        )
+        mock_firmware_gateway.get_latest = AsyncMock(return_value=_release("1.8.0"))
+
+        with pytest.raises(FirmwareError, match="1.3.3"):
+            await use_case.execute(BaseDeviceRequest(device_ip=IP))
+
+        mock_acquire.execute.assert_not_awaited()
+        mock_device_gateway.execute_component_action.assert_not_awaited()
+
+    async def test_it_refuses_a_gated_update_from_a_bare_version(
+        self, use_case, mock_device_gateway, mock_firmware_gateway
+    ):
+        mock_device_gateway.get_device_status = AsyncMock(
+            return_value=_status(firmware_version="1.0.7")
+        )
+        mock_firmware_gateway.get_latest = AsyncMock(return_value=_release("1.8.0"))
+
+        with pytest.raises(FirmwareError, match="1.3.3"):
+            await use_case.execute(BaseDeviceRequest(device_ip=IP))
+
+    async def test_it_updates_a_device_running_the_mandatory_step(
+        self, use_case, mock_device_gateway, mock_firmware_gateway
+    ):
+        mock_device_gateway.get_device_status = AsyncMock(
+            return_value=_status(firmware_version="20240613-000000/1.3.3-gabc")
+        )
+        mock_firmware_gateway.get_latest = AsyncMock(return_value=_release("1.8.0"))
+
+        await use_case.execute(BaseDeviceRequest(device_ip=IP))
+
+        mock_device_gateway.execute_component_action.assert_awaited_once()
+
+    async def test_it_updates_below_the_gate_when_the_target_is_too(
+        self, use_case, mock_device_gateway, mock_firmware_gateway
+    ):
+        mock_device_gateway.get_device_status = AsyncMock(
+            return_value=_status(firmware_version="20230101-000000/1.0.7-gabc")
+        )
+        mock_firmware_gateway.get_latest = AsyncMock(return_value=_release("1.3.3"))
+
+        await use_case.execute(BaseDeviceRequest(device_ip=IP))
+
+        mock_device_gateway.execute_component_action.assert_awaited_once()
+
     async def test_it_updates_a_device_running_an_older_version(
         self, use_case, mock_device_gateway, mock_firmware_gateway
     ):


### PR DESCRIPTION
## Purpose

Refuse local updates that a device below Shelly's mandatory 1.3.3 step would download and silently discard, instead of reporting success.

## Context

Shelly's changelog makes 1.3.3 a mandatory update before 1.4.0. The cloud enforces that server-side, but the local path serves the latest release directly, so a pre-1.3.3 device downloads the bundle, drops it without reporting a failure, and the UI claims success — the trace in #4. The use case now checks the installed version before acquiring the bundle and fails with the workaround: update once with internet access, and local updates work from then on. A version that cannot be parsed blocks nothing.

## Notes

1.3.3 is the only mandatory step Shelly has ever documented (checked through 2.0.0); the gate table makes a future one a one-line addition.

The manager cannot serve the 1.3.3 step itself — no archive of older Gen2+ firmware exists.

A real success signal after the `Shelly.Update` ACK is a separate follow-up.
