### PR TITLE
chore(ci): Limit push builds to main and scope dependabot groups

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,9 @@ updates:
       github-actions:
         patterns:
           - "*"
+        update-types:
+          - "minor"
+          - "patch"
 
   - package-ecosystem: "uv"
     directory: "/"
@@ -66,3 +69,6 @@ updates:
       base-images:
         patterns:
           - "*"
+        update-types:
+          - "minor"
+          - "patch"

--- a/.github/workflows/api-ci.yml
+++ b/.github/workflows/api-ci.yml
@@ -2,6 +2,8 @@ name: API CI
 
 on:
   push:
+    branches:
+      - main
     paths:
       - "packages/api/**"
       - "packages/core/**"

--- a/.github/workflows/cli-ci.yml
+++ b/.github/workflows/cli-ci.yml
@@ -2,6 +2,8 @@ name: CLI CI
 
 on:
   push:
+    branches:
+      - main
     paths:
       - "packages/cli/**"
       - "packages/core/**"

--- a/.github/workflows/core-ci.yml
+++ b/.github/workflows/core-ci.yml
@@ -2,6 +2,8 @@ name: Core CI
 
 on:
   push:
+    branches:
+      - main
     paths:
       - "packages/core/**"
       - "pyproject.toml"

--- a/.github/workflows/web-ci.yml
+++ b/.github/workflows/web-ci.yml
@@ -2,6 +2,8 @@ name: Web CI
 
 on:
   push:
+    branches:
+      - main
     paths:
       - "packages/web/**"
       - ".github/workflows/web-ci.yml"


### PR DESCRIPTION
## Push trigger

The `push` trigger in the four CI workflows had no branch filter. Every push to a `dependabot/*` branch started a run in which `push: ${{ github.event_name != 'pull_request' }}` evaluated true, so the build job tried to push images to ghcr.io with a read-scoped token and failed:

```
denied: installation not allowed to Write organization package
```

Every open dependency pull request shows a red `build` because of this. Restricting the trigger to `main` keeps image pushes on the branch that should produce them.

## Dependabot groups

The `github-actions` and `base-images` groups matched `*` with no `update-types` filter, while `uv` and `npm` restrict to minor and patch. That asymmetry swept major bumps into single grouped pull requests. Both groups now use the same minor and patch scope, so majors arrive individually and can be reviewed on their own.