### PR TITLE
Make via-manager updates channel-aware and settle offline badges

### DIFF
--- a/packages/api/src/api/controllers/devices.py
+++ b/packages/api/src/api/controllers/devices.py
@@ -19,6 +19,7 @@ from core.use_cases.bulk_operations import BulkOperationsUseCase
 from core.use_cases.check_device_status import CheckDeviceStatusUseCase
 from core.use_cases.execute_component_action import ExecuteComponentActionUseCase
 from core.use_cases.get_component_actions import GetComponentActionsUseCase
+from core.use_cases.get_local_firmware_releases import GetLocalFirmwareReleases
 from core.use_cases.scan_devices import ScanDevicesUseCase
 from core.use_cases.update_device_from_local import UpdateDeviceFromLocal
 from litestar import Router, get, post
@@ -274,13 +275,8 @@ async def update_device(
         update_device_from_local_interactor = _require(
             "update_device_from_local_interactor", update_device_from_local_interactor
         )
-        if channel is not UpdateChannel.STABLE:
-            raise HTTPException(
-                status_code=400,
-                detail="Local updates support the stable channel only",
-            )
         result = await update_device_from_local_interactor.execute(
-            BaseDeviceRequest(device_ip=ip)
+            BaseDeviceRequest(device_ip=ip), channel=channel.value
         )
     else:
         execute_component_action_interactor = _require(
@@ -304,6 +300,47 @@ async def update_device(
         "action_type": result.action_type,
         "channel": channel.value,
         "source": source,
+    }
+
+
+@get(
+    "/{ip:str}/firmware-releases",
+    tags=["Devices"],
+    summary="Preview Firmware Releases for Local Update",
+)
+async def get_firmware_releases(
+    ip: str,
+    local_firmware_releases_interactor: GetLocalFirmwareReleases | None = None,
+) -> dict:
+    """
+    Show what firmware a local (via manager) update would install, per channel.
+
+    The versions come from the manager's own index lookup, so they are
+    accurate for devices without internet access. Channels the index
+    publishes nothing for are null, as is every channel for a device local
+    updates cannot serve (Gen1 or no reported app name).
+
+    Args:
+        ip: Device IP address (e.g., "192.168.1.100")
+
+    Returns:
+        dict: Release metadata by channel name, e.g.
+            {"stable": {"version": ..., "build_id": ...}, "beta": null}
+    """
+    local_firmware_releases_interactor = _require(
+        "local_firmware_releases_interactor", local_firmware_releases_interactor
+    )
+
+    releases = await local_firmware_releases_interactor.execute(
+        BaseDeviceRequest(device_ip=ip)
+    )
+    return {
+        channel: (
+            None
+            if release is None
+            else {"version": release.version, "build_id": release.build_id}
+        )
+        for channel, release in releases.items()
     }
 
 
@@ -463,6 +500,7 @@ devices_router = Router(
         execute_component_action,
         get_device_status,
         update_device,
+        get_firmware_releases,
         reboot_device,
         execute_bulk_operations,
         bulk_export_config,

--- a/packages/api/src/api/dependencies/container.py
+++ b/packages/api/src/api/dependencies/container.py
@@ -82,6 +82,10 @@ def get_dependencies(container: APIContainer) -> dict:
             lambda: container.get_update_device_from_local_interactor(),
             sync_to_thread=False,
         ),
+        "local_firmware_releases_interactor": Provide(
+            lambda: container.get_local_firmware_releases_interactor(),
+            sync_to_thread=False,
+        ),
         "manage_firmware_use_case": Provide(
             lambda: container.get_manage_firmware_interactor(),
             sync_to_thread=False,

--- a/packages/api/tests/unit/controllers/test_devices.py
+++ b/packages/api/tests/unit/controllers/test_devices.py
@@ -7,6 +7,7 @@ from api.controllers.devices import (
     execute_component_action,
     get_component_actions,
     get_device_status,
+    get_firmware_releases,
     scan_devices,
     update_device,
 )
@@ -20,6 +21,7 @@ from core.use_cases.bulk_operations import BulkOperationsUseCase
 from core.use_cases.check_device_status import CheckDeviceStatusUseCase
 from core.use_cases.execute_component_action import ExecuteComponentActionUseCase
 from core.use_cases.get_component_actions import GetComponentActionsUseCase
+from core.use_cases.get_local_firmware_releases import GetLocalFirmwareReleases
 from core.use_cases.scan_devices import ScanDevicesUseCase
 from core.use_cases.update_device_from_local import UpdateDeviceFromLocal
 from litestar.di import Provide
@@ -188,8 +190,9 @@ class TestDevicesController:
             def __init__(self):
                 pass
 
-            async def execute(self, request):
+            async def execute(self, request, channel="stable"):
                 captured["request"] = request
+                captured["channel"] = channel
                 return ActionResult(
                     device_ip=request.device_ip,
                     success=True,
@@ -213,6 +216,98 @@ class TestDevicesController:
             assert data["source"] == "local"
             assert data["channel"] == "stable"
             assert captured["request"].device_ip == "192.168.1.100"
+            assert captured["channel"] == "stable"
+
+    def test_update_device_from_local_source_passes_the_channel(self):
+        captured = {}
+
+        class MockUpdateDeviceFromLocal(UpdateDeviceFromLocal):
+            def __init__(self):
+                pass
+
+            async def execute(self, request, channel="stable"):
+                captured["channel"] = channel
+                return ActionResult(
+                    device_ip=request.device_ip,
+                    success=True,
+                    message="Update executed successfully on shelly",
+                    action_type="shelly.Update",
+                )
+
+        with create_test_client(
+            route_handlers=[update_device],
+            dependencies={
+                "update_device_from_local_interactor": Provide(
+                    lambda: MockUpdateDeviceFromLocal(), sync_to_thread=False
+                )
+            },
+        ) as client:
+            response = client.post(
+                "/192.168.1.100/update",
+                json={"source": "local", "channel": "beta"},
+            )
+
+            assert response.status_code == 200
+            assert response.json()["channel"] == "beta"
+            assert captured["channel"] == "beta"
+
+    def test_get_firmware_releases_reports_each_channel(self):
+        from core.domain.value_objects.firmware_release import FirmwareRelease
+
+        class MockGetLocalFirmwareReleases(GetLocalFirmwareReleases):
+            def __init__(self):
+                pass
+
+            async def execute(self, request):
+                return {
+                    "stable": FirmwareRelease(
+                        app_name="Plus2PM",
+                        version="1.8.0",
+                        build_id="20250611-100000/1.8.0-g1234567",
+                        download_url="https://fwcdn.example.test/Plus2PM.zip",
+                    ),
+                    "beta": None,
+                }
+
+        with create_test_client(
+            route_handlers=[get_firmware_releases],
+            dependencies={
+                "local_firmware_releases_interactor": Provide(
+                    lambda: MockGetLocalFirmwareReleases(), sync_to_thread=False
+                )
+            },
+        ) as client:
+            response = client.get("/192.168.1.100/firmware-releases")
+
+            assert response.status_code == 200
+            assert response.json() == {
+                "stable": {
+                    "version": "1.8.0",
+                    "build_id": "20250611-100000/1.8.0-g1234567",
+                },
+                "beta": None,
+            }
+
+    def test_get_firmware_releases_maps_an_index_failure_to_422(self):
+        class MockGetLocalFirmwareReleases(GetLocalFirmwareReleases):
+            def __init__(self):
+                pass
+
+            async def execute(self, request):
+                raise FirmwareError("Firmware index request failed for Plus2PM")
+
+        with create_test_client(
+            route_handlers=[get_firmware_releases],
+            dependencies={
+                "local_firmware_releases_interactor": Provide(
+                    lambda: MockGetLocalFirmwareReleases(), sync_to_thread=False
+                )
+            },
+            exception_handlers=EXCEPTION_HANDLERS,
+        ) as client:
+            response = client.get("/192.168.1.100/firmware-releases")
+
+            assert response.status_code == 422
 
     def test_update_device_rejects_an_unknown_source(self):
         with create_test_client(route_handlers=[update_device]) as client:
@@ -229,26 +324,6 @@ class TestDevicesController:
 
             assert response.status_code == 400
 
-    def test_update_device_rejects_a_beta_local_update(self):
-        class MockUpdateDeviceFromLocal(UpdateDeviceFromLocal):
-            def __init__(self):
-                pass
-
-        with create_test_client(
-            route_handlers=[update_device],
-            dependencies={
-                "update_device_from_local_interactor": Provide(
-                    lambda: MockUpdateDeviceFromLocal(), sync_to_thread=False
-                )
-            },
-        ) as client:
-            response = client.post(
-                "/192.168.1.100/update",
-                json={"source": "local", "channel": "beta"},
-            )
-
-            assert response.status_code == 400
-
     def test_update_device_maps_firmware_misconfiguration_to_500(self):
         from core.domain.entities.exceptions import FirmwareConfigurationError
 
@@ -256,7 +331,7 @@ class TestDevicesController:
             def __init__(self):
                 pass
 
-            async def execute(self, request):
+            async def execute(self, request, channel="stable"):
                 raise FirmwareConfigurationError(
                     "Local updates need SHELLY_FIRMWARE_ADVERTISED_BASE_URL set"
                 )
@@ -280,8 +355,8 @@ class TestDevicesController:
             def __init__(self):
                 pass
 
-            async def execute(self, request):
-                raise FirmwareError("No firmware published for app 'Plus2PM'")
+            async def execute(self, request, channel="stable"):
+                raise FirmwareError("No stable firmware published for app 'Plus2PM'")
 
         with create_test_client(
             route_handlers=[update_device],

--- a/packages/core/src/core/dependencies/container_base.py
+++ b/packages/core/src/core/dependencies/container_base.py
@@ -43,6 +43,7 @@ from core.use_cases.capture_device_config import CaptureDeviceConfig
 from core.use_cases.check_device_status import CheckDeviceStatusUseCase
 from core.use_cases.execute_component_action import ExecuteComponentActionUseCase
 from core.use_cases.get_component_actions import GetComponentActionsUseCase
+from core.use_cases.get_local_firmware_releases import GetLocalFirmwareReleases
 from core.use_cases.manage_backup_schedules import ManageBackupSchedulesUseCase
 from core.use_cases.manage_firmware import ManageFirmware
 from core.use_cases.manage_provisioning_profiles import (
@@ -82,6 +83,7 @@ class BaseContainer:
         self._firmware_gateway: ShellyCloudFirmwareGateway | None = None
         self._acquire_firmware_interactor: AcquireFirmware | None = None
         self._update_device_from_local_interactor: UpdateDeviceFromLocal | None = None
+        self._local_firmware_releases_interactor: GetLocalFirmwareReleases | None = None
         self._manage_firmware_interactor: ManageFirmware | None = None
         # Every slot above is a device-scoped cache cleared by
         # _reset_device_caches(); slots below survive close().
@@ -180,6 +182,7 @@ class BaseContainer:
                 device_gateway=self.get_device_gateway(),
                 mdns_client=self.get_mdns_client(),
                 auth_state_cache=self.get_auth_state_cache(),
+                firmware_gateway=self.get_firmware_gateway(),
             )
         return self._scan_interactor
 
@@ -229,6 +232,14 @@ class BaseContainer:
                 settings=core_settings.firmware,
             )
         return self._update_device_from_local_interactor
+
+    def get_local_firmware_releases_interactor(self) -> GetLocalFirmwareReleases:
+        if self._local_firmware_releases_interactor is None:
+            self._local_firmware_releases_interactor = GetLocalFirmwareReleases(
+                device_gateway=self.get_device_gateway(),
+                firmware_gateway=self.get_firmware_gateway(),
+            )
+        return self._local_firmware_releases_interactor
 
     def get_manage_firmware_interactor(self) -> ManageFirmware:
         if self._manage_firmware_interactor is None:

--- a/packages/core/src/core/domain/entities/discovered_device.py
+++ b/packages/core/src/core/domain/entities/discovered_device.py
@@ -17,6 +17,9 @@ class DiscoveredDevice(BaseModel):
     status: Status = Field(..., description="Current device status")
     device_id: str | None = Field(None, description="Unique device identifier")
     device_type: str | None = Field(None, description="Device model/type")
+    app_name: str | None = Field(
+        None, description="Device app name firmware is looked up by, e.g. 'Plus2PM'"
+    )
     firmware_version: str | None = Field(None, description="Current firmware version")
     device_name: str | None = Field(None, description="User-defined device name")
     auth_required: bool = Field(

--- a/packages/core/src/core/domain/value_objects/firmware_release.py
+++ b/packages/core/src/core/domain/value_objects/firmware_release.py
@@ -13,3 +13,19 @@ class FirmwareRelease(BaseModel):
     build_id: str = Field(..., description="Full build identifier")
     download_url: str = Field(..., description="Direct download URL for the bundle")
     channel: str = Field(default="stable", description="Release channel (stable/beta)")
+
+    def is_installed_on(self, firmware_version: str | None) -> bool:
+        """Whether a device reporting this fw_id already runs exactly this build.
+
+        A fw_id and the index's build id name one exact build, so they decide
+        this whenever the device reports one. Comparing versions instead would
+        call a device current when the same version has been republished under
+        a new build, which is how a reissued fix would never install. A device
+        that reports a bare version has no build to compare, so its version has
+        to settle it, otherwise it would be reflashed on every run.
+        """
+        if not firmware_version:
+            return False
+        if "/" in firmware_version:
+            return firmware_version == self.build_id
+        return firmware_version.split("-g", 1)[0] == self.version

--- a/packages/core/src/core/gateways/device/shelly_device_gateway.py
+++ b/packages/core/src/core/gateways/device/shelly_device_gateway.py
@@ -90,6 +90,7 @@ class ShellyDeviceGateway(DeviceGateway):
                 status=Status.DETECTED,
                 device_id=device_data.get("id"),
                 device_type=device_data.get("model"),
+                app_name=device_data.get("app"),
                 device_name=device_data.get("name"),
                 firmware_version=device_data.get("fw_id"),
                 auth_required=auth_required,

--- a/packages/core/src/core/gateways/firmware/firmware.py
+++ b/packages/core/src/core/gateways/firmware/firmware.py
@@ -7,8 +7,10 @@ from core.domain.value_objects.firmware_release import FirmwareRelease
 
 class FirmwareGateway(ABC):
     @abstractmethod
-    async def get_latest(self, app_name: str) -> FirmwareRelease | None:
-        """Latest stable release for an app, or ``None`` when the index has none."""
+    async def get_latest(
+        self, app_name: str, channel: str = "stable"
+    ) -> FirmwareRelease | None:
+        """Latest release for an app on a channel, or ``None`` when the index has none."""
         pass
 
     @abstractmethod

--- a/packages/core/src/core/gateways/firmware/shelly_cloud_firmware_gateway.py
+++ b/packages/core/src/core/gateways/firmware/shelly_cloud_firmware_gateway.py
@@ -59,7 +59,9 @@ class ShellyCloudFirmwareGateway(FirmwareGateway):
                 verify=verify,
             )
 
-    async def get_latest(self, app_name: str) -> FirmwareRelease | None:
+    async def get_latest(
+        self, app_name: str, channel: str = "stable"
+    ) -> FirmwareRelease | None:
         if not _is_safe_app_name(app_name):
             raise FirmwareError(
                 f"Refusing firmware lookup for unsafe app name '{app_name}'",
@@ -80,7 +82,7 @@ class ShellyCloudFirmwareGateway(FirmwareGateway):
                 {"app_name": app_name},
             ) from e
 
-        return _release_from_index_entry(app_name, data)
+        return _release_from_index_entry(app_name, data, channel)
 
     async def download(
         self, release: FirmwareRelease, dest_path: str
@@ -254,16 +256,18 @@ def _reject_oversized(response: httpx.Response, release: FirmwareRelease) -> Non
         )
 
 
-def _release_from_index_entry(app_name: str, data: Any) -> FirmwareRelease | None:
+def _release_from_index_entry(
+    app_name: str, data: Any, channel: str
+) -> FirmwareRelease | None:
     if not isinstance(data, dict):
         return None
-    stable = data.get("stable")
-    if not isinstance(stable, dict):
+    entry = data.get(channel)
+    if not isinstance(entry, dict):
         return None
 
-    version = stable.get("version")
-    build_id = stable.get("build_id")
-    download_url = stable.get("url")
+    version = entry.get("version")
+    build_id = entry.get("build_id")
+    download_url = entry.get("url")
     if not (
         isinstance(version, str)
         and version
@@ -279,5 +283,5 @@ def _release_from_index_entry(app_name: str, data: Any) -> FirmwareRelease | Non
         version=version,
         build_id=build_id,
         download_url=download_url,
-        channel="stable",
+        channel=channel,
     )

--- a/packages/core/src/core/use_cases/get_local_firmware_releases.py
+++ b/packages/core/src/core/use_cases/get_local_firmware_releases.py
@@ -1,0 +1,53 @@
+"""Use case for previewing the firmware a local update would install."""
+
+from core.domain.entities.exceptions import DeviceNotFoundError
+from core.domain.enums.enums import UpdateChannel
+from core.domain.value_objects.base_device_request import BaseDeviceRequest
+from core.domain.value_objects.firmware_release import FirmwareRelease
+from core.gateways.device import DeviceGateway
+from core.gateways.firmware import FirmwareGateway
+
+
+class GetLocalFirmwareReleases:
+    """Resolve what the firmware index publishes for one device, per channel.
+
+    Backs the channel choice in the update dialog: an offline device cannot
+    report what is available, so the manager answers from the same index a
+    local update would install from.
+    """
+
+    def __init__(
+        self,
+        device_gateway: DeviceGateway,
+        firmware_gateway: FirmwareGateway,
+    ):
+        self._device_gateway = device_gateway
+        self._firmware_gateway = firmware_gateway
+
+    async def execute(
+        self, request: BaseDeviceRequest
+    ) -> dict[str, FirmwareRelease | None]:
+        """Releases by channel name, ``None`` where the index publishes nothing.
+
+        A device local updates cannot serve (Gen1, or one reporting no app
+        name) gets all-``None``: the dialog needs "nothing to offer", not an
+        error, to disable the start button.
+
+        Raises:
+            DeviceNotFoundError: If the device is unreachable.
+            FirmwareError: If the index cannot be queried.
+        """
+        ip = request.device_ip
+        status = await self._device_gateway.get_device_status(ip)
+        if status is None:
+            raise DeviceNotFoundError(ip)
+
+        if status.gen == 1 or not status.app_name:
+            return {channel.value: None for channel in UpdateChannel}
+
+        return {
+            channel.value: await self._firmware_gateway.get_latest(
+                status.app_name, channel.value
+            )
+            for channel in UpdateChannel
+        }

--- a/packages/core/src/core/use_cases/scan_devices.py
+++ b/packages/core/src/core/use_cases/scan_devices.py
@@ -10,8 +10,10 @@ from ..domain.entities.exceptions import (
     ValidationError,
 )
 from ..domain.enums.enums import Status
+from ..domain.value_objects.firmware_release import FirmwareRelease
 from ..domain.value_objects.scan_request import ScanRequest
 from ..gateways.device import DeviceGateway
+from ..gateways.firmware import FirmwareGateway
 from ..gateways.network import MDNSGateway
 
 logger = logging.getLogger(__name__)
@@ -24,10 +26,12 @@ class ScanDevicesUseCase:
         device_gateway: DeviceGateway,
         mdns_client: MDNSGateway | None = None,
         auth_state_cache: Any | None = None,
+        firmware_gateway: FirmwareGateway | None = None,
     ):
         self._device_gateway = device_gateway
         self._mdns_client = mdns_client
         self._auth_state_cache = auth_state_cache
+        self._firmware_gateway = firmware_gateway
 
     async def execute(self, request: ScanRequest) -> list[DiscoveredDevice]:
         """
@@ -68,7 +72,54 @@ class ScanDevicesUseCase:
             ]:
                 discovered_devices.append(result)
 
+        await self._settle_update_status(discovered_devices)
+
         return discovered_devices
+
+    async def _settle_update_status(self, devices: list[DiscoveredDevice]) -> None:
+        """Answer stalled update checks from the manager's own index lookup.
+
+        A device that cannot reach Shelly's cloud fails its own update check
+        and stays DETECTED, which the UI reads as an open question even though
+        the manager can still serve it firmware locally. The index the manager
+        queries here is the same one local updates install from, so the badge
+        and the via-manager path cannot disagree. Stable only: it is what an
+        unqualified "update available" means everywhere else in the app.
+        """
+        firmware_gateway = self._firmware_gateway
+        if firmware_gateway is None:
+            return
+
+        pending: dict[str, list[DiscoveredDevice]] = {}
+        for device in devices:
+            if device.status == Status.DETECTED and device.app_name:
+                pending.setdefault(device.app_name, []).append(device)
+        if not pending:
+            return
+
+        apps = sorted(pending)
+        lookups = await asyncio.gather(
+            *(self._lookup_release(firmware_gateway, app) for app in apps)
+        )
+
+        for app, release in zip(apps, lookups, strict=True):
+            if release is None:
+                continue
+            for device in pending[app]:
+                device.status = (
+                    Status.NO_UPDATE_NEEDED
+                    if release.is_installed_on(device.firmware_version)
+                    else Status.UPDATE_AVAILABLE
+                )
+
+    async def _lookup_release(
+        self, firmware_gateway: FirmwareGateway, app_name: str
+    ) -> FirmwareRelease | None:
+        try:
+            return await firmware_gateway.get_latest(app_name)
+        except Exception as e:
+            logger.warning("Firmware index lookup failed for app %s: %s", app_name, e)
+            return None
 
     def _validate_scan_request(self, request: ScanRequest) -> None:
         """Validate scan request."""

--- a/packages/core/src/core/use_cases/update_device_from_local.py
+++ b/packages/core/src/core/use_cases/update_device_from_local.py
@@ -10,7 +10,6 @@ from core.domain.entities.exceptions import (
 )
 from core.domain.value_objects.action_result import ActionResult
 from core.domain.value_objects.base_device_request import BaseDeviceRequest
-from core.domain.value_objects.firmware_release import FirmwareRelease
 from core.gateways.device import DeviceGateway
 from core.gateways.firmware import FirmwareGateway
 from core.settings import FirmwareSettings
@@ -41,14 +40,16 @@ class UpdateDeviceFromLocal:
         self._acquire_firmware = acquire_firmware
         self._settings = settings
 
-    async def execute(self, request: BaseDeviceRequest) -> ActionResult:
+    async def execute(
+        self, request: BaseDeviceRequest, channel: str = "stable"
+    ) -> ActionResult:
         """Point the device at a locally cached copy of its latest firmware.
 
         Raises:
             DeviceNotFoundError: If the device is unreachable.
             FirmwareError: If the advertised base URL is unset, the device is
-                Gen1 or reports no app name, no release is published, or a
-                mandatory intermediate update is missing.
+                Gen1 or reports no app name, no release is published on the
+                channel, or a mandatory intermediate update is missing.
         """
         base_url = (self._settings.advertised_base_url or "").strip()
         if not base_url:
@@ -74,15 +75,15 @@ class UpdateDeviceFromLocal:
                 {"device_ip": ip},
             )
 
-        release = await self._firmware_gateway.get_latest(status.app_name)
+        release = await self._firmware_gateway.get_latest(status.app_name, channel)
         if release is None:
             raise FirmwareError(
-                f"No firmware published for app '{status.app_name}'",
-                {"app_name": status.app_name},
+                f"No {channel} firmware published for app '{status.app_name}'",
+                {"app_name": status.app_name, "channel": channel},
             )
 
         installed = _installed_version(status.firmware_version)
-        if _already_runs(status.firmware_version, installed, release):
+        if release.is_installed_on(status.firmware_version):
             return ActionResult(
                 device_ip=ip,
                 action_type="shelly.Update",
@@ -135,25 +136,6 @@ def _installed_version(firmware_version: str | None) -> str | None:
         return None
     _, _, after_build_date = firmware_version.partition("/")
     return (after_build_date or firmware_version).split("-g", 1)[0]
-
-
-def _already_runs(
-    firmware_version: str | None, installed: str | None, release: FirmwareRelease
-) -> bool:
-    """Whether the device already runs exactly what the index publishes.
-
-    A fw_id and the index's build id name one exact build, so they decide this
-    whenever the device reports one. Comparing versions instead would call a
-    device current when the same version has been republished under a new
-    build, which is how a reissued fix would never install. A device that
-    reports a bare version has no build to compare, so its version has to
-    settle it, otherwise it would be reflashed on every run.
-    """
-    if not firmware_version:
-        return False
-    if "/" in firmware_version:
-        return firmware_version == release.build_id
-    return installed is not None and installed == release.version
 
 
 def _version_key(version: str) -> tuple[int, ...] | None:

--- a/packages/core/tests/unit/dependencies/test_container_base.py
+++ b/packages/core/tests/unit/dependencies/test_container_base.py
@@ -93,6 +93,7 @@ class TestProviderWiring:
             "get_firmware_gateway",
             "get_acquire_firmware_interactor",
             "get_update_device_from_local_interactor",
+            "get_local_firmware_releases_interactor",
             "get_manage_firmware_interactor",
             "get_ap_device_detector",
             "get_mdns_client",

--- a/packages/core/tests/unit/gateways/device/test_shelly_device_gateway.py
+++ b/packages/core/tests/unit/gateways/device/test_shelly_device_gateway.py
@@ -35,6 +35,7 @@ class TestShellyDeviceGateway:
         device_info = {
             "id": "shelly1pm-001",
             "model": "SHPM-1",
+            "app": "Plus1PM",
             "name": "Living Room Switch",
             "fw_id": "20230913-114010/v1.14.0-gcb84623",
         }
@@ -51,6 +52,7 @@ class TestShellyDeviceGateway:
         assert result.status == Status.NO_UPDATE_NEEDED
         assert result.device_id == "shelly1pm-001"
         assert result.device_type == "SHPM-1"
+        assert result.app_name == "Plus1PM"
         assert result.device_name == "Living Room Switch"
         assert result.firmware_version == "20230913-114010/v1.14.0-gcb84623"
         assert result.response_time == 0.15

--- a/packages/core/tests/unit/gateways/firmware/test_shelly_cloud_firmware_gateway.py
+++ b/packages/core/tests/unit/gateways/firmware/test_shelly_cloud_firmware_gateway.py
@@ -56,6 +56,46 @@ class TestGetLatest:
         assert release.download_url == "https://fwcdn.example.test/Plus2PM.zip"
         assert release.channel == "stable"
 
+    async def test_it_returns_the_beta_release_when_asked(self):
+        def handler(request):
+            return httpx.Response(
+                200,
+                json={
+                    "stable": {
+                        "version": "1.7.5",
+                        "build_id": "20250611-100000/1.7.5-g1234567",
+                        "url": "https://fwcdn.example.test/Plus2PM.zip",
+                    },
+                    "beta": {
+                        "version": "1.8.0-beta2",
+                        "build_id": "20250701-100000/1.8.0-beta2-g89abcde",
+                        "url": "https://fwcdn.example.test/Plus2PM-beta.zip",
+                    },
+                },
+            )
+
+        release = await _gateway(handler).get_latest("Plus2PM", "beta")
+
+        assert release is not None
+        assert release.version == "1.8.0-beta2"
+        assert release.build_id == "20250701-100000/1.8.0-beta2-g89abcde"
+        assert release.channel == "beta"
+
+    async def test_it_returns_none_when_the_channel_has_no_entry(self):
+        def handler(request):
+            return httpx.Response(
+                200,
+                json={
+                    "stable": {
+                        "version": "1.7.5",
+                        "build_id": "20250611-100000/1.7.5-g1234567",
+                        "url": "https://fwcdn.example.test/Plus2PM.zip",
+                    }
+                },
+            )
+
+        assert (await _gateway(handler).get_latest("Plus2PM", "beta")) is None
+
     async def test_it_returns_none_when_the_index_has_no_entry(self):
         def handler(request):
             return httpx.Response(404)

--- a/packages/core/tests/unit/use_cases/test_get_local_firmware_releases.py
+++ b/packages/core/tests/unit/use_cases/test_get_local_firmware_releases.py
@@ -1,0 +1,106 @@
+"""Tests for the local firmware release preview use case."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, call
+
+import pytest
+from core.domain.entities.exceptions import DeviceNotFoundError, FirmwareError
+from core.domain.value_objects.base_device_request import BaseDeviceRequest
+from core.domain.value_objects.firmware_release import FirmwareRelease
+from core.use_cases.get_local_firmware_releases import GetLocalFirmwareReleases
+
+IP = "192.168.1.100"
+
+
+def _status(gen=2, app_name="Plus2PM"):
+    return SimpleNamespace(gen=gen, app_name=app_name)
+
+
+def _release(channel, version="1.8.0"):
+    return FirmwareRelease(
+        app_name="Plus2PM",
+        version=version,
+        build_id=f"20250611-100000/{version}-g1234567",
+        download_url="https://fwcdn.example.test/Plus2PM.zip",
+        channel=channel,
+    )
+
+
+class TestGetLocalFirmwareReleases:
+    @pytest.fixture
+    def mock_firmware_gateway(self):
+        gateway = AsyncMock()
+        gateway.get_latest = AsyncMock(
+            side_effect=lambda app_name, channel: _release(channel)
+        )
+        return gateway
+
+    @pytest.fixture
+    def use_case(self, mock_device_gateway, mock_firmware_gateway):
+        mock_device_gateway.get_device_status = AsyncMock(return_value=_status())
+        return GetLocalFirmwareReleases(
+            device_gateway=mock_device_gateway,
+            firmware_gateway=mock_firmware_gateway,
+        )
+
+    async def test_it_returns_a_release_per_channel(
+        self, use_case, mock_firmware_gateway
+    ):
+        releases = await use_case.execute(BaseDeviceRequest(device_ip=IP))
+
+        assert set(releases) == {"stable", "beta"}
+        assert releases["stable"].channel == "stable"
+        assert releases["beta"].channel == "beta"
+        mock_firmware_gateway.get_latest.assert_has_awaits(
+            [call("Plus2PM", "stable"), call("Plus2PM", "beta")]
+        )
+
+    async def test_it_passes_through_a_channel_without_a_release(
+        self, use_case, mock_firmware_gateway
+    ):
+        mock_firmware_gateway.get_latest.side_effect = lambda app_name, channel: (
+            _release(channel) if channel == "stable" else None
+        )
+
+        releases = await use_case.execute(BaseDeviceRequest(device_ip=IP))
+
+        assert releases["stable"] is not None
+        assert releases["beta"] is None
+
+    async def test_it_raises_when_the_device_is_unreachable(
+        self, use_case, mock_device_gateway
+    ):
+        mock_device_gateway.get_device_status = AsyncMock(return_value=None)
+
+        with pytest.raises(DeviceNotFoundError):
+            await use_case.execute(BaseDeviceRequest(device_ip=IP))
+
+    async def test_it_offers_nothing_for_a_gen1_device(
+        self, use_case, mock_device_gateway, mock_firmware_gateway
+    ):
+        mock_device_gateway.get_device_status = AsyncMock(return_value=_status(gen=1))
+
+        releases = await use_case.execute(BaseDeviceRequest(device_ip=IP))
+
+        assert releases == {"stable": None, "beta": None}
+        mock_firmware_gateway.get_latest.assert_not_awaited()
+
+    async def test_it_offers_nothing_without_an_app_name(
+        self, use_case, mock_device_gateway, mock_firmware_gateway
+    ):
+        mock_device_gateway.get_device_status = AsyncMock(
+            return_value=_status(app_name=None)
+        )
+
+        releases = await use_case.execute(BaseDeviceRequest(device_ip=IP))
+
+        assert releases == {"stable": None, "beta": None}
+        mock_firmware_gateway.get_latest.assert_not_awaited()
+
+    async def test_it_propagates_an_index_failure(
+        self, use_case, mock_firmware_gateway
+    ):
+        mock_firmware_gateway.get_latest.side_effect = FirmwareError("index down")
+
+        with pytest.raises(FirmwareError):
+            await use_case.execute(BaseDeviceRequest(device_ip=IP))

--- a/packages/core/tests/unit/use_cases/test_scan_devices.py
+++ b/packages/core/tests/unit/use_cases/test_scan_devices.py
@@ -4,6 +4,7 @@ import pytest
 from core.domain.entities.discovered_device import DiscoveredDevice
 from core.domain.entities.exceptions import ConfigurationError
 from core.domain.enums.enums import Status
+from core.domain.value_objects.firmware_release import FirmwareRelease
 from core.domain.value_objects.scan_request import ScanRequest
 from core.gateways.network import MDNSGateway
 from core.use_cases.scan_devices import ScanDevicesUseCase
@@ -228,3 +229,144 @@ class TestScanDevicesUseCase:
 
         assert result == []
         mock_mdns_client.discover_device_ips.assert_called_once_with(timeout=5.0)
+
+
+class TestScanSettlesUpdateStatus:
+    """A stalled device-side update check is answered from the manager's index."""
+
+    @pytest.fixture
+    def single_ip_request(self):
+        return ScanRequest(
+            targets=["192.168.1.1"],
+            use_predefined=False,
+            use_mdns=False,
+            timeout=3.0,
+            max_workers=10,
+        )
+
+    def _device(self, status=Status.DETECTED, **kwargs):
+        base = {
+            "ip": "192.168.1.1",
+            "status": status,
+            "device_id": "1",
+            "device_type": "SNSW-102P16EU",
+            "app_name": "Plus2PM",
+            "firmware_version": "20240101-000000/1.7.5-gabc",
+        }
+        base.update(kwargs)
+        return DiscoveredDevice(**base)
+
+    def _use_case(self, mock_device_gateway, release):
+        firmware_gateway = AsyncMock()
+        if isinstance(release, Exception):
+            firmware_gateway.get_latest = AsyncMock(side_effect=release)
+        else:
+            firmware_gateway.get_latest = AsyncMock(return_value=release)
+        use_case = ScanDevicesUseCase(
+            device_gateway=mock_device_gateway,
+            firmware_gateway=firmware_gateway,
+        )
+        return use_case, firmware_gateway
+
+    async def test_it_marks_an_update_the_index_publishes(
+        self, mock_device_gateway, single_ip_request
+    ):
+        mock_device_gateway.discover_device = AsyncMock(return_value=self._device())
+        use_case, firmware_gateway = self._use_case(
+            mock_device_gateway,
+            FirmwareRelease(
+                app_name="Plus2PM",
+                version="1.8.0",
+                build_id="20250611-100000/1.8.0-g1234567",
+                download_url="https://fwcdn.example.test/Plus2PM.zip",
+            ),
+        )
+
+        result = await use_case.execute(single_ip_request)
+
+        assert result[0].status == Status.UPDATE_AVAILABLE
+        firmware_gateway.get_latest.assert_awaited_once_with("Plus2PM")
+
+    async def test_it_marks_a_device_already_on_the_published_build(
+        self, mock_device_gateway, single_ip_request
+    ):
+        build_id = "20250611-100000/1.7.5-g1234567"
+        mock_device_gateway.discover_device = AsyncMock(
+            return_value=self._device(firmware_version=build_id)
+        )
+        use_case, _ = self._use_case(
+            mock_device_gateway,
+            FirmwareRelease(
+                app_name="Plus2PM",
+                version="1.7.5",
+                build_id=build_id,
+                download_url="https://fwcdn.example.test/Plus2PM.zip",
+            ),
+        )
+
+        result = await use_case.execute(single_ip_request)
+
+        assert result[0].status == Status.NO_UPDATE_NEEDED
+
+    async def test_it_leaves_detected_when_the_index_has_no_release(
+        self, mock_device_gateway, single_ip_request
+    ):
+        mock_device_gateway.discover_device = AsyncMock(return_value=self._device())
+        use_case, _ = self._use_case(mock_device_gateway, None)
+
+        result = await use_case.execute(single_ip_request)
+
+        assert result[0].status == Status.DETECTED
+
+    async def test_it_leaves_detected_when_the_index_is_unreachable(
+        self, mock_device_gateway, single_ip_request
+    ):
+        mock_device_gateway.discover_device = AsyncMock(return_value=self._device())
+        use_case, _ = self._use_case(mock_device_gateway, Exception("index down"))
+
+        result = await use_case.execute(single_ip_request)
+
+        assert result[0].status == Status.DETECTED
+
+    async def test_it_leaves_a_settled_status_alone(
+        self, mock_device_gateway, single_ip_request
+    ):
+        mock_device_gateway.discover_device = AsyncMock(
+            return_value=self._device(status=Status.NO_UPDATE_NEEDED)
+        )
+        use_case, firmware_gateway = self._use_case(mock_device_gateway, None)
+
+        result = await use_case.execute(single_ip_request)
+
+        assert result[0].status == Status.NO_UPDATE_NEEDED
+        firmware_gateway.get_latest.assert_not_awaited()
+
+    async def test_it_skips_a_device_without_an_app_name(
+        self, mock_device_gateway, single_ip_request
+    ):
+        mock_device_gateway.discover_device = AsyncMock(
+            return_value=self._device(app_name=None)
+        )
+        use_case, firmware_gateway = self._use_case(mock_device_gateway, None)
+
+        result = await use_case.execute(single_ip_request)
+
+        assert result[0].status == Status.DETECTED
+        firmware_gateway.get_latest.assert_not_awaited()
+
+    async def test_it_asks_the_index_once_per_app(self, mock_device_gateway):
+        request = ScanRequest(
+            targets=["192.168.1.1", "192.168.1.2"],
+            use_predefined=False,
+            use_mdns=False,
+            timeout=3.0,
+            max_workers=10,
+        )
+        mock_device_gateway.discover_device = AsyncMock(
+            side_effect=lambda ip, timeout: self._device(ip=ip)
+        )
+        use_case, firmware_gateway = self._use_case(mock_device_gateway, None)
+
+        await use_case.execute(request)
+
+        firmware_gateway.get_latest.assert_awaited_once_with("Plus2PM")

--- a/packages/core/tests/unit/use_cases/test_update_device_from_local.py
+++ b/packages/core/tests/unit/use_cases/test_update_device_from_local.py
@@ -179,10 +179,32 @@ class TestUpdateDeviceFromLocal:
     ):
         mock_firmware_gateway.get_latest = AsyncMock(return_value=None)
 
-        with pytest.raises(FirmwareError, match="No firmware published"):
+        with pytest.raises(FirmwareError, match="No stable firmware published"):
             await use_case.execute(BaseDeviceRequest(device_ip=IP))
 
         mock_device_gateway.execute_component_action.assert_not_awaited()
+
+    async def test_it_asks_the_index_for_the_requested_channel(
+        self, use_case, mock_firmware_gateway
+    ):
+        await use_case.execute(BaseDeviceRequest(device_ip=IP), channel="beta")
+
+        mock_firmware_gateway.get_latest.assert_awaited_once_with("Plus2PM", "beta")
+
+    async def test_it_asks_the_index_for_stable_by_default(
+        self, use_case, mock_firmware_gateway
+    ):
+        await use_case.execute(BaseDeviceRequest(device_ip=IP))
+
+        mock_firmware_gateway.get_latest.assert_awaited_once_with("Plus2PM", "stable")
+
+    async def test_it_names_the_channel_that_has_no_release(
+        self, use_case, mock_firmware_gateway
+    ):
+        mock_firmware_gateway.get_latest = AsyncMock(return_value=None)
+
+        with pytest.raises(FirmwareError, match="No beta firmware published"):
+            await use_case.execute(BaseDeviceRequest(device_ip=IP), channel="beta")
 
     async def test_it_short_circuits_when_already_up_to_date(
         self, use_case, mock_device_gateway, mock_firmware_gateway, mock_acquire

--- a/packages/web/src/components/device-detail/device-actions.tsx
+++ b/packages/web/src/components/device-detail/device-actions.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { useMutation } from "@tanstack/react-query";
+import { useMutation, useQuery } from "@tanstack/react-query";
 import { useTranslation } from "react-i18next";
 import {
   Download,
@@ -70,12 +70,7 @@ export function DeviceActions({
     }: {
       channel: UpdateChannel;
       source: UpdateSource;
-    }) =>
-      deviceApi.updateDevice(
-        ip,
-        source === "local" ? "stable" : channel,
-        source,
-      ),
+    }) => deviceApi.updateDevice(ip, channel, source),
     onSuccess: (result) => {
       if (result.success) {
         toast.success(
@@ -130,6 +125,23 @@ export function DeviceActions({
   const availableUpdates = deviceStatus?.firmware.available_updates;
   const selectedRelease = getChannelRelease(availableUpdates, updateChannel);
   const hasUpdates = hasAnyRelease(availableUpdates);
+
+  // The device's own available_updates answer for the internet source; an
+  // offline device reports none, so the local source asks the manager what
+  // its index can serve instead.
+  const localReleasesQuery = useQuery({
+    queryKey: ["local-firmware-releases", ip],
+    queryFn: () => deviceApi.getFirmwareReleases(ip),
+    enabled: updateDialogOpen && updateSource === "local",
+    staleTime: 60_000,
+  });
+  // On a failed refetch the query keeps its previous data next to isError;
+  // stale availability must not offer an update the manager may no longer
+  // have, so an errored query means "unknown", not "last known".
+  const localReleases = localReleasesQuery.isError
+    ? undefined
+    : localReleasesQuery.data;
+  const selectedLocalRelease = localReleases?.[updateChannel] ?? null;
 
   return (
     <Card>
@@ -220,39 +232,35 @@ export function DeviceActions({
                   </ol>
                 </div>
 
-                {updateSource === "internet" && (
-                  <div className="space-y-3">
-                    <label className="block text-sm font-medium">
-                      {t("deviceDetail.dialogs.updateFirmware.updateChannel")}
-                    </label>
-                    <Select
-                      value={updateChannel}
-                      onValueChange={(value: UpdateChannel) =>
-                        setUpdateChannel(value)
-                      }
-                    >
-                      <SelectTrigger>
-                        <SelectValue />
-                      </SelectTrigger>
-                      <SelectContent>
-                        {UPDATE_CHANNELS.map((channel) => {
-                          const release = getChannelRelease(
-                            availableUpdates,
-                            channel,
-                          );
-                          const label = t(`bulkActions.${channel}`);
-                          return (
-                            <SelectItem key={channel} value={channel}>
-                              {release
-                                ? `${label} (${release.version})`
-                                : label}
-                            </SelectItem>
-                          );
-                        })}
-                      </SelectContent>
-                    </Select>
-                  </div>
-                )}
+                <div className="space-y-3">
+                  <label className="block text-sm font-medium">
+                    {t("deviceDetail.dialogs.updateFirmware.updateChannel")}
+                  </label>
+                  <Select
+                    value={updateChannel}
+                    onValueChange={(value: UpdateChannel) =>
+                      setUpdateChannel(value)
+                    }
+                  >
+                    <SelectTrigger>
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {UPDATE_CHANNELS.map((channel) => {
+                        const release =
+                          updateSource === "local"
+                            ? localReleases?.[channel]
+                            : getChannelRelease(availableUpdates, channel);
+                        const label = t(`bulkActions.${channel}`);
+                        return (
+                          <SelectItem key={channel} value={channel}>
+                            {release ? `${label} (${release.version})` : label}
+                          </SelectItem>
+                        );
+                      })}
+                    </SelectContent>
+                  </Select>
+                </div>
 
                 {updateSource === "internet" && selectedRelease && (
                   <div className="p-3 bg-muted rounded-lg space-y-2">
@@ -285,6 +293,29 @@ export function DeviceActions({
                           )}
                     </div>
                   )}
+
+                {updateSource === "local" && selectedLocalRelease && (
+                  <div className="p-3 bg-muted rounded-lg text-sm text-muted-foreground">
+                    {t("deviceDetail.dialogs.updateFirmware.version")}:{" "}
+                    {selectedLocalRelease.version}
+                  </div>
+                )}
+
+                {updateSource === "local" &&
+                  localReleases &&
+                  !selectedLocalRelease && (
+                    <div className="p-3 bg-muted rounded-lg text-sm text-muted-foreground">
+                      {t(
+                        "deviceDetail.dialogs.updateFirmware.noUpdateOnChannel",
+                      )}
+                    </div>
+                  )}
+
+                {updateSource === "local" && localReleasesQuery.isError && (
+                  <div className="p-3 bg-muted rounded-lg text-sm text-muted-foreground">
+                    {handleApiError(localReleasesQuery.error)}
+                  </div>
+                )}
               </div>
 
               <DialogFooter>
@@ -303,7 +334,8 @@ export function DeviceActions({
                   }
                   disabled={
                     updateMutation.isPending ||
-                    (updateSource === "internet" && !selectedRelease)
+                    (updateSource === "internet" && !selectedRelease) ||
+                    (updateSource === "local" && !selectedLocalRelease)
                   }
                 >
                   {updateMutation.isPending

--- a/packages/web/src/i18n/en.json
+++ b/packages/web/src/i18n/en.json
@@ -401,7 +401,6 @@
         "updateSource": "Update Source",
         "sourceInternet": "Internet",
         "sourceLocal": "Via manager",
-        "sourceLocalHint": "The manager downloads the official firmware once and serves it to the device over the local network. Useful for devices without internet access. Stable channel only.",
         "internetStep1": "The device is told to update itself",
         "internetStep2": "It downloads the firmware from Shelly and installs it",
         "localStep1": "The manager asks Shelly which version is current",

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -24,6 +24,7 @@ import type {
   UpdateBackupScheduleRequest,
   ScheduleRunResult,
   UpdateSource,
+  LocalFirmwareReleases,
 } from "@/types/api";
 import { loadAppSettings } from "./settings";
 import { parseResponse } from "./schemas/parse";
@@ -160,6 +161,11 @@ export const deviceApi = {
 
   getDeviceStatus: async (ip: string): Promise<DeviceStatus> => {
     const response = await apiClient.get(`/devices/${ip}/status`);
+    return response.data;
+  },
+
+  getFirmwareReleases: async (ip: string): Promise<LocalFirmwareReleases> => {
+    const response = await apiClient.get(`/devices/${ip}/firmware-releases`);
     return response.data;
   },
 

--- a/packages/web/src/types/api.ts
+++ b/packages/web/src/types/api.ts
@@ -335,6 +335,12 @@ export interface DeviceStatusError {
 
 export type UpdateSource = "internet" | "local";
 
+/** What the manager itself can serve for a local update, per channel. */
+export type LocalFirmwareReleases = Record<
+  string,
+  { version: string; build_id: string } | null
+>;
+
 export interface ActionResult {
   ip: string;
   success: boolean;


### PR DESCRIPTION
## Purpose

Make the firmware status badge and the via-manager update path agree on offline devices, and let via-manager updates install from the beta channel.

Fixes #81, fixes #82.

## Context

A device without internet access fails its own `Shelly.CheckForUpdate`, so scans left it stuck at "Detected" — which reads as an update available — while a via-manager update for the same device reported it already latest (#81). The two paths used different sources: the badge trusted the device's own cloud check, the local update path queried Shelly's index from the manager host. Scans now settle those stalled devices against the manager's own index lookup — the same source local updates install from — comparing exact build ids, so the badge reflects what the manager can actually serve. One index query per distinct app per scan, run concurrently; an unreachable index leaves the status as it was.

The local source also silently forced the stable channel (#82). The channel selector now shows for both sources, the API accepts local + beta, and a new `GET /devices/{ip}/firmware-releases` endpoint previews the per-channel versions from the manager's index — an offline device cannot report what is available, so the device-reported `available_updates` the internet source uses are empty for exactly the fleets that need this.

## Notes

The badge fallback checks the stable channel only: it is what an unqualified "update available" means everywhere else in the app; beta lives in the update dialog.

The dialog keeps showing a previously fetched release while a background refetch is in flight (standard stale-while-revalidate). The window is seconds, and the backend re-validates availability at submit time, so a vanished release fails with a clear error rather than installing something stale.

Bulk updates are untouched — adding a via-manager source there (#83) builds on this channel plumbing.


Validated read-only against real hardware (Gen4 Shelly 1PM, app `S1PMG4ZB`): the scan badge, the device's own report, and the new firmware-releases preview all agree — installed 1.7.1 build differs from the index's stable 2.0.0 build, update offered on both paths. The index settling stayed correctly dormant for an online device. Not exercised: an actual via-manager install (mutating) and the offline settling path on hardware (unit-tested).

Empirically validated against the live index: stable resolves correctly for every app checked, and no app publishes a beta entry today (the 2.0.0 beta cycle just closed), so the beta path currently reports "nothing published" end to end. The assumed `{version, build_id, url}` shape of a future beta entry mirrors the documented device-side `Shelly.CheckForUpdate` response; if it ever differs, the parser yields `None` and the UI degrades to "no update on this channel" rather than installing anything.

