### PR TITLE
Add Dependabot for actions, Python, web and base images

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,68 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      timezone: "Europe/Lisbon"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "uv"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      timezone: "Europe/Lisbon"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+    groups:
+      python:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+
+  - package-ecosystem: "npm"
+    directory: "/packages/web"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      timezone: "Europe/Lisbon"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+    groups:
+      web:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+
+  - package-ecosystem: "docker"
+    directories:
+      - "/packages/api"
+      - "/packages/cli"
+      - "/packages/core"
+      - "/packages/web"
+    schedule:
+      interval: "monthly"
+      timezone: "Europe/Lisbon"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+    groups:
+      base-images:
+        patterns:
+          - "*"


### PR DESCRIPTION
Adds `.github/dependabot.yml`. Nothing tracked dependency drift until now, and the v1.9.0 release run warned that every workflow action targets a deprecated Node runtime.

## What it watches

| Ecosystem | Where | Cadence |
| --- | --- | --- |
| `github-actions` | `/` | weekly |
| `uv` | `/` (workspace root) | weekly |
| `npm` | `/packages/web` | weekly |
| `docker` | the four `packages/*` image directories | monthly |

Minor and patch updates are grouped into one pull request per ecosystem so the weekly volume stays readable. Majors arrive on their own, since those deserve a proper read. Commits use the `chore(deps):` prefix, and the schedule is pinned to Monday, Europe/Lisbon.

## Known gaps

- The api and cli runtime stages build `FROM python:${PYTHON_VERSION}`. Dependabot cannot resolve an ARG into a tag, so those two base images stay a manual bump. The tags it can see are handled: the uv builder image, `node:20-alpine` and `nginx:1.25-alpine`.
- The `dev.Dockerfile` files may not be picked up, depending on how the Docker scanner matches that filename. They are development images only.

Expect a burst of pull requests on the first run, covering the Node 20 action bumps and whatever npm and the pinned Python tools have drifted. It settles after that.
