### PR TITLE
Add the via-manager source to bulk firmware updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,7 +230,7 @@ Earlier images wrote to `/app/data` instead. If you carried that over with a mou
 
 **Scheduled backups** run on the API server itself. When `SHELLY_BACKUP_SCHEDULER_ENABLED` is `true` (the default), an in-process poller captures backups for any due schedules every `SHELLY_BACKUP_POLL_INTERVAL_SECONDS` (default 60). Because the timer lives in-process, run the API as a single worker (the default); see the [API README](packages/api/README.md) for the full setting reference.
 
-**Local firmware updates** let a device that cannot reach the internet still be updated. Ask for one with `"source": "local"` on the update endpoint, or `--source local` from the CLI: the manager downloads the official firmware from Shelly once, keeps it, and tells the device to fetch it from the manager instead. The same copy serves every device running that model, so only the manager needs internet access.
+**Local firmware updates** let a device that cannot reach the internet still be updated. Ask for one with `"source": "local"` on the update endpoint (single-device or bulk), or `--source local` from the CLI: the manager downloads the official firmware from Shelly once, keeps it, and tells the device to fetch it from the manager instead. The same copy serves every device running that model, so only the manager needs internet access.
 
 Set `SHELLY_FIRMWARE_ADVERTISED_BASE_URL` to a URL your devices can reach, for example `http://192.168.1.50:8000`. There is no default and a local update fails immediately without it, because the manager cannot work out its own device-facing address. The devices fetch that URL unauthenticated, so it has to be reachable from the device network.
 

--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -69,8 +69,10 @@ POST /api/devices/{ip}/update      # Update device firmware
 
 POST /api/devices/{ip}/reboot      # Reboot device
 
-POST /api/devices/bulk/update      # Bulk firmware updates
-  # Body: {"device_ips": ["192.168.1.100", "192.168.1.101"], "channel": "stable"}
+POST /api/devices/bulk             # Bulk operations (update, reboot, factory_reset)
+  # Body: {"device_ips": ["192.168.1.100", "192.168.1.101"], "operation": "update",
+  #        "channel": "stable", "source": "internet"}
+  #   update takes the same channel and source fields as the single-device route
 
 # Component Actions
 GET /api/devices/{ip}/components/actions           # Discover available actions
@@ -244,7 +246,7 @@ curl -X POST http://localhost:8000/api/devices/192.168.1.100/update \
 
 For a device with no internet access, ask the manager to serve the firmware.
 It downloads the official bundle once, keeps it, and hands the device a URL on
-this host. Requires `SHELLY_FIRMWARE_ADVERTISED_BASE_URL`; stable channel only.
+this host. Requires `SHELLY_FIRMWARE_ADVERTISED_BASE_URL`.
 
 ```bash
 curl -X POST http://localhost:8000/api/devices/192.168.1.100/update \

--- a/packages/api/src/api/controllers/devices.py
+++ b/packages/api/src/api/controllers/devices.py
@@ -397,7 +397,9 @@ async def execute_bulk_operations(
     returned for each device individually.
 
     Args:
-        data: Request containing device_ips list and operation type
+        data: Request containing device_ips list, operation type, and for
+            updates an optional "channel" (stable/beta) and "source"
+            (internet/local, default internet)
 
     Returns:
         list[dict]: Operation results for each device with success status
@@ -424,9 +426,20 @@ async def execute_bulk_operations(
 
     if operation == "update":
         channel = data.get("channel", "stable")
-        results = await bulk_operations_use_case.execute_bulk_update(
-            device_ips, channel
-        )
+        source = data.get("source", "internet")
+        if source not in ("internet", "local"):
+            raise HTTPException(
+                status_code=400,
+                detail=f"Unsupported source: {source}. Supported: internet, local",
+            )
+        if source == "local":
+            results = await bulk_operations_use_case.execute_bulk_local_update(
+                device_ips, channel
+            )
+        else:
+            results = await bulk_operations_use_case.execute_bulk_update(
+                device_ips, channel
+            )
     elif operation == "reboot":
         results = await bulk_operations_use_case.execute_bulk_reboot(device_ips)
     elif operation == "factory_reset":

--- a/packages/api/tests/unit/controllers/test_devices.py
+++ b/packages/api/tests/unit/controllers/test_devices.py
@@ -571,6 +571,109 @@ class TestDevicesController:
 
             assert response.status_code == 400
 
+    def test_bulk_operations_update_via_local_source(self):
+        from core.use_cases.bulk_operations import BulkOperationsUseCase
+
+        class MockBulkOperationsUseCase(BulkOperationsUseCase):
+            def __init__(self):
+                pass
+
+            async def execute_bulk_update(self, device_ips, channel="stable"):
+                raise AssertionError("local source must not use the device path")
+
+            async def execute_bulk_local_update(self, device_ips, channel="stable"):
+                return [
+                    ActionResult(
+                        device_ip=ip,
+                        success=True,
+                        message=f"Updating to {channel}",
+                        action_type="shelly.Update",
+                    )
+                    for ip in device_ips
+                ]
+
+        with create_test_client(
+            route_handlers=[execute_bulk_operations],
+            dependencies={
+                "bulk_operations_use_case": Provide(
+                    lambda: MockBulkOperationsUseCase(), sync_to_thread=False
+                )
+            },
+        ) as client:
+            response = client.post(
+                "/bulk",
+                json={
+                    "device_ips": ["192.168.1.100", "192.168.1.101"],
+                    "operation": "update",
+                    "channel": "beta",
+                    "source": "local",
+                },
+            )
+
+            assert response.status_code == 200
+            data = response.json()
+            assert len(data) == 2
+            assert all(result["success"] for result in data)
+            assert all(result["source"] == "local" for result in data)
+            assert all(result["channel"] == "beta" for result in data)
+
+    def test_bulk_operations_local_update_reports_missing_configuration(self):
+        from core.domain.entities.exceptions import FirmwareConfigurationError
+        from core.use_cases.bulk_operations import BulkOperationsUseCase
+
+        class MockBulkOperationsUseCase(BulkOperationsUseCase):
+            def __init__(self):
+                pass
+
+            async def execute_bulk_local_update(self, device_ips, channel="stable"):
+                raise FirmwareConfigurationError("Advertised base URL unset")
+
+        with create_test_client(
+            route_handlers=[execute_bulk_operations],
+            dependencies={
+                "bulk_operations_use_case": Provide(
+                    lambda: MockBulkOperationsUseCase(), sync_to_thread=False
+                )
+            },
+            exception_handlers=EXCEPTION_HANDLERS,
+        ) as client:
+            response = client.post(
+                "/bulk",
+                json={
+                    "device_ips": ["192.168.1.100"],
+                    "operation": "update",
+                    "source": "local",
+                },
+            )
+
+            assert response.status_code == 500
+
+    def test_bulk_operations_update_rejects_an_unknown_source(self):
+        from core.use_cases.bulk_operations import BulkOperationsUseCase
+
+        class MockBulkOperationsUseCase(BulkOperationsUseCase):
+            def __init__(self):
+                pass
+
+        with create_test_client(
+            route_handlers=[execute_bulk_operations],
+            dependencies={
+                "bulk_operations_use_case": Provide(
+                    lambda: MockBulkOperationsUseCase(), sync_to_thread=False
+                )
+            },
+        ) as client:
+            response = client.post(
+                "/bulk",
+                json={
+                    "device_ips": ["192.168.1.100"],
+                    "operation": "update",
+                    "source": "cloud",
+                },
+            )
+
+            assert response.status_code == 400
+
     def test_bulk_operations_reboot_successfully(self):
         from core.use_cases.bulk_operations import BulkOperationsUseCase
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -161,7 +161,7 @@ With `--source local` the manager downloads the official firmware once and the
 device fetches it from the manager, so only this host needs internet access.
 It reads the same firmware store as the API and requires
 `SHELLY_FIRMWARE_ADVERTISED_BASE_URL` to be set to a URL your devices can
-reach; the API must serve that URL. Stable channel only.
+reach; the API must serve that URL.
 
 ### Configuration Management
 

--- a/packages/cli/src/cli/commands/device_commands.py
+++ b/packages/cli/src/cli/commands/device_commands.py
@@ -15,7 +15,7 @@ from ..entities import (
     DeviceScanRequest,
     DeviceStatusRequest,
 )
-from ..exceptions import EXIT_USAGE, EXIT_VALIDATION
+from ..exceptions import EXIT_VALIDATION
 from ..presentation.styles import Messages
 from ..use_cases.device.component_actions import ComponentActionsUseCase
 from ..use_cases.device.device_status import DeviceStatusUseCase
@@ -340,12 +340,6 @@ async def update_firmware(
       shelly-manager device update 192.168.1.0/24 --channel beta
       shelly-manager device update -t 192.168.1.100 --source local
     """
-    if source == "local" and channel != UpdateChannel.STABLE.value:
-        ctx.obj.console.print(
-            Messages.error("Local updates support the stable channel only")
-        )
-        sys.exit(EXIT_USAGE)
-
     request = ComponentActionRequest(
         targets=list(targets) + list(targets_opt),
         component_key="shelly",
@@ -362,6 +356,7 @@ async def update_firmware(
         "shelly-manager device update -t 192.168.1.100",
         "shelly-manager device update 192.168.1.0/24 --channel beta",
         from_local_store=source == "local",
+        channel=channel,
     )
 
 
@@ -416,21 +411,21 @@ async def _run_component_action(
     request: ComponentActionRequest,
     *examples: str,
     from_local_store: bool = False,
+    channel: str = "stable",
 ) -> None:
     """Run one component action across every requested device.
 
     ``from_local_store`` serves a firmware update out of this host's own
-    firmware store rather than leaving each device to fetch from the internet.
+    firmware store rather than leaving each device to fetch from the
+    internet; ``channel`` picks the release it serves.
     """
     console = ctx.obj.console
     actions_use_case = ComponentActionsUseCase(ctx.obj.container, console)
-    execute = (
-        actions_use_case.execute_local_update
-        if from_local_store
-        else actions_use_case.execute_action
-    )
     try:
-        results = await execute(request)
+        if from_local_store:
+            results = await actions_use_case.execute_local_update(request, channel)
+        else:
+            results = await actions_use_case.execute_action(request)
     except ValueError as e:
         _print_usage_error(console, e, *examples)
         sys.exit(EXIT_VALIDATION)

--- a/packages/cli/src/cli/use_cases/device/component_actions.py
+++ b/packages/cli/src/cli/use_cases/device/component_actions.py
@@ -133,7 +133,7 @@ class ComponentActionsUseCase:
         return results
 
     async def execute_local_update(
-        self, request: ComponentActionRequest
+        self, request: ComponentActionRequest, channel: str = "stable"
     ) -> list[ComponentActionResult]:
         """Update devices with firmware served from the manager's local store.
 
@@ -184,7 +184,7 @@ class ComponentActionsUseCase:
             for device_ip in device_ips:
                 try:
                     action_result = await update_interactor.execute(
-                        BaseDeviceRequest(device_ip=device_ip)
+                        BaseDeviceRequest(device_ip=device_ip), channel
                     )
 
                     result = ComponentActionResult(

--- a/packages/cli/tests/unit/commands/test_device_commands.py
+++ b/packages/cli/tests/unit/commands/test_device_commands.py
@@ -583,28 +583,52 @@ class TestActionsCommands:
 
         assert result.exit_code == 0
         mock_local_interactor.execute.assert_called_once()
-        request = mock_local_interactor.execute.call_args.args[0]
+        request, channel = mock_local_interactor.execute.call_args.args
         assert request.device_ip == sample_device.ip
+        assert channel == "stable"
 
-    def test_device_update_local_source_rejects_beta(self, cli_context):
-        """Test that a beta local update is refused."""
+    def test_device_update_local_source_passes_the_beta_channel(
+        self, cli_context, sample_device
+    ):
+        """Test that a beta local update reaches the interactor with its channel."""
+        from core.domain.value_objects.action_result import ActionResult
+
+        mock_scan_interactor = cli_context.container.get_scan_interactor.return_value
+        mock_scan_interactor.execute.return_value = [sample_device]
+        cli_context.container.initialize_database = AsyncMock()
+
+        mock_local_interactor = AsyncMock()
+        mock_local_interactor.execute.return_value = ActionResult(
+            device_ip=sample_device.ip,
+            action_type="shelly.Update",
+            success=True,
+            message="Update executed successfully on shelly",
+        )
+        cli_context.container.get_update_device_from_local_interactor.return_value = (
+            mock_local_interactor
+        )
+
         runner = CliRunner()
         result = runner.invoke(
             device_commands,
             [
                 "update",
                 "-t",
-                "192.168.1.100",
+                sample_device.ip,
                 "--source",
                 "local",
                 "--channel",
                 "beta",
+                "--force",
             ],
             obj=cli_context,
         )
 
-        assert result.exit_code != 0
-        cli_context.container.get_update_device_from_local_interactor.assert_not_called()
+        assert result.exit_code == 0
+        mock_local_interactor.execute.assert_called_once()
+        request, channel = mock_local_interactor.execute.call_args.args
+        assert request.device_ip == sample_device.ip
+        assert channel == "beta"
 
     def test_actions_execute_help(self, cli_context):
         """Test actions execute command help."""

--- a/packages/core/src/core/dependencies/container_base.py
+++ b/packages/core/src/core/dependencies/container_base.py
@@ -210,7 +210,8 @@ class BaseContainer:
     def get_bulk_operations_interactor(self) -> BulkOperationsUseCase:
         if self._bulk_operations_interactor is None:
             self._bulk_operations_interactor = BulkOperationsUseCase(
-                device_gateway=self.get_device_gateway()
+                device_gateway=self.get_device_gateway(),
+                update_device_from_local=self.get_update_device_from_local_interactor(),
             )
         return self._bulk_operations_interactor
 

--- a/packages/core/src/core/use_cases/bulk_operations.py
+++ b/packages/core/src/core/use_cases/bulk_operations.py
@@ -4,11 +4,17 @@ from datetime import UTC, datetime
 from typing import Any, TypeVar
 
 from ..domain.entities.config_snapshot import DeviceSnapshot
-from ..domain.entities.exceptions import BulkOperationError, ConfigurationError
+from ..domain.entities.exceptions import (
+    BulkOperationError,
+    ConfigurationError,
+    FirmwareConfigurationError,
+)
 from ..domain.enums.enums import UpdateChannel
 from ..domain.value_objects.action_result import ActionResult
+from ..domain.value_objects.base_device_request import BaseDeviceRequest
 from ..gateways.device import DeviceGateway
 from .capture_device_config import CaptureDeviceConfig
+from .update_device_from_local import UpdateDeviceFromLocal
 
 T = TypeVar("T")
 
@@ -46,8 +52,10 @@ class BulkOperationsUseCase:
     def __init__(
         self,
         device_gateway: DeviceGateway,
+        update_device_from_local: UpdateDeviceFromLocal,
     ):
         self._device_gateway = device_gateway
+        self._update_from_local = update_device_from_local
         self._capture = CaptureDeviceConfig(device_gateway)
 
     async def execute_bulk_update(
@@ -67,6 +75,47 @@ class BulkOperationsUseCase:
         return await self._execute_shelly_action(
             device_ips, "Update", parameters, "bulk_update", "Bulk update"
         )
+
+    async def execute_bulk_local_update(
+        self, device_ips: list[str], channel: str = "stable"
+    ) -> list[ActionResult]:
+        """
+        Update multiple devices from the manager's local firmware store.
+
+        Devices go one at a time so the first device of each app caches the
+        bundle and the rest reuse it. A failing device gets a failed result
+        while the rest proceed; a missing advertised base URL fails every
+        device identically, so it raises instead.
+
+        Args:
+            device_ips: List of device IP addresses
+            channel: Update channel (stable/beta)
+
+        Returns:
+            List of action results, one per unique device
+        """
+        channel = UpdateChannel(channel).value
+        results: list[ActionResult] = []
+        for device_ip in _unique(device_ips):
+            try:
+                results.append(
+                    await self._update_from_local.execute(
+                        BaseDeviceRequest(device_ip=device_ip), channel
+                    )
+                )
+            except FirmwareConfigurationError:
+                raise
+            except Exception as e:
+                results.append(
+                    ActionResult(
+                        device_ip=device_ip,
+                        action_type="shelly.Update",
+                        success=False,
+                        message="Local update failed",
+                        error=str(e),
+                    )
+                )
+        return results
 
     async def execute_bulk_reboot(self, device_ips: list[str]) -> list[ActionResult]:
         """

--- a/packages/core/tests/unit/use_cases/test_bulk_operations.py
+++ b/packages/core/tests/unit/use_cases/test_bulk_operations.py
@@ -9,16 +9,27 @@ from core.domain.entities.components import (
     SystemComponent,
 )
 from core.domain.entities.device_status import DeviceStatus
-from core.domain.entities.exceptions import BulkOperationError
+from core.domain.entities.exceptions import (
+    BulkOperationError,
+    FirmwareConfigurationError,
+)
 from core.domain.value_objects.action_result import ActionResult
+from core.domain.value_objects.base_device_request import BaseDeviceRequest
 from core.use_cases.bulk_operations import BulkOperationsUseCase
 
 
 class TestBulkOperationsUseCase:
 
     @pytest.fixture
-    def use_case(self, mock_device_gateway):
-        return BulkOperationsUseCase(device_gateway=mock_device_gateway)
+    def mock_update_from_local(self):
+        return AsyncMock()
+
+    @pytest.fixture
+    def use_case(self, mock_device_gateway, mock_update_from_local):
+        return BulkOperationsUseCase(
+            device_gateway=mock_device_gateway,
+            update_device_from_local=mock_update_from_local,
+        )
 
     async def test_it_updates_multiple_devices_successfully(
         self, use_case, mock_device_gateway
@@ -82,6 +93,98 @@ class TestBulkOperationsUseCase:
 
         with pytest.raises(BulkOperationError, match="Bulk update failed"):
             await use_case.execute_bulk_update(device_ips)
+
+    async def test_it_updates_each_device_from_the_local_store(
+        self, use_case, mock_update_from_local
+    ):
+        mock_update_from_local.execute = AsyncMock(
+            side_effect=[
+                ActionResult(
+                    success=True,
+                    action_type="shelly.Update",
+                    device_ip="192.168.1.100",
+                    message="Update initiated",
+                ),
+                ActionResult(
+                    success=True,
+                    action_type="shelly.Update",
+                    device_ip="192.168.1.101",
+                    message="Update initiated",
+                ),
+            ]
+        )
+
+        results = await use_case.execute_bulk_local_update(
+            ["192.168.1.100", "192.168.1.101"], "beta"
+        )
+
+        assert [r.device_ip for r in results] == ["192.168.1.100", "192.168.1.101"]
+        assert all(r.success for r in results)
+        assert mock_update_from_local.execute.call_args_list == [
+            ((BaseDeviceRequest(device_ip="192.168.1.100"), "beta"),),
+            ((BaseDeviceRequest(device_ip="192.168.1.101"), "beta"),),
+        ]
+
+    async def test_it_continues_local_updates_past_a_failing_device(
+        self, use_case, mock_update_from_local
+    ):
+        mock_update_from_local.execute = AsyncMock(
+            side_effect=[
+                Exception("Device unreachable"),
+                ActionResult(
+                    success=True,
+                    action_type="shelly.Update",
+                    device_ip="192.168.1.101",
+                    message="Update initiated",
+                ),
+            ]
+        )
+
+        results = await use_case.execute_bulk_local_update(
+            ["192.168.1.100", "192.168.1.101"]
+        )
+
+        assert results[0].success is False
+        assert results[0].device_ip == "192.168.1.100"
+        assert results[0].error == "Device unreachable"
+        assert results[1].success is True
+
+    async def test_it_updates_a_repeated_device_locally_only_once(
+        self, use_case, mock_update_from_local
+    ):
+        mock_update_from_local.execute = AsyncMock(
+            return_value=ActionResult(
+                success=True,
+                action_type="shelly.Update",
+                device_ip="192.168.1.100",
+                message="Update initiated",
+            )
+        )
+
+        results = await use_case.execute_bulk_local_update(
+            ["192.168.1.100", "192.168.1.100"]
+        )
+
+        assert len(results) == 1
+        assert mock_update_from_local.execute.await_count == 1
+
+    async def test_it_raises_when_local_updates_are_not_configured(
+        self, use_case, mock_update_from_local
+    ):
+        mock_update_from_local.execute = AsyncMock(
+            side_effect=FirmwareConfigurationError("Advertised base URL unset")
+        )
+
+        with pytest.raises(FirmwareConfigurationError):
+            await use_case.execute_bulk_local_update(["192.168.1.100", "192.168.1.101"])
+
+    async def test_it_rejects_an_unknown_channel_for_local_updates(
+        self, use_case, mock_update_from_local
+    ):
+        with pytest.raises(ValueError):
+            await use_case.execute_bulk_local_update(["192.168.1.100"], "nightly")
+
+        mock_update_from_local.execute.assert_not_awaited()
 
     async def test_it_reboots_multiple_devices_successfully(
         self, use_case, mock_device_gateway

--- a/packages/web/src/components/dashboard/bulk-actions-dialog/bulk-actions-dialog.tsx
+++ b/packages/web/src/components/dashboard/bulk-actions-dialog/bulk-actions-dialog.tsx
@@ -19,6 +19,7 @@ import { ActionConfiguration } from "./components/action-configuration";
 import { ProgressDisplay } from "./components/progress-display";
 
 import type { BulkActionsDialogProps, BulkActionType } from "./types";
+import type { UpdateSource } from "@/types/api";
 
 export function BulkActionsDialog({
   open,
@@ -35,6 +36,7 @@ export function BulkActionsDialog({
   const [updateChannel, setUpdateChannel] = useState<"stable" | "beta">(
     "stable",
   );
+  const [updateSource, setUpdateSource] = useState<UpdateSource>("internet");
   const [confirmFactoryReset, setConfirmFactoryReset] = useState(false);
   const [selectedComponentTypes, setSelectedComponentTypes] = useState<
     string[]
@@ -68,6 +70,8 @@ export function BulkActionsDialog({
   const resetDialog = () => {
     setSelectedAction(null);
     resetProgress();
+    setUpdateChannel("stable");
+    setUpdateSource("internet");
     setConfirmFactoryReset(false);
     setSelectedComponentTypes([]);
     setSelectedComponentType("");
@@ -89,10 +93,20 @@ export function BulkActionsDialog({
     }
   };
 
+  // Local updates run sequentially on the server and may wait on a firmware
+  // download, so the default 3s/device estimate would fill the bar in seconds.
+  const LOCAL_UPDATE_MS_PER_DEVICE = 20000;
+
   const executeAction = async () => {
     if (!selectedAction) return;
 
-    initializeProgress(selectedDevices.length, selectedAction);
+    initializeProgress(
+      selectedDevices.length,
+      selectedAction,
+      selectedAction === "update" && updateSource === "local"
+        ? LOCAL_UPDATE_MS_PER_DEVICE
+        : undefined,
+    );
 
     if (selectedAction === "export_config") {
       if (selectedComponentTypes.length === 0) {
@@ -118,7 +132,10 @@ export function BulkActionsDialog({
 
     switch (selectedAction) {
       case "update":
-        bulkUpdateMutation.mutate(updateChannel);
+        bulkUpdateMutation.mutate({
+          channel: updateChannel,
+          source: updateSource,
+        });
         break;
       case "reboot":
         bulkRebootMutation.mutate();
@@ -169,6 +186,8 @@ export function BulkActionsDialog({
               selectedAction={selectedAction}
               updateChannel={updateChannel}
               onUpdateChannelChange={setUpdateChannel}
+              updateSource={updateSource}
+              onUpdateSourceChange={setUpdateSource}
               confirmFactoryReset={confirmFactoryReset}
               onConfirmFactoryResetChange={setConfirmFactoryReset}
               selectedComponentTypes={selectedComponentTypes}

--- a/packages/web/src/components/dashboard/bulk-actions-dialog/components/action-configuration.tsx
+++ b/packages/web/src/components/dashboard/bulk-actions-dialog/components/action-configuration.tsx
@@ -11,6 +11,8 @@ export function ActionConfiguration({
   selectedAction,
   updateChannel,
   onUpdateChannelChange,
+  updateSource,
+  onUpdateSourceChange,
   confirmFactoryReset,
   onConfirmFactoryResetChange,
   selectedComponentTypes,
@@ -29,6 +31,8 @@ export function ActionConfiguration({
         <UpdateActionConfig
           updateChannel={updateChannel}
           onUpdateChannelChange={onUpdateChannelChange}
+          updateSource={updateSource}
+          onUpdateSourceChange={onUpdateSourceChange}
           onExecute={onExecute}
           onCancel={onCancel}
         />

--- a/packages/web/src/components/dashboard/bulk-actions-dialog/components/action-configurations/update-action-config.tsx
+++ b/packages/web/src/components/dashboard/bulk-actions-dialog/components/action-configurations/update-action-config.tsx
@@ -9,10 +9,13 @@ import {
 } from "@/components/ui/select";
 import { ActionConfigWrapper } from "./action-config-wrapper";
 import type { UpdateActionConfigProps } from "../../types";
+import type { UpdateSource } from "@/types/api";
 
 export function UpdateActionConfig({
   updateChannel,
   onUpdateChannelChange,
+  updateSource,
+  onUpdateSourceChange,
   onExecute,
   onCancel,
 }: UpdateActionConfigProps) {
@@ -25,6 +28,27 @@ export function UpdateActionConfig({
       onExecute={onExecute}
       onCancel={onCancel}
     >
+      <div className="space-y-2">
+        <label className="text-sm font-medium">
+          {t("deviceDetail.dialogs.updateFirmware.updateSource")}
+        </label>
+        <Select
+          value={updateSource}
+          onValueChange={(value: UpdateSource) => onUpdateSourceChange(value)}
+        >
+          <SelectTrigger className="w-48">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="internet">
+              {t("deviceDetail.dialogs.updateFirmware.sourceInternet")}
+            </SelectItem>
+            <SelectItem value="local">
+              {t("deviceDetail.dialogs.updateFirmware.sourceLocal")}
+            </SelectItem>
+          </SelectContent>
+        </Select>
+      </div>
       <div className="space-y-2">
         <label className="text-sm font-medium">
           {t("bulkActions.channel")}

--- a/packages/web/src/components/dashboard/bulk-actions-dialog/hooks/use-bulk-actions.ts
+++ b/packages/web/src/components/dashboard/bulk-actions-dialog/hooks/use-bulk-actions.ts
@@ -2,7 +2,7 @@ import { useMutation } from "@tanstack/react-query";
 import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
 import { deviceApi, handleApiError } from "@/lib/api";
-import type { Device } from "@/types/api";
+import type { Device, UpdateSource } from "@/types/api";
 import type { BulkProgress } from "../types";
 
 interface UseBulkActionsProps {
@@ -24,10 +24,17 @@ export function useBulkActions({
   const { t } = useTranslation();
 
   const bulkUpdateMutation = useMutation({
-    mutationFn: async (updateChannel: "stable" | "beta") => {
+    mutationFn: async ({
+      channel,
+      source,
+    }: {
+      channel: "stable" | "beta";
+      source: UpdateSource;
+    }) => {
       const deviceIps = selectedDevices.map((device) => device.ip);
       return deviceApi.bulkExecuteOperation(deviceIps, "update", {
-        channel: updateChannel,
+        channel,
+        source,
       });
     },
     onSuccess: (results) => {

--- a/packages/web/src/components/dashboard/bulk-actions-dialog/hooks/use-bulk-progress.ts
+++ b/packages/web/src/components/dashboard/bulk-actions-dialog/hooks/use-bulk-progress.ts
@@ -33,8 +33,10 @@ export function useBulkProgress() {
   const calculateEstimatedDuration = (
     operationType: BulkActionType,
     deviceCount: number,
+    msPerDevice?: number,
   ): number => {
-    const baseTimePerDevice = OPERATION_TIME_ESTIMATES[operationType];
+    const baseTimePerDevice =
+      msPerDevice ?? OPERATION_TIME_ESTIMATES[operationType];
     // Add some overhead for network latency and processing
     const overheadFactor = 1.2;
     return Math.ceil(baseTimePerDevice * deviceCount * overheadFactor);
@@ -60,6 +62,7 @@ export function useBulkProgress() {
   const startProgressTimer = (
     operationType: BulkActionType,
     deviceCount: number,
+    msPerDevice?: number,
   ) => {
     if (timerRef.current) {
       clearInterval(timerRef.current);
@@ -69,6 +72,7 @@ export function useBulkProgress() {
     const estimatedDuration = calculateEstimatedDuration(
       operationType,
       deviceCount,
+      msPerDevice,
     );
 
     timerRef.current = setInterval(() => {
@@ -118,7 +122,11 @@ export function useBulkProgress() {
     };
   }, []);
 
-  const initializeProgress = (total: number, operationType: BulkActionType) => {
+  const initializeProgress = (
+    total: number,
+    operationType: BulkActionType,
+    msPerDevice?: number,
+  ) => {
     setProgress({
       total,
       completed: 0,
@@ -127,7 +135,7 @@ export function useBulkProgress() {
       isRunning: true,
       startTime: Date.now(),
     });
-    startProgressTimer(operationType, total);
+    startProgressTimer(operationType, total, msPerDevice);
   };
 
   const resetProgress = () => {

--- a/packages/web/src/components/dashboard/bulk-actions-dialog/types.ts
+++ b/packages/web/src/components/dashboard/bulk-actions-dialog/types.ts
@@ -1,4 +1,4 @@
-import type { Device, ActionResult } from "@/types/api";
+import type { Device, ActionResult, UpdateSource } from "@/types/api";
 
 export type BulkActionType =
   | "update"
@@ -36,6 +36,8 @@ export interface ActionConfigurationProps {
   selectedAction: BulkActionType;
   updateChannel: "stable" | "beta";
   onUpdateChannelChange: (channel: "stable" | "beta") => void;
+  updateSource: UpdateSource;
+  onUpdateSourceChange: (source: UpdateSource) => void;
   confirmFactoryReset: boolean;
   onConfirmFactoryResetChange: (confirm: boolean) => void;
   selectedComponentTypes: string[];
@@ -90,6 +92,8 @@ export interface BaseActionConfigProps {
 export interface UpdateActionConfigProps extends BaseActionConfigProps {
   updateChannel: "stable" | "beta";
   onUpdateChannelChange: (channel: "stable" | "beta") => void;
+  updateSource: UpdateSource;
+  onUpdateSourceChange: (source: UpdateSource) => void;
 }
 
 export interface FactoryResetConfigProps extends BaseActionConfigProps {

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -64,6 +64,17 @@ export const getBulkOperationTimeout = (deviceCount: number): number => {
   return Math.min(baseTimeout + deviceCount * perDeviceTimeout, maxTimeout);
 };
 
+// Local updates run sequentially server-side and the first device of an app
+// may wait on the bundle download, so the window starts where the
+// single-device local timeout ends.
+export const getBulkLocalUpdateTimeout = (deviceCount: number): number => {
+  const baseTimeout = 120000;
+  const perDeviceTimeout = 15000;
+  const maxTimeout = 600000;
+
+  return Math.min(baseTimeout + deviceCount * perDeviceTimeout, maxTimeout);
+};
+
 export const apiClient = axios.create({
   baseURL: `${baseURL}/api`,
   headers: {
@@ -187,7 +198,10 @@ export const deviceApi = {
     operation: "update" | "reboot" | "factory_reset",
     parameters: Record<string, unknown> = {},
   ): Promise<ActionResult[]> => {
-    const timeout = getBulkOperationTimeout(deviceIps.length);
+    const timeout =
+      operation === "update" && parameters.source === "local"
+        ? getBulkLocalUpdateTimeout(deviceIps.length)
+        : getBulkOperationTimeout(deviceIps.length);
     const response = await apiClient.post(
       "/devices/bulk",
       {
@@ -205,6 +219,7 @@ export const deviceApi = {
   ): Promise<ActionResult[]> => {
     return deviceApi.bulkExecuteOperation(request.device_ips, "update", {
       channel: request.channel || "stable",
+      source: request.source || "internet",
     });
   },
 

--- a/packages/web/src/types/api.ts
+++ b/packages/web/src/types/api.ts
@@ -362,6 +362,7 @@ export interface BulkActionResult {
 export interface BulkUpdateRequest {
   device_ips: string[];
   channel?: "stable" | "beta";
+  source?: UpdateSource;
 }
 
 export interface ScanRequest {


### PR DESCRIPTION
## Purpose

Let the bulk update action use the manager as firmware source, same as the single-device dialog. Fixes #83.

## Context

- `POST /devices/bulk` with `operation: update` now takes the same optional `source` field as the single-device route. The local path runs device by device through the existing local-update interactor, so the first device of each app caches the bundle and the rest reuse it. One failing device does not stop the batch; a missing advertised base URL fails fast before any device is touched.
- The bulk dialog gets the source selector, and local runs use a longer request timeout and progress estimate than the 5s-per-device default.
- The CLI local update now honours `--channel`: the stable-only guard predated the channel-aware interactor from #75 and the loop never forwarded the choice.

## Notes

- The dialog now resets channel and source when closed. The sticky channel was a pre-existing quirk, fixed here for consistency with the new source field.
- Corrected the api README: the bulk route is `POST /api/devices/bulk`, not `/bulk/update`, and local updates are no longer stable-only.
- Known quirks left alone: duplicate IPs in a raw API call return one result per unique IP via local but one per entry via internet, and CLI `bulk update` has no `--source` flag yet.